### PR TITLE
WEBRTC-620 - Disconnect the client properly

### DIFF
--- a/TelnyxRTC/Telnyx/Services/Socket.swift
+++ b/TelnyxRTC/Telnyx/Services/Socket.swift
@@ -30,7 +30,8 @@ class Socket {
     
     func disconnect() {
         Logger.log.i(message: "Socket:: disconnect()")
-        self.socket?.disconnect()
+		self.socket?.disconnect()
+		self.socket?.forceDisconnect()
     }
     
     func sendMessage(message: String?) {

--- a/TelnyxRTC/Telnyx/Services/Socket.swift
+++ b/TelnyxRTC/Telnyx/Services/Socket.swift
@@ -31,7 +31,6 @@ class Socket {
     func disconnect() {
         Logger.log.i(message: "Socket:: disconnect()")
         self.socket?.disconnect()
-        self.socket?.forceDisconnect()
     }
     
     func sendMessage(message: String?) {

--- a/TelnyxRTC/Telnyx/Services/Socket.swift
+++ b/TelnyxRTC/Telnyx/Services/Socket.swift
@@ -30,8 +30,8 @@ class Socket {
     
     func disconnect() {
         Logger.log.i(message: "Socket:: disconnect()")
-		self.socket?.disconnect()
-		self.socket?.forceDisconnect()
+        self.socket?.disconnect()
+        self.socket?.forceDisconnect()
     }
     
     func sendMessage(message: String?) {

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -155,6 +155,12 @@ public class TxClient {
     public func disconnect() {
         Logger.log.i(message: "TxClient:: disconnect()")
         socket?.disconnect()
+
+		// Let's cancell all the current calls
+		for (_ ,call) in self.calls {
+			call.hangup()
+		}
+
         socket = nil
         delegate?.onSocketDisconnected()
     }

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -154,13 +154,13 @@ public class TxClient {
     /// Disconnects the TxClient from the Telnyx signaling server.
     public func disconnect() {
         Logger.log.i(message: "TxClient:: disconnect()")
-        socket?.disconnect()
 
         // Let's cancell all the current calls
         for (_ ,call) in self.calls {
             call.hangup()
         }
 
+        socket?.disconnect()
         socket = nil
         delegate?.onSocketDisconnected()
     }

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -156,10 +156,10 @@ public class TxClient {
         Logger.log.i(message: "TxClient:: disconnect()")
         socket?.disconnect()
 
-		// Let's cancell all the current calls
-		for (_ ,call) in self.calls {
-			call.hangup()
-		}
+        // Let's cancell all the current calls
+        for (_ ,call) in self.calls {
+            call.hangup()
+        }
 
         socket = nil
         delegate?.onSocketDisconnected()

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -162,7 +162,6 @@ public class TxClient {
 
         self.calls.removeAll()
         socket?.disconnect()
-        socket = nil
         delegate?.onSocketDisconnected()
     }
 
@@ -380,6 +379,7 @@ extension TxClient : SocketDelegate {
     
     func onSocketDisconnected() {
         Logger.log.i(message: "TxClient:: SocketDelegate onSocketDisconnected()")
+        self.socket = nil
         self.delegate?.onSocketDisconnected()
     }
 

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -160,6 +160,7 @@ public class TxClient {
             call.hangup()
         }
 
+        self.calls.removeAll()
         socket?.disconnect()
         socket = nil
         delegate?.onSocketDisconnected()

--- a/TelnyxRTC/Telnyx/WebRTC/Call.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call.swift
@@ -179,7 +179,7 @@ public class Call {
             guard let sdp = sdp else {
                 return
             }
-            Logger.log.i(message: "Call:: Offer compleated >> SDP: \(sdp)")
+            Logger.log.i(message: "Call:: Offer completed >> SDP: \(sdp)")
             self.updateCallState(callState: .CONNECTING)
         })
     }

--- a/TelnyxRTC/Telnyx/WebRTC/Peer.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Peer.swift
@@ -269,7 +269,7 @@ extension Peer : RTCPeerConnectionDelegate {
     }
 
     func peerConnection(_ peerConnection: RTCPeerConnection, didAdd stream: RTCMediaStream) {
-        Logger.log.i(message: "Peer:: connection didaDD: \(stream)")
+        Logger.log.i(message: "Peer:: connection didAdd: \(stream)")
         if stream.videoTracks.count > 0 {
             self.remoteVideoTrack = stream.videoTracks[0]
         }

--- a/TelnyxRTCTests/WebRTC/CallTests.swift
+++ b/TelnyxRTCTests/WebRTC/CallTests.swift
@@ -29,7 +29,7 @@ class CallTests: XCTestCase {
 
     /**
      Test that the invite message is sent through the socket.
-     - Wait socket connection to be compleated.
+     - Wait socket connection to be completed.
      - Starts the call process by creating an offer
      - Once the ICE candidates negotiation finishes, we send an invite through the socket.
      - Wait for a server response onMessageReceived.

--- a/TelnyxWebRTCDemo/ViewController.swift
+++ b/TelnyxWebRTCDemo/ViewController.swift
@@ -110,6 +110,15 @@ class ViewController: UIViewController {
             userDefaults.saveUser(sipUser: sipUser, password: password)
         }
     }
+
+    func resetCallStates() {
+        self.incomingCall = false
+        self.incomingCallView.isHidden = true
+        self.callView.isHidden = false
+        self.callView.resetMuteUnmuteState()
+        self.callView.resetHoldUnholdState()
+        self.callView.resetSpeakerState()
+    }
 }
 
 // MARK: - TxClientDelegate
@@ -127,6 +136,7 @@ extension ViewController: TxClientDelegate {
     func onSocketDisconnected() {
         print("ViewController:: TxClientDelegate onSocketDisconnected()")
         DispatchQueue.main.async {
+            self.resetCallStates()
             self.socketStateLabel.text = "Disconnected"
             self.connectButton.setTitle("Connect", for: .normal)
             self.sessionIdLabel.text = "-"
@@ -210,12 +220,7 @@ extension ViewController: TxClientDelegate {
                    currentCallId == callId {
                     self.currentCall = nil // clear current call
                 }
-                self.incomingCall = false
-                self.incomingCallView.isHidden = true
-                self.callView.isHidden = false
-                self.callView.muteUnmuteSwitch.setOn(false, animated: false)
-                self.callView.holdUnholdSwitch.setOn(false, animated: false)
-                self.callView.resetHoldUnholdState()
+                self.resetCallStates()
                 break
             case .HELD:
                 break

--- a/TelnyxWebRTCDemo/ViewController.swift
+++ b/TelnyxWebRTCDemo/ViewController.swift
@@ -125,7 +125,7 @@ extension ViewController: TxClientDelegate {
     }
     
     func onSocketDisconnected() {
-        print("ViewController:: TxClientDelegate onSocketConnected()")
+        print("ViewController:: TxClientDelegate onSocketDisconnected()")
         DispatchQueue.main.async {
             self.socketStateLabel.text = "Disconnected"
             self.connectButton.setTitle("Connect", for: .normal)

--- a/TelnyxWebRTCDemo/Views/UICallScreen.swift
+++ b/TelnyxWebRTCDemo/Views/UICallScreen.swift
@@ -113,10 +113,19 @@ class UICallScreen: UIView {
             }
         }
     }
-    
+
+    func resetSpeakerState() {
+        self.speakerOnOffSwitch.setOn(false, animated: false)
+    }
+
     func resetHoldUnholdState() {
         self.holdUnholdSwitch.setOn(false, animated: false)
         self.holdUnholdLabel.text = "Hold"
+    }
+
+    func resetMuteUnmuteState() {
+        self.muteUnmuteSwitch.setOn(false, animated: false)
+        self.muteUnmuteLabel.text = "Mute"
     }
 
     @IBAction func callButtonTapped(_ sender: Any) {


### PR DESCRIPTION
[WebRTC-620 - Disconnect the client properly](https://telnyx.atlassian.net/browse/WEBRTC-620)
---
<!-- Describe your change here -->
- The socket was not been disconnecting when calling` socket.disconnect()`. We are adding a call to force the socket disconnection: `socket.forceDisconnect()`.
- We are also hanging up all the ongoing calls (if there's any call connected), and cleaning the list of available calls.
- On the Demo App we are setting the Call Screen states in the correct status after disconnecting the client or when an ongoing call has ended. 

## :older_man: :baby: Behaviors
### Before changes
- The calls remain active and the socket remained connected after calling the `disconnect() `function.

### After changes
- The client is disconnected properly when calling the `disconnect()` function and all the active calls are cancelled.
- The demo app updates the UI to the correct state after the call is disconnected.

## ✋ Manual testing

1. Go to the demo app. 
2. Connect using SIP credentials
3. Receive an incoming call
4. Accept the call
5. Press the disconnect button. 
6. The call should be cancelled and the Caller should receive the CALL ENDED event.





