### PR TITLE
WEBRTC-435: Fix socket disconnection error handling

### DIFF
--- a/WebRTCSDK/Telnyx/Services/Socket.swift
+++ b/WebRTCSDK/Telnyx/Services/Socket.swift
@@ -69,9 +69,8 @@ extension Socket : WebSocketDelegate {
             break;
 
         case .cancelled:
-            //TODO: THIS IS USER DISCONNECTED (IS NOT AN ERROR)
             isConnected = false
-            self.delegate?.onSocketError(error: TxError.SocketFailureReason.socketCancelled)
+            self.delegate?.onSocketDisconnected()
             print("Socket:: WebSocketDelegate .cancelled")
             break
             


### PR DESCRIPTION
[WebRTC-335 - [iOS] Fix socket disconnection error handling](https://telnyx.atlassian.net/browse/WEBRTC-435)

---

<!-- Describe your changed here -->
When explicitly calling to disconnect a socket, it status changes to **.cancelled**. We were treating this state as an error and not a normal disconnection.

## :older_man: :baby: Behaviors

### Before changes
- onSocketError() was been called when the socket is explicitly disconnected.
- Socket disconnection Unit Test was failing

- ### After changes
- onSoketDisconnected() is called when the socket is explicitly disconnected
- Socket disconnection Unit Test ends successfully

## ✋ Manual testing

1. Build the SDK
2. Run the unit tests.
3. Socket Unit Test should not fail.

