### PR TITLE
WEBRTC-403: Process the incoming ANSWER Verto message.

### DIFF
--- a/WebRTCSDK/Telnyx/TxClient.swift
+++ b/WebRTCSDK/Telnyx/TxClient.swift
@@ -121,6 +121,17 @@ extension TxClient : SocketDelegate {
             case .CLIENT_READY:
                 self.delegate?.onClientReady()
                 break
+            case .ANSWER:
+                //When the remote peer answers the call
+                //Set the remote SDP into the current RTCPConnection and the call should start!
+                if let params = vertoMessage.params {
+                    guard let remoteSdp = params["sdp"] as? String else {
+                        return
+                    }
+                    //retrieve the remote SDP from the ANSWER verto message and set it to the current RTCPconnection
+                    self.call?.answered(sdp: remoteSdp)
+                }
+                break;
             default:
                 print("TxClient:: SocketDelegate Default method")
                 break


### PR DESCRIPTION
[WebRTC-403 - [iOS] Process ANSWER message to connect the outgoing call](https://telnyx.atlassian.net/browse/WEBRTC-403)

---

<!-- Describe your changed here -->
Process the incoming ANSWER Verto message and set's the remote SDP.

## :older_man: :baby: Behaviors

### Before changes
After the remote client answers a call, the RTP connection was not been established (no audio communication was made).

### After changes
Audio communication is established after the remote client answers the call.

## ✋ Manual testing

1. Build the WebRTC SDK
2. Build the Demo App.
3. Enter a sip user and password.
4. Press the connect button. After the sessionID is received, you will be redirected to the call screen.
5. Enter a sip address or phone number.
6. Press the call button
7. Answer the call on the remote Peer
8. Now you can talk between clients
