### PR TITLE
WEBRTC-653 - GitHub - Create a default pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+<!-- Ticket details and link -->
+[WEBRTC-XXX - Ticket title](https://telnyx.atlassian.net/browse/WEBRTC-XXX)
+---
+<!-- Describe your change here -->
+Please provide a summary of the change / issue with a proper context.
+
+## :older_man: :baby: Behaviors
+### Before changes
+- Describe the behaviour before making the changes.
+
+### After changes
+- Describe the behaviour and impact after the changes.
+
+## TODO
+Please mention pending items if any.
+
+## ✋ Manual testing
+1. Please list down all the steps required to test the changes.
+
+## Known Issues
+Please mention known issues if any.
+
+## Screenshots
+Please attach the screenshots if required


### PR DESCRIPTION
<!-- Ticket details and link -->
[WEBRTC-653 - GitHub - Create a default pull request template](https://telnyx.atlassian.net/browse/WEBRTC-653)
---
<!-- Describe your change here -->
Added a default template for pull request.

## :older_man: :baby: Behaviors
### Before changes
- Contributors had to create the entire pull request body manually to describe the changes in the pull request.

### After changes
- Now, all the project contributors will automatically see the template's contents in the pull request body for every new pull request they create.


## ✋ Manual testing
- After merging this PR to `main`, going forward, all the new pull requests will be populated with the new template.