### PR TITLE
WEBRTC-450 - Repo url updated in podspec file

### DIFF
--- a/TelnyxRTC.podspec
+++ b/TelnyxRTC.podspec
@@ -5,10 +5,10 @@ Pod::Spec.new do |spec|
   spec.version      = "0.0.1"
   spec.summary      = "Enable Telnyx real-time communication services on iOS."
   spec.description  = "The Telnyx iOS WebRTC Client SDK provides all the functionality you need to start making voice calls from an iPhone."
-  spec.homepage     = "https://github.com/team-telnyx/webrtc-ios-sdk"
+  spec.homepage     = "https://github.com/team-telnyx/telnyx-webrtc-ios"
   spec.license      = { :type => "MIT", :file => "LICENSE" }
   spec.author       = { "Telnyx LLC" => "mobile.app.eng.chapter@telnyx.com" }
-  spec.source       = { :git => "https://github.com/team-telnyx/webrtc-ios-sdk.git", :tag => "#{spec.version}" }
+  spec.source       = { :git => "https://github.com/team-telnyx/telnyx-webrtc-ios.git", :tag => "#{spec.version}" }
 
   spec.platform     = :ios, "10.0"
   spec.swift_version = "5.0"


### PR DESCRIPTION
[WEBRTC-450 - Repo url updated in podspec file](https://telnyx.atlassian.net/browse/WEBRTC-450)

---
<!-- Describe your changed here -->
Final repository name has changed. Updating podspec file with the new repo name.

## :older_man: :baby: Behaviors
### Before changes
Previous name was webrtc-ios-sdk.

### After changes
New name is telnyx-webrtc-ios

## ✋ Manual testing

You will need to follow the README file project setup.

1. Check the repository name