### PR TITLE
WEBRTC-641 - Set User-Agent field with client type and version on INVITE and ANSWER

### DIFF
--- a/TelnyxRTC.xcodeproj/project.pbxproj
+++ b/TelnyxRTC.xcodeproj/project.pbxproj
@@ -902,6 +902,7 @@
 					"@loader_path/Frameworks",
 					"$(BUILT_PRODUCTS_DIR)/Starscream",
 				);
+				MARKETING_VERSION = 0.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.WebRTCSDK;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -937,6 +938,7 @@
 					"@loader_path/Frameworks",
 					"$(BUILT_PRODUCTS_DIR)/Starscream",
 				);
+				MARKETING_VERSION = 0.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.WebRTCSDK;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/TelnyxRTC/Info.plist
+++ b/TelnyxRTC/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/TelnyxRTC/Telnyx/Verto/AnswerMessage.swift
+++ b/TelnyxRTC/Telnyx/Verto/AnswerMessage.swift
@@ -22,10 +22,7 @@ class AnswerMessage : Message {
         // Merge callOptions into dialogParams
         callOptions.encode().forEach { (key, value) in dialogParams[key] = value }
 
-        // Get the SDK version
-        let version = Bundle(for: Message.self).infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
-        let type = Message.CLIENT_TYPE
-        params["User-Agent"] = type + "-" + version
+        params["User-Agent"] = Message.USER_AGENT
 
         params["sessionId"] = sessionId
         params["sdp"] = sdp

--- a/TelnyxRTC/Telnyx/Verto/AnswerMessage.swift
+++ b/TelnyxRTC/Telnyx/Verto/AnswerMessage.swift
@@ -22,6 +22,11 @@ class AnswerMessage : Message {
         // Merge callOptions into dialogParams
         callOptions.encode().forEach { (key, value) in dialogParams[key] = value }
 
+        // Get the SDK version
+        let version = Bundle(for: Message.self).infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
+        let type = Message.CLIENT_TYPE
+        params["User-Agent"] = type + "-" + version
+
         params["sessionId"] = sessionId
         params["sdp"] = sdp
         params["dialogParams"] = dialogParams

--- a/TelnyxRTC/Telnyx/Verto/InviteMessage.swift
+++ b/TelnyxRTC/Telnyx/Verto/InviteMessage.swift
@@ -20,8 +20,9 @@ class InviteMessage : Message {
         var dialogParams = [String: Any]()
 
         // Get the SDK version
-        dialogParams["client_version"] = Bundle(for: InviteMessage.self).infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
-        dialogParams["client_type"] = InviteMessage.CLIENT_TYPE
+        let version = Bundle(for: InviteMessage.self).infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
+        let type = InviteMessage.CLIENT_TYPE
+        params["User-Agent"] = type + "-" + version
 
         dialogParams["callID"] = callInfo.callId.uuidString.lowercased()
         dialogParams["destination_number"] = callOptions.destinationNumber

--- a/TelnyxRTC/Telnyx/Verto/InviteMessage.swift
+++ b/TelnyxRTC/Telnyx/Verto/InviteMessage.swift
@@ -10,12 +10,18 @@ import Foundation
 
 class InviteMessage : Message {
         
+    private static let CLIENT_TYPE = "iOS"
+
     init(sessionId: String,
          sdp: String,
          callInfo: TxCallInfo,
          callOptions: TxCallOptions) {
         var params = [String: Any]()
         var dialogParams = [String: Any]()
+
+        // Get the SDK version
+        dialogParams["client_version"] = Bundle(for: InviteMessage.self).infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
+        dialogParams["client_type"] = InviteMessage.CLIENT_TYPE
 
         dialogParams["callID"] = callInfo.callId.uuidString.lowercased()
         dialogParams["destination_number"] = callOptions.destinationNumber
@@ -27,6 +33,7 @@ class InviteMessage : Message {
         dialogParams["useStereo"] = callOptions.useStereo
         dialogParams["attach"] = callOptions.attach
         dialogParams["screenShare"] = callOptions.screenShare
+
         dialogParams["userVariables"] = callOptions.userVariables
         if let clientState = callOptions.clientState {
             dialogParams["clientState"] = clientState

--- a/TelnyxRTC/Telnyx/Verto/InviteMessage.swift
+++ b/TelnyxRTC/Telnyx/Verto/InviteMessage.swift
@@ -34,7 +34,6 @@ class InviteMessage : Message {
         dialogParams["useStereo"] = callOptions.useStereo
         dialogParams["attach"] = callOptions.attach
         dialogParams["screenShare"] = callOptions.screenShare
-
         dialogParams["userVariables"] = callOptions.userVariables
         if let clientState = callOptions.clientState {
             dialogParams["clientState"] = clientState

--- a/TelnyxRTC/Telnyx/Verto/InviteMessage.swift
+++ b/TelnyxRTC/Telnyx/Verto/InviteMessage.swift
@@ -9,8 +9,6 @@
 import Foundation
 
 class InviteMessage : Message {
-        
-    private static let CLIENT_TYPE = "iOS"
 
     init(sessionId: String,
          sdp: String,
@@ -18,11 +16,6 @@ class InviteMessage : Message {
          callOptions: TxCallOptions) {
         var params = [String: Any]()
         var dialogParams = [String: Any]()
-
-        // Get the SDK version
-        let version = Bundle(for: InviteMessage.self).infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
-        let type = InviteMessage.CLIENT_TYPE
-        params["User-Agent"] = type + "-" + version
 
         dialogParams["callID"] = callInfo.callId.uuidString.lowercased()
         dialogParams["destination_number"] = callOptions.destinationNumber
@@ -38,6 +31,11 @@ class InviteMessage : Message {
         if let clientState = callOptions.clientState {
             dialogParams["clientState"] = clientState
         }
+
+        // Get the SDK version
+        let version = Bundle(for: InviteMessage.self).infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
+        let type = Message.CLIENT_TYPE
+        params["User-Agent"] = type + "-" + version
 
         params["sessionId"] = sessionId
         params["sdp"] = sdp

--- a/TelnyxRTC/Telnyx/Verto/InviteMessage.swift
+++ b/TelnyxRTC/Telnyx/Verto/InviteMessage.swift
@@ -32,10 +32,7 @@ class InviteMessage : Message {
             dialogParams["clientState"] = clientState
         }
 
-        // Get the SDK version
-        let version = Bundle(for: InviteMessage.self).infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
-        let type = Message.CLIENT_TYPE
-        params["User-Agent"] = type + "-" + version
+        params["User-Agent"] = Message.USER_AGENT
 
         params["sessionId"] = sessionId
         params["sdp"] = sdp

--- a/TelnyxRTC/Telnyx/Verto/Message.swift
+++ b/TelnyxRTC/Telnyx/Verto/Message.swift
@@ -11,6 +11,7 @@ import Foundation
 private let PROTOCOL_VERSION: String = "2.0"
 
 class Message {
+    internal static let CLIENT_TYPE = "iOS"
     private var jsonMessage: [String: Any] = [String: Any]()
 
     let jsonrpc = PROTOCOL_VERSION

--- a/TelnyxRTC/Telnyx/Verto/Message.swift
+++ b/TelnyxRTC/Telnyx/Verto/Message.swift
@@ -12,6 +12,14 @@ private let PROTOCOL_VERSION: String = "2.0"
 
 class Message {
     internal static let CLIENT_TYPE = "iOS"
+    internal static var USER_AGENT: String {
+        get {
+            let version = Bundle(for: Message.self).infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
+            let type = Message.CLIENT_TYPE
+            return type + "-" + version
+        }
+    }
+
     private var jsonMessage: [String: Any] = [String: Any]()
 
     let jsonrpc = PROTOCOL_VERSION
@@ -20,7 +28,7 @@ class Message {
     var params: [String: Any]?
     var result: [String: Any]?
     var serverError: [String: Any]?
-    
+
     init() {}
     
     init(_ params: [String: Any], method: Method) {


### PR DESCRIPTION
[WebRTC-641 - Set User-Agent field with client type and version on INVITE ](https://telnyx.atlassian.net/browse/WEBRTC-641)
---
<!-- Describe your change here -->
The `User-Agent` field is added inside the INVITE message to track outbound calls and inside the ANSWER message to track inbound calls.

This field contains ` PLATFORM-VERSION`

**Example of the new INVITE message:**
```
{
  "jsonrpc": "2.0",
  "method": "telnyx_rtc.invite",
  "params": {
    "User-Agent": "iOS-0.0.3", 
    "sdp": "SDP",
    "sessionId": "sessionID"
    "dialogParams": {
      "remote_caller_id_name": "",
      "useStereo": false,
      "screenShare": false,
      "video": false,
      "caller_id_name": "",
      "caller_id_number": "",
      "destination_number": "",
      "callID": "callID",
      "audio": true,
      "attach": false
    },
  },
  "id": "ID"
}
```

**Example of the new ANSWER message:**

```
{
  "jsonrpc": "2.0",
  "method": "telnyx_rtc.answer",
  "params": {
    "User-Agent": "iOS-0.0.3",
    "sdp": "",
    "dialogParams": {
      "caller_id_name": "",
      "useStereo": false,
      "caller_id_number": "",
      "screenShare": false,
      "video": false,
      "remote_caller_id_name": "",
      "audio": true,
      "attach": false,
      "callID": ""
    },
    "sessionId": ""
  },
  "id": ""
}
```
## :older_man: :baby: Behaviors
### Before changes
`User-Agent` field was not present on INVITE / ANSWER message.

### After changes
`User-Agent` field is present on INVITE/ANSWER message. 

## ✋ Manual testing

1. Go to the demo app. 
2. Login with token or credentials.
3. Place and outbound call.
4. Verify that `User-Agent` is sent inside the INVITE message.
5. Receive an inbound call
6. Answer the incoming call.
7. Verify that `User-Agent` is present inside the ANSWER message


