### PR TITLE
WEBRTC-615 - Stop ringback and ringtone

### DIFF
--- a/TelnyxRTC/Telnyx/WebRTC/Call.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call.swift
@@ -256,6 +256,7 @@ extension Call {
     ///     call.answer()
     public func answer() {
         self.stopRingtone()
+        self.stopRingbackTone()
         //TODO: Create an error if there's no remote SDP
         guard let remoteSdp = self.remoteSdp else {
             return
@@ -436,6 +437,8 @@ extension Call {
             break
 
         case .MEDIA:
+            self.stopRingtone()
+            self.stopRingbackTone()
             //Whenever we place a call from a client and the "Generate ring back tone" is enabled in the portal,
             //the Telnyx Cloud sends the telnyx_rtc.media Verto signaling message with an SDP.
             //The incoming SDP must be set in the caller client as the remote SDP to start listening a ringback tone
@@ -451,6 +454,8 @@ extension Call {
             break
 
         case .ANSWER:
+            self.stopRingtone()
+            self.stopRingbackTone()
             //When the remote peer answers the call
             //Set the remote SDP into the current RTCPConnection and the call should start!
             if let params = message.params {
@@ -461,8 +466,6 @@ extension Call {
                 //retrieve the remote SDP from the ANSWER verto message and set it to the current RTCPconnection
                 self.answered(sdp: remoteSdp)
             }
-            self.stopRingtone()
-            self.stopRingbackTone()
             //TODO: handle error when there's no sdp
             break;
 


### PR DESCRIPTION
[WebRTC-615 - Stop ringback and ringtone](https://telnyx.atlassian.net/browse/WEBRTC-615)
---
<!-- Describe your change here -->
We are stopping both ringtone and ringback tone whenever a WebRTC connection will be completed, that means that:
- A remote SDP has been received.
- Or we have answered the call.

## :older_man: :baby: Behaviors
### Before changes
Sometimes the ringtone or ringback tone kept playing once the call had been established.

### After changes
Ringtone and ringback tone are stopped when a call is established. 

## ✋ Manual testing

1. Go to the demo app. 
2. Connect using SIP credentials
3. Receive an incoming call
4. Accept the call
5. End the call.
6. Place an outbound call to a real phone number.
7. Reject the call from the remote phone.
8. Place an outbound call to a real phone number.
9. Answer the call
10. End the call.

For each scenario, both ringback and ringtone should be stopped.






