### PR TITLE
WEBRTC-549 - Voice SDK DTMF implementation

### DIFF
--- a/TelnyxRTC.xcodeproj/project.pbxproj
+++ b/TelnyxRTC.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		B3B1D9A126542860008D28C9 /* TxPushConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B1D9A026542860008D28C9 /* TxPushConfig.swift */; };
 		B3B1D9A426545807008D28C9 /* UserDefaultExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B1D9A326545807008D28C9 /* UserDefaultExtension.swift */; };
 		B3B1D9A626545E2C008D28C9 /* ViewControllerCallKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B1D9A526545E2C008D28C9 /* ViewControllerCallKitExtension.swift */; };
+		B3E0B0662656ED73005E7431 /* InfoMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E0B0652656ED73005E7431 /* InfoMessage.swift */; };
 		B3E1029A25F2C16500227DCE /* ModifyMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E1029925F2C16500227DCE /* ModifyMessage.swift */; };
 		B3E1033225F7F94900227DCE /* incoming_call.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = B3E1033025F7F94900227DCE /* incoming_call.mp3 */; };
 		B3E1033325F7F94900227DCE /* ringback_tone.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = B3E1033125F7F94900227DCE /* ringback_tone.mp3 */; };
@@ -148,6 +149,7 @@
 		B3B1D9A22654546E008D28C9 /* TelnyxWebRTCDemo.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TelnyxWebRTCDemo.entitlements; sourceTree = "<group>"; };
 		B3B1D9A326545807008D28C9 /* UserDefaultExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultExtension.swift; sourceTree = "<group>"; };
 		B3B1D9A526545E2C008D28C9 /* ViewControllerCallKitExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerCallKitExtension.swift; sourceTree = "<group>"; };
+		B3E0B0652656ED73005E7431 /* InfoMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoMessage.swift; sourceTree = "<group>"; };
 		B3E1029925F2C16500227DCE /* ModifyMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyMessage.swift; sourceTree = "<group>"; };
 		B3E1033025F7F94900227DCE /* incoming_call.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = incoming_call.mp3; sourceTree = "<group>"; };
 		B3E1033125F7F94900227DCE /* ringback_tone.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = ringback_tone.mp3; sourceTree = "<group>"; };
@@ -215,6 +217,7 @@
 				B309D28125F1838700A2AADF /* ByeMessage.swift */,
 				B309D28525F184A100A2AADF /* AnswerMessage.swift */,
 				B3E1029925F2C16500227DCE /* ModifyMessage.swift */,
+				B3E0B0652656ED73005E7431 /* InfoMessage.swift */,
 			);
 			path = Verto;
 			sourceTree = "<group>";
@@ -684,6 +687,7 @@
 				B309D23625F06D2100A2AADF /* TxCallInfo.swift in Sources */,
 				B309D23B25F06DC000A2AADF /* TxCallOptions.swift in Sources */,
 				B3AF249825EE7DC70062EDA9 /* SocketDelegate.swift in Sources */,
+				B3E0B0662656ED73005E7431 /* InfoMessage.swift in Sources */,
 				B3E1029A25F2C16500227DCE /* ModifyMessage.swift in Sources */,
 				B309D24025F06EA600A2AADF /* InviteMessage.swift in Sources */,
 				B309D22925F06C6900A2AADF /* Call.swift in Sources */,

--- a/TelnyxRTC/Telnyx/Models/TxCallInfo.swift
+++ b/TelnyxRTC/Telnyx/Models/TxCallInfo.swift
@@ -17,4 +17,12 @@ public struct TxCallInfo {
     public internal(set) var callerName:String?
     /// The caller number of the call
     public internal(set) var callerNumber: String?
+
+    func encode() -> [String : Any] {
+        var dictionary = [String : Any]()
+        dictionary["callID"] = callId.uuidString.lowercased()
+        dictionary["caller_id_name"] = callerName ?? ""
+        dictionary["caller_id_number"] = callerNumber ?? ""
+        return dictionary
+    }
 }

--- a/TelnyxRTC/Telnyx/Models/TxCallOptions.swift
+++ b/TelnyxRTC/Telnyx/Models/TxCallOptions.swift
@@ -27,4 +27,17 @@ struct TxCallOptions {
     var useStereo: Bool = false
     var screenShare: Bool = false
     var userVariables: [String: Any]?
+
+    func encode() -> [String : Any] {
+        var dictionary = [String: Any]()
+        dictionary["remote_caller_id_name"] = remoteCallerName
+        dictionary["caller_id_number"] = remoteCallerNumber
+        dictionary["audio"] = audio
+        dictionary["video"] = video
+        dictionary["useStereo"] = useStereo
+        dictionary["attach"] = attach
+        dictionary["screenShare"] = screenShare
+        dictionary["userVariables"] = userVariables
+        return dictionary
+    }
 }

--- a/TelnyxRTC/Telnyx/Verto/InfoMessage.swift
+++ b/TelnyxRTC/Telnyx/Verto/InfoMessage.swift
@@ -1,30 +1,28 @@
 //
-//  AnswerMessage.swift
+//  InfoMessage.swift
 //  TelnyxRTC
 //
-//  Created by Guillermo Battistel on 04/03/2021.
+//  Created by Guillermo Battistel on 20/05/2021.
 //  Copyright © 2021 Telnyx LLC. All rights reserved.
 //
 
-import Foundation
-
-class AnswerMessage : Message {
+class InfoMessage : Message {
 
     init(sessionId: String,
-         sdp: String,
+         dtmf: String,
          callInfo: TxCallInfo,
          callOptions: TxCallOptions) {
-
         var params = [String: Any]()
+        params["sessid"] = sessionId
+        params["dtmf"] = dtmf
+
         var dialogParams = [String: Any]()
         // Merge callInfo into dialogParams
         callInfo.encode().forEach { (key, value) in dialogParams[key] = value }
         // Merge callOptions into dialogParams
         callOptions.encode().forEach { (key, value) in dialogParams[key] = value }
 
-        params["sessionId"] = sessionId
-        params["sdp"] = sdp
         params["dialogParams"] = dialogParams
-        super.init(params, method: .ANSWER)
+        super.init(params, method: .INFO)
     }
 }

--- a/TelnyxRTC/Telnyx/Verto/Method.swift
+++ b/TelnyxRTC/Telnyx/Verto/Method.swift
@@ -18,9 +18,8 @@ enum Method : String {
     case BYE = "telnyx_rtc.bye"
     case MODIFY = "telnyx_rtc.modify"
     case MEDIA = "telnyx_rtc.media"
-
-    //not implemented
     case INFO = "telnyx_rtc.info"
+    //not implemented
     case ATTACH = "telnyx_rtc.attach"
     case DISPLAY = "telnyx_rtc.display"
     case EVENT = "telnyx_rtc.event"

--- a/TelnyxRTC/Telnyx/WebRTC/Call.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call.swift
@@ -278,6 +278,34 @@ extension Call {
         })
     }
 }
+
+// MARK: - DTMF
+extension Call {
+
+    /// Sends dual-tone multi-frequency (DTMF) signal
+    /// - Parameter dtmf: Single DTMF key
+    /// ## Examples:
+    /// ### Send DTMF signals:
+    ///
+    /// ```
+    ///    currentCall?.dtmf("0")
+    ///    currentCall?.dtmf("1")
+    ///    currentCall?.dtmf("*")
+    ///    currentCall?.dtmf("#")
+    /// ```
+    public func dtmf(dtmf: String) {
+        Logger.log.i(message: "Call:: dtmf() \(dtmf)")
+        guard let sessionId = self.sessionId,
+              let callInfo = self.callInfo,
+              let callOptions = self.callOptions else { return }
+
+        let dtmfMessage = InfoMessage(sessionId: sessionId, dtmf: dtmf, callInfo: callInfo, callOptions: callOptions)
+        guard let message = dtmfMessage.encode(),
+              let socket = self.socket else { return }
+        socket.sendMessage(message: message)
+        Logger.log.s(message: "Call:: dtmf() \(dtmf)")
+    }
+}
 // MARK: - Audio handling
 extension Call {
     

--- a/TelnyxRTCTests/Verto/VertoMessagesTests.swift
+++ b/TelnyxRTCTests/Verto/VertoMessagesTests.swift
@@ -273,4 +273,34 @@ class VertoMessagesTests: XCTestCase {
         let decodedMethod = decodedMessage?.method
         XCTAssertEqual(decodedMethod, Method.MODIFY)
     }
+
+    /**
+     Test dtmf message
+     */
+    func testDtmfMessage() {
+        print("VertoMessagesTest :: testDtmfMessage()")
+
+        let sessionId = "<sessionId>"
+        let callId = UUID.init()
+        let dtmf = "1"
+
+        let callInfo = TxCallInfo(callId: callId, callerName: "<caller_name>", callerNumber: "<caller_number>")
+        let callOptions = TxCallOptions(destinationNumber: "<destination_number>", audio: true)
+        let infoMessage = InfoMessage(sessionId: sessionId, dtmf: dtmf, callInfo: callInfo, callOptions: callOptions)
+
+        //Encode and decode the Bye message
+        let encodedMessage: String = infoMessage.encode() ?? ""
+        let decodedMessage = Message().decode(message: encodedMessage)
+
+        XCTAssertEqual(decodedMessage?.params?["sessid"] as! String, sessionId)
+        XCTAssertEqual(decodedMessage?.params?["dtmf"] as! String, dtmf)
+
+        let dialogParams = decodedMessage?.params?["dialogParams"] as! [String: Any]
+        XCTAssertEqual(dialogParams["callID"] as! String , callInfo.callId.uuidString.lowercased())
+        XCTAssertEqual(dialogParams["remote_caller_id_number"] as? String , callOptions.remoteCallerNumber)
+        XCTAssertEqual(dialogParams["audio"] as? Bool , callOptions.audio)
+
+        let decodedMethod = decodedMessage?.method
+        XCTAssertEqual(decodedMethod, Method.INFO)
+    }
 }


### PR DESCRIPTION
[WebRTC-549 - Voice SDK DTMF implementation](https://telnyx.atlassian.net/browse/WEBRTC-549)
---
<!-- Describe your change here -->
We are adding DTMF(Dual-tone multi-frequency signaling) support into the SDK.

- New Verto message is implemented: **telnyx_rtc.info**
- New function added to the Call class: `func dtmf(dtmf: String)`
- Added documentation markdown in code so the developer can access the examples of usage through the Quick Guide on Xcode:

<p align="center">
<img width="502" alt="Screen Shot 2021-05-20 at 16 41 42" src="https://user-images.githubusercontent.com/75636882/119049886-79d2f200-b997-11eb-8d8c-2aa77fb32882.png">
</p>

- Unit tests implemented to verify telnyx_rtc.info message encoding and decoding.

## :older_man: :baby: Behaviors
### Before changes
DTMF was not supported

### After changes
DTMF is supported.

TODO: Add example on demo app.

## ✋ Manual testing
1. Go to the demo app. 
2. Add a button into the UI.
3. Add the following code in the button press event: `self.currentCall?.dtmf("2")`
4. Run the app.
5. Call to **+13129457420**.
6. Bot will answer the call and present a list of options. One of the options is: **"press 2 to go to support"**
7. Press the button implemented on step 3.
8. Bot should redirect the call to support.

