### PR TITLE
WEBRTC-648 - Fix memory leaks and retain cycles

### DIFF
--- a/TelnyxRTC/Telnyx/Services/Socket.swift
+++ b/TelnyxRTC/Telnyx/Services/Socket.swift
@@ -11,7 +11,7 @@ import Starscream
 
 class Socket {
     
-    var delegate: SocketDelegate?
+    weak var delegate: SocketDelegate?
     var isConnected : Bool = false
 
     private let config = InternalConfig.default

--- a/TelnyxRTC/Telnyx/Services/SocketDelegate.swift
+++ b/TelnyxRTC/Telnyx/Services/SocketDelegate.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-protocol SocketDelegate {
+protocol SocketDelegate: AnyObject {
     func onSocketConnected()
     func onSocketDisconnected()
     func onSocketError(error: Error)

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -124,7 +124,7 @@ public class TxClient {
     /// Keeps track of all the created calls by theirs UUIDs
     public internal(set) var calls: [UUID: Call] = [UUID: Call]()
     /// Subscribe to TxClient delegate to receive Telnyx SDK events
-    public var delegate: TxClientDelegate?
+    public weak var delegate: TxClientDelegate?
     private var socket : Socket?
 
     private var sessionId : String?

--- a/TelnyxRTC/Telnyx/TxClientDelegate.swift
+++ b/TelnyxRTC/Telnyx/TxClientDelegate.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// Delegate protocol asociated with the TxClient
 /// Methods for receiving TxClient events.
-public protocol TxClientDelegate {
+public protocol TxClientDelegate: AnyObject {
 
     /// Tells the delegate when the Telnyx Client has successfully connected to the Telnyx Backend
     func onSocketConnected()

--- a/TelnyxRTC/Telnyx/WebRTC/Call.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call.swift
@@ -32,7 +32,7 @@ enum CallDirection : String {
 }
 
 
-protocol CallProtocol {
+protocol CallProtocol: AnyObject {
     func callStateUpdated(call: Call)
 }
 
@@ -90,8 +90,8 @@ public class Call {
     var direction: CallDirection = .OUTBOUND
     var config: InternalConfig = InternalConfig.default
     var peer: Peer?
-    var socket: Socket?
-    var delegate: CallProtocol?
+    weak var socket: Socket?
+    weak var delegate: CallProtocol?
 
     var remoteSdp: String?
     var callOptions: TxCallOptions?

--- a/TelnyxRTC/Telnyx/WebRTC/Peer.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Peer.swift
@@ -9,7 +9,7 @@
 import Foundation
 import WebRTC
 
-protocol PeerDelegate {
+protocol PeerDelegate: AnyObject {
     //TODO: Rename this to "negotiationDidEnded"
     func onICECandidate(sdp: RTCSessionDescription?, iceCandidate: RTCIceCandidate)
 }
@@ -24,7 +24,7 @@ class Peer : NSObject {
 
     private let mediaConstrains = [kRTCMediaConstraintsOfferToReceiveAudio: kRTCMediaConstraintsValueTrue, kRTCMediaConstraintsOfferToReceiveVideo: kRTCMediaConstraintsValueTrue]
 
-    var delegate: PeerDelegate?
+    weak var delegate: PeerDelegate?
     var connection : RTCPeerConnection
 
     //Audio

--- a/TelnyxWebRTCDemo/AppDelegate.swift
+++ b/TelnyxWebRTCDemo/AppDelegate.swift
@@ -11,7 +11,7 @@ import PushKit
 import TelnyxRTC
 
 
-protocol PushKitDelegate {
+protocol PushKitDelegate: AnyObject {
     func onPushNotificationReceived(payload: PKPushPayload) -> Void
     func onPushNotificationReceived(payload: PKPushPayload, completion: @escaping () -> Void) -> Void
 }
@@ -23,7 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     private var telnyxClient : TxClient?
     private var pushRegistry = PKPushRegistry.init(queue: DispatchQueue.main)
-    var pushKitDelegate: PushKitDelegate?
+    weak var pushKitDelegate: PushKitDelegate?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 

--- a/TelnyxWebRTCDemo/Views/UICallScreen.swift
+++ b/TelnyxWebRTCDemo/Views/UICallScreen.swift
@@ -9,7 +9,7 @@
 import UIKit
 import TelnyxRTC
 
-protocol UICallScreenDelegate {
+protocol UICallScreenDelegate: AnyObject {
     func onCallButton()
     func onEndCallButton()
     func onMuteUnmuteSwitch(isMuted: Bool)
@@ -24,7 +24,7 @@ class UICallScreen: UIView {
     
     private var textFields:[UITextField] = [UITextField]()
     
-    var delegate: UICallScreenDelegate?
+    weak var delegate: UICallScreenDelegate?
 
     @IBOutlet var contentView: UIView!
     @IBOutlet weak var endButton: UIButton!

--- a/TelnyxWebRTCDemo/Views/UIIncomingCallView.swift
+++ b/TelnyxWebRTCDemo/Views/UIIncomingCallView.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 import TelnyxRTC
 
-protocol UIIncomingCallViewDelegate {
+protocol UIIncomingCallViewDelegate: AnyObject {
     func onAnswerButton()
     func onRejectButton()
 }
@@ -22,7 +22,7 @@ class UIIncomingCallView: UIView {
 
     private var textFields:[UITextField] = [UITextField]()
 
-    var delegate: UIIncomingCallViewDelegate?
+    weak var delegate: UIIncomingCallViewDelegate?
     @IBOutlet var contentView: UIView!
     @IBOutlet weak var endButton: UIButton!
     @IBOutlet weak var answerButton: UIButton!


### PR DESCRIPTION
[WEBRTC-648 - Fix memory leaks and retain cycles](https://telnyx.atlassian.net/browse/WEBRTC-648)
---
<!-- Describe your change here -->
Make delegate references weak within the SDK and check for memory leaks.
All the delegate reference were declared strong that could result in strong reference cycles and memory leaks.
As a part of this PR, I have changed all the delegate to weak references to prevent strong reference cycles.

TODO: Resolve the memory leaks in WebRTC SDK.

## :older_man: :baby: Behaviors
### Before changes
- All the delegate references were strong.

### After changes
- All the delegate references are weak.

## ✋ Manual testing
1. Run the WebRTC demo app.
2. Login and make calls.
3. Check the memory graph post hanging up the call.
4. There should be no memory leak due to strong reference cycles within the TelnyxRTC SDK.

## Known Issues:
There are a few memory leaks in the WebRTC framework. Have opened a new [issue](https://bugs.chromium.org/p/webrtc/issues/detail?id=13046) for the same.

