### PR TITLE
WEBRTC-643 - Push notifications parameters Fix.

### DIFF
--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -381,7 +381,7 @@ extension TxClient : SocketDelegate {
             guard let sipUser = self.txConfig?.sipUser else { return }
             guard let password = self.txConfig?.password else { return }
             let pushToken = self.txConfig?.pushNotificationConfig?.pushDeviceToken
-            let vertoLogin = LoginMessage(user: sipUser, password: password, pushDeviceToken: pushToken)
+            let vertoLogin = LoginMessage(user: sipUser, password: password, pushDeviceToken: pushToken, pushNotificationProvider: pushProvider)
             self.socket?.sendMessage(message: vertoLogin.encode())
         }
     }

--- a/TelnyxRTC/Telnyx/Verto/LoginMessage.swift
+++ b/TelnyxRTC/Telnyx/Verto/LoginMessage.swift
@@ -18,15 +18,18 @@ class LoginMessage : Message {
         var params = [String: Any]()
         params["login"] = user
         params["passwd"] = password
+
         //Setup push variables
+        var userVariables = [String: Any]()
         if let pushDeviceToken = pushDeviceToken {
-            params["push_device_token"] = pushDeviceToken
+            userVariables["push_device_token"] = pushDeviceToken
         }
         if let provider = pushNotificationProvider {
-            params["push_notification_provider"] = provider
+            userVariables["push_notification_provider"] = provider
         }
+
         params["loginParams"] = [String: String]()
-        params["userVariables"] = [String: String]()
+        params["userVariables"] = userVariables
         super.init(params, method: .LOGIN)
     }
     
@@ -36,14 +39,18 @@ class LoginMessage : Message {
          pushNotificationProvider: String? = nil) {
         var params = [String: Any]()
         params["login_token"] = token
+
+        //Setup push variables
+        var userVariables = [String: Any]()
         if let pushDeviceToken = pushDeviceToken {
-            params["push_device_token"] = pushDeviceToken
+            userVariables["push_device_token"] = pushDeviceToken
         }
         if let provider = pushNotificationProvider {
-            params["push_notification_provider"] = provider
+            userVariables["push_notification_provider"] = provider
         }
-        params["loginParams"] = [String: String]()
-        params["userVariables"] = [String: String]()
+
+		params["loginParams"] = [String: String]()
+        params["userVariables"] = userVariables
         super.init(params, method: .LOGIN)
     }
     


### PR DESCRIPTION
[WebRTC-643 - Fix: push_provider not been sent for credentials login](https://telnyx.atlassian.net/browse/WEBRTC-643)
---
<!-- Describe your change here -->
In order to register a user to receive push notifications, the following parameters has to be sent inside the `login Verto `message as part of the `user variables`:
- push_notification_token
- push_notification_provider

**Example of login message:**
```
{
  "id": "bcaa0286-4f54-440f-a0f9-e626d96878a4",
  "params": {
    "login": "sip_user",
    "passwd": "sip_password",
    "loginParams": {},
    "userVariables": {
      "push_device_token": "deviceToken",
      "push_notification_provider": "ios"
    }
  },
  "jsonrpc": "2.0",
  "method": "login"
}
```
## :older_man: :baby: Behaviors
### Before changes
Push notifications parameters were not sent inside the user variable section of the login message

### After changes
`push_device_token`  and `push_notification_provider` are sent inside the `userVariable` section of the login message.

## ✋ Manual testing

1. Go to the demo app. 
2. Login with token or credentials.
3. Check inside the logs for the login message: `"method":"login"`
4. Verify that `push_device_token` and `push_notification_provider` are been sent.


