### PR TITLE
WEBRTC-646 - Handle Gateway states

### DIFF
--- a/TelnyxRTC.xcodeproj/project.pbxproj
+++ b/TelnyxRTC.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		B3B1D9A126542860008D28C9 /* TxPushConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B1D9A026542860008D28C9 /* TxPushConfig.swift */; };
 		B3B1D9A426545807008D28C9 /* UserDefaultExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B1D9A326545807008D28C9 /* UserDefaultExtension.swift */; };
 		B3B1D9A626545E2C008D28C9 /* ViewControllerCallKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B1D9A526545E2C008D28C9 /* ViewControllerCallKitExtension.swift */; };
+		B3BB8FA026BC076000DDCB84 /* GatewayMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BB8F9F26BC076000DDCB84 /* GatewayMessage.swift */; };
 		B3E0B0662656ED73005E7431 /* InfoMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E0B0652656ED73005E7431 /* InfoMessage.swift */; };
 		B3E1029A25F2C16500227DCE /* ModifyMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E1029925F2C16500227DCE /* ModifyMessage.swift */; };
 		B3E1033225F7F94900227DCE /* incoming_call.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = B3E1033025F7F94900227DCE /* incoming_call.mp3 */; };
@@ -149,6 +150,7 @@
 		B3B1D9A22654546E008D28C9 /* TelnyxWebRTCDemo.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TelnyxWebRTCDemo.entitlements; sourceTree = "<group>"; };
 		B3B1D9A326545807008D28C9 /* UserDefaultExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultExtension.swift; sourceTree = "<group>"; };
 		B3B1D9A526545E2C008D28C9 /* ViewControllerCallKitExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerCallKitExtension.swift; sourceTree = "<group>"; };
+		B3BB8F9F26BC076000DDCB84 /* GatewayMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewayMessage.swift; sourceTree = "<group>"; };
 		B3E0B0652656ED73005E7431 /* InfoMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoMessage.swift; sourceTree = "<group>"; };
 		B3E1029925F2C16500227DCE /* ModifyMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyMessage.swift; sourceTree = "<group>"; };
 		B3E1033025F7F94900227DCE /* incoming_call.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = incoming_call.mp3; sourceTree = "<group>"; };
@@ -218,6 +220,7 @@
 				B309D28525F184A100A2AADF /* AnswerMessage.swift */,
 				B3E1029925F2C16500227DCE /* ModifyMessage.swift */,
 				B3E0B0652656ED73005E7431 /* InfoMessage.swift */,
+				B3BB8F9F26BC076000DDCB84 /* GatewayMessage.swift */,
 			);
 			path = Verto;
 			sourceTree = "<group>";
@@ -674,6 +677,7 @@
 			files = (
 				B36FC8C02612794A00A30BC4 /* Logger.swift in Sources */,
 				B3AF248B25EE7C350062EDA9 /* Socket.swift in Sources */,
+				B3BB8FA026BC076000DDCB84 /* GatewayMessage.swift in Sources */,
 				B309D1DB25F020D400A2AADF /* Method.swift in Sources */,
 				B39121AF25FFCE680051E076 /* TxError.swift in Sources */,
 				B368BEE125EDDC7D0032AE52 /* TxClient.swift in Sources */,

--- a/TelnyxRTC.xcodeproj/project.pbxproj
+++ b/TelnyxRTC.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		B3B1D9A426545807008D28C9 /* UserDefaultExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B1D9A326545807008D28C9 /* UserDefaultExtension.swift */; };
 		B3B1D9A626545E2C008D28C9 /* ViewControllerCallKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B1D9A526545E2C008D28C9 /* ViewControllerCallKitExtension.swift */; };
 		B3BB8FA026BC076000DDCB84 /* GatewayMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BB8F9F26BC076000DDCB84 /* GatewayMessage.swift */; };
+		B3C008B226C1B2C5003E7AE3 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C008B126C1B2C5003E7AE3 /* LoadingView.swift */; };
 		B3E0B0662656ED73005E7431 /* InfoMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E0B0652656ED73005E7431 /* InfoMessage.swift */; };
 		B3E1029A25F2C16500227DCE /* ModifyMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E1029925F2C16500227DCE /* ModifyMessage.swift */; };
 		B3E1033225F7F94900227DCE /* incoming_call.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = B3E1033025F7F94900227DCE /* incoming_call.mp3 */; };
@@ -151,6 +152,7 @@
 		B3B1D9A326545807008D28C9 /* UserDefaultExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultExtension.swift; sourceTree = "<group>"; };
 		B3B1D9A526545E2C008D28C9 /* ViewControllerCallKitExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerCallKitExtension.swift; sourceTree = "<group>"; };
 		B3BB8F9F26BC076000DDCB84 /* GatewayMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewayMessage.swift; sourceTree = "<group>"; };
+		B3C008B126C1B2C5003E7AE3 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
 		B3E0B0652656ED73005E7431 /* InfoMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoMessage.swift; sourceTree = "<group>"; };
 		B3E1029925F2C16500227DCE /* ModifyMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyMessage.swift; sourceTree = "<group>"; };
 		B3E1033025F7F94900227DCE /* incoming_call.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = incoming_call.mp3; sourceTree = "<group>"; };
@@ -246,6 +248,7 @@
 				B309D20125F0291B00A2AADF /* UISettingsView.swift */,
 				B309D24D25F0717B00A2AADF /* UICallScreen.xib */,
 				B309D25225F071DD00A2AADF /* UICallScreen.swift */,
+				B3C008B126C1B2C5003E7AE3 /* LoadingView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -727,6 +730,7 @@
 				B368BEEB25EDDD060032AE52 /* AppDelegate.swift in Sources */,
 				B309D20225F0291B00A2AADF /* UISettingsView.swift in Sources */,
 				B3B1D9A626545E2C008D28C9 /* ViewControllerCallKitExtension.swift in Sources */,
+				B3C008B226C1B2C5003E7AE3 /* LoadingView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TelnyxRTC/Telnyx/InternalConfig.swift
+++ b/TelnyxRTC/Telnyx/InternalConfig.swift
@@ -10,7 +10,7 @@ import Foundation
 import WebRTC
 //Servers
 fileprivate let PROD_HOST = "wss://rtc.telnyx.com:14938"
-fileprivate let DEVELOPMENT_HOST = "wss://64.16.226.27:14938"
+fileprivate let DEVELOPMENT_HOST = "wss://rtcdev.telnyx.com:14938"
 
 fileprivate let DEFAULT_TURN = RTCIceServer(urlStrings: ["turn:turn.telnyx.com:3478?transport=tcp"],
                                             username: "testuser",

--- a/TelnyxRTC/Telnyx/InternalConfig.swift
+++ b/TelnyxRTC/Telnyx/InternalConfig.swift
@@ -10,7 +10,7 @@ import Foundation
 import WebRTC
 //Servers
 fileprivate let PROD_HOST = "wss://rtc.telnyx.com:14938"
-fileprivate let DEVELOPMENT_HOST = "wss://rtcdev.telnyx.com:14938"
+fileprivate let DEVELOPMENT_HOST = "wss://64.16.226.27:14938"
 
 fileprivate let DEFAULT_TURN = RTCIceServer(urlStrings: ["turn:turn.telnyx.com:3478?transport=tcp"],
                                             username: "testuser",
@@ -18,7 +18,7 @@ fileprivate let DEFAULT_TURN = RTCIceServer(urlStrings: ["turn:turn.telnyx.com:3
 fileprivate let DEFAULT_STUN = RTCIceServer(urlStrings: ["stun:stun.telnyx.com:3843"])
 
 // Set this to the machine's address which runs the signaling server
-fileprivate let defaultSignalingServerUrl = URL(string: PROD_HOST)!
+fileprivate let defaultSignalingServerUrl = URL(string: DEVELOPMENT_HOST)!
 fileprivate let defaultIceServers = [DEFAULT_TURN, DEFAULT_STUN]
 
 struct InternalConfig {

--- a/TelnyxRTC/Telnyx/InternalConfig.swift
+++ b/TelnyxRTC/Telnyx/InternalConfig.swift
@@ -18,7 +18,7 @@ fileprivate let DEFAULT_TURN = RTCIceServer(urlStrings: ["turn:turn.telnyx.com:3
 fileprivate let DEFAULT_STUN = RTCIceServer(urlStrings: ["stun:stun.telnyx.com:3843"])
 
 // Set this to the machine's address which runs the signaling server
-fileprivate let defaultSignalingServerUrl = URL(string: DEVELOPMENT_HOST)!
+fileprivate let defaultSignalingServerUrl = URL(string: PROD_HOST)!
 fileprivate let defaultIceServers = [DEFAULT_TURN, DEFAULT_STUN]
 
 struct InternalConfig {

--- a/TelnyxRTC/Telnyx/Models/TxError.swift
+++ b/TelnyxRTC/Telnyx/Models/TxError.swift
@@ -44,6 +44,8 @@ public enum TxError : Error {
     public enum ServerErrorReason {
         /// Any server signaling error. We get the message and code from the server
         case signalingServerError(message: String, code: String)
+        /// Gateway is not registered.
+        case gatewayNotRegistered
     }
 
     /// Socket connection failures.
@@ -92,14 +94,17 @@ extension TxError.CallFailureReason {
 extension TxError.ServerErrorReason {
     var errorMessage: String? {
         switch self {
-        case let .signalingServerError(message: message, code: code):
-            return "Message: \(message), code: \(code)"
+            case let .signalingServerError(message: message, code: code):
+                return "Message: \(message), code: \(code)"
+            case .gatewayNotRegistered:
+                return nil
         }
     }
 
     var underlyingError: Error? {
         switch self {
-        case .signalingServerError:
+            case .signalingServerError,
+                 .gatewayNotRegistered:
             return nil
         }
     }
@@ -161,8 +166,10 @@ extension TxError.CallFailureReason {
 extension TxError.ServerErrorReason {
     public var localizedDescription: String {
         switch self {
-        case .signalingServerError(message: let message, code: let code):
-            return "Server error: \(message), code: \(code)"
+            case .signalingServerError(message: let message, code: let code):
+                return "Server error: \(message), code: \(code)"
+            case let .gatewayNotRegistered:
+                return "Gateway not registered."
         }
     }
 }

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -445,42 +445,42 @@ extension TxClient : SocketDelegate {
                         }
                     }
                     break
-            case .CLIENT_READY:
-                self.delegate?.onClientReady()
-                break
+                case .CLIENT_READY:
+                    self.delegate?.onClientReady()
+                    break
 
-            case .INVITE:
-                //invite received
-                if let params = vertoMessage.params {
-                    guard let sdp = params["sdp"] as? String,
-                          let callId = params["callID"] as? String,
-                          let uuid = UUID(uuidString: callId) else {
-                        return
+                case .INVITE:
+                    //invite received
+                    if let params = vertoMessage.params {
+                        guard let sdp = params["sdp"] as? String,
+                              let callId = params["callID"] as? String,
+                              let uuid = UUID(uuidString: callId) else {
+                            return
+                        }
+
+                        let callerName = params["caller_id_name"] as? String ?? ""
+                        let callerNumber = params["caller_id_number"] as? String ?? ""
+                        let telnyxSessionId = params["telnyx_session_id"] as? String ?? ""
+                        let telnyxLegId = params["telnyx_leg_id"] as? String ?? ""
+                        
+                        if telnyxSessionId.isEmpty {
+                            Logger.log.w(message: "TxClient:: Telnyx Session ID unavailable on INVITE message")
+                        }
+                        if telnyxLegId.isEmpty {
+                            Logger.log.w(message: "TxClient:: Telnyx Leg ID unavailable on INVITE message")
+                        }
+                        self.createIncomingCall(callerName: callerName,
+                                                callerNumber: callerNumber,
+                                                callId: uuid,
+                                                remoteSdp: sdp,
+                                                telnyxSessionId: telnyxSessionId,
+                                                telnyxLegId: telnyxLegId)
                     }
+                    break;
 
-                    let callerName = params["caller_id_name"] as? String ?? ""
-                    let callerNumber = params["caller_id_number"] as? String ?? ""
-                    let telnyxSessionId = params["telnyx_session_id"] as? String ?? ""
-                    let telnyxLegId = params["telnyx_leg_id"] as? String ?? ""
-
-                    if telnyxSessionId.isEmpty {
-                        Logger.log.w(message: "TxClient:: Telnyx Session ID unavailable on INVITE message")
-                    }
-                    if telnyxLegId.isEmpty {
-                        Logger.log.w(message: "TxClient:: Telnyx Leg ID unavailable on INVITE message")
-                    }
-                    self.createIncomingCall(callerName: callerName,
-                                            callerNumber: callerNumber,
-                                            callId: uuid,
-                                            remoteSdp: sdp,
-                                            telnyxSessionId: telnyxSessionId,
-                                            telnyxLegId: telnyxLegId)
-                }
-                break;
-
-            default:
-                Logger.log.i(message: "TxClient:: SocketDelegate Default method")
-                break
+                default:
+                    Logger.log.i(message: "TxClient:: SocketDelegate Default method")
+                    break
             }
         }
     }

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -121,6 +121,9 @@ import Bugsnag
 public class TxClient {
 
     // MARK: - Properties
+    private static let DEFAULT_REGISTER_INTERVAL = 3.0 // In seconds
+    private static let MAX_REGISTER_RETRY = 3 // Number of retry
+
     /// Keeps track of all the created calls by theirs UUIDs
     public internal(set) var calls: [UUID: Call] = [UUID: Call]()
     /// Subscribe to TxClient delegate to receive Telnyx SDK events
@@ -130,9 +133,11 @@ public class TxClient {
     private var sessionId : String?
     private var txConfig: TxConfig?
 
-    private static let DEFAULT_REGISTER_INTERVAL = 3.0 // In seconds
+    private var registerRetryCount: Int = MAX_REGISTER_RETRY
     private var registerTimer: Timer = Timer()
     private var gatewayState: GatewayStates = .NOREG
+
+    /// Client must be registered in order to receive or place calls.
     public var isRegistered: Bool {
         get {
             return gatewayState == .REGED
@@ -154,6 +159,7 @@ public class TxClient {
         //Check connetion parameters
         try txConfig.validateParams()
 
+        self.registerRetryCount = TxClient.MAX_REGISTER_RETRY
         self.gatewayState = .NOREG
         self.txConfig = txConfig
         self.socket = Socket()
@@ -164,6 +170,7 @@ public class TxClient {
     /// Disconnects the TxClient from the Telnyx signaling server.
     public func disconnect() {
         Logger.log.i(message: "TxClient:: disconnect()")
+        self.registerRetryCount = TxClient.MAX_REGISTER_RETRY
         self.gatewayState = .NOREG
 
         // Let's cancell all the current calls
@@ -192,28 +199,54 @@ public class TxClient {
     /// This function check the gateway status updates to determine if the current user has been successfully
     /// registered and can start receiving and/or making calls.
     /// - Parameter newState: The new gateway state received from B2BUA
-    private func registerCheck(newState: GatewayStates) {
-        Logger.log.i(message: "TxClient registerCheck() newState [\(newState)] gatewayState [\(self.gatewayState)]")
+    private func updateGatewayState(newState: GatewayStates) {
+        Logger.log.i(message: "TxClient:: updateGatewayState() newState [\(newState)] gatewayState [\(self.gatewayState)]")
 
-        if self.gatewayState == .REGED { return }
+        if self.gatewayState == .REGED {
+            // If the client is already registered, we don't need to do anything else.
+            Logger.log.i(message: "TxClient:: updateGatewayState() already registered")
+            return
+        }
+        // Keep the new state.
         self.gatewayState = newState
         switch newState {
             case .REGED:
-                Logger.log.i(message: "TxClient registerCheck() REGED")
+                // If the client is now registered:
+                // - Stop the timer
+                // - Propagate the client state to the app.
                 self.registerTimer.invalidate()
                 self.delegate?.onClientReady()
+                Logger.log.i(message: "TxClient:: updateGatewayState() clientReady")
                 break
             default:
+                // The gateway state can transition through multiple states before changing to REGED (Registered).
+                Logger.log.i(message: "TxClient:: updateGatewayState() no registered")
+                self.registerTimer.invalidate()
                 DispatchQueue.main.async {
-                    self.registerTimer.invalidate()
                     self.registerTimer = Timer.scheduledTimer(withTimeInterval: TimeInterval(TxClient.DEFAULT_REGISTER_INTERVAL), repeats: false) { [weak self] _ in
-                        Logger.log.i(message: "TxClient registerCheck() registerTimer elapsed.")
-                        self?.gatewayState = .REGED
-                        self?.delegate?.onClientReady()
+                        Logger.log.i(message: "TxClient:: updateGatewayState() registerTimer elapsed: gatewayState [\(String(describing: self?.gatewayState))] registerRetryCount [\(String(describing: self?.registerRetryCount))]")
+
+                        if self?.gatewayState == .REGED {
+                            self?.delegate?.onClientReady()
+                        } else {
+                            self?.registerRetryCount -= 1
+                            if self?.registerRetryCount ?? 0 > 0 {
+                                self?.requestGatewayState()
+                            } else {
+                                Logger.log.e(message: "TxClient:: updateGatewayState() client not registered")
+                            }
+                        }
                     }
                 }
                 break
         }
+    }
+
+    private func requestGatewayState() {
+        let gatewayMessage = GatewayMessage()
+        let message = gatewayMessage.encode() ?? ""
+        // Request gateway state
+        self.socket?.sendMessage(message: message)
     }
 }
 
@@ -453,13 +486,19 @@ extension TxClient : SocketDelegate {
 
         //Check if we are getting the new sessionId in response to the "login" message.
         if let result = vertoMessage.result {
-            //process result
+            // Process gateway state result.
+            if let params = result["params"] as? [String: Any],
+               let state = params["state"] as? String,
+               let gatewayState = GatewayStates(rawValue: state) {
+                Logger.log.i(message: "GATEWAY_STATE RESULT: \(state)")
+                self.updateGatewayState(newState: gatewayState)
+            }
+
             guard let sessionId = result["sessid"] as? String else { return }
             //keep the sessionId
             self.sessionId = sessionId
             self.delegate?.onSessionUpdated(sessionId: sessionId)
         } else {
-
             //Forward message to call based on it's uuid
             if let params = vertoMessage.params,
                let callUUIDString = params["callID"] as? String,
@@ -470,15 +509,12 @@ extension TxClient : SocketDelegate {
 
             //Parse incoming Verto message
             switch vertoMessage.method {
-                case .GATEWAY_STATE:
-                    if let params = vertoMessage.params,
-                       let state = params["state"] as? GatewayStates {
-                        self.registerCheck(newState: state)
-                    }
-                    break
                 case .CLIENT_READY:
-                    // Start checking the gateway registration states
-                    self.registerCheck(newState: .NOREG)
+                    // Once the client logs into the backend, a registration process starts.
+                    // Clients can receive or place calls when they are fully registered into the backend.
+                    // If a client try to call beforw been registered, a GATEWAY_DOWN error is received.
+                    // Therefore, we need to check the gateway state once we have successfully loged in:
+                    self.requestGatewayState()
                     break
 
                 case .INVITE:

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -233,6 +233,8 @@ public class TxClient {
                             if self?.registerRetryCount ?? 0 > 0 {
                                 self?.requestGatewayState()
                             } else {
+                                let notRegisteredError = TxError.serverError(reason: .gatewayNotRegistered)
+                                self?.delegate?.onClientError(error: notRegisteredError)
                                 Logger.log.e(message: "TxClient:: updateGatewayState() client not registered")
                             }
                         }

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -432,6 +432,19 @@ extension TxClient : SocketDelegate {
 
             //Parse incoming Verto message
             switch vertoMessage.method {
+                case .GATEWAY_STATE:
+                    if let params = vertoMessage.params,
+                       let state = params["state"] as? String {
+                        switch state {
+                            case "REGED":
+                                break
+                            case "FAIL":
+                                break
+                            default:
+                                break
+                        }
+                    }
+                    break
             case .CLIENT_READY:
                 self.delegate?.onClientReady()
                 break

--- a/TelnyxRTC/Telnyx/Verto/GatewayMessage.swift
+++ b/TelnyxRTC/Telnyx/Verto/GatewayMessage.swift
@@ -16,3 +16,9 @@ internal enum GatewayStates : String {
     case EXPIRED = "EXPIRED"
     case NOREG = "NOREG"
 }
+
+class GatewayMessage : Message {
+    override init() {
+        super.init([String: Any](), method: .GATEWAY_STATE)
+    }
+}

--- a/TelnyxRTC/Telnyx/Verto/GatewayMessage.swift
+++ b/TelnyxRTC/Telnyx/Verto/GatewayMessage.swift
@@ -1,0 +1,18 @@
+//
+//  GatewayMessage.swift
+//  TelnyxRTC
+//
+//  Created by Guillermo Battistel on 05/08/2021.
+//
+
+internal enum GatewayStates : String {
+    case UNREGED = "UNREGED"
+    case TRYING = "TRYING"
+    case REGISTER = "REGISTER"
+    case REGED = "REGED"
+    case UNREGISTER = "UNREGISTER"
+    case FAILED = "FAILED"
+    case FAIL_WAIT = "FAIL_WAIT"
+    case EXPIRED = "EXPIRED"
+    case NOREG = "NOREG"
+}

--- a/TelnyxRTC/Telnyx/Verto/Method.swift
+++ b/TelnyxRTC/Telnyx/Verto/Method.swift
@@ -19,6 +19,7 @@ enum Method : String {
     case MODIFY = "telnyx_rtc.modify"
     case MEDIA = "telnyx_rtc.media"
     case INFO = "telnyx_rtc.info"
+    case GATEWAY_STATE = "telnyx_rtc.gatewayState"
     //not implemented
     case ATTACH = "telnyx_rtc.attach"
     case DISPLAY = "telnyx_rtc.display"

--- a/TelnyxWebRTCDemo/Extensions/UIViewControllerExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/UIViewControllerExtension.swift
@@ -17,6 +17,17 @@ extension UIViewController {
 // Keyboard handling
 extension UIViewController {
 
+    func showLoadingView() {
+        let loadingView = LoadingView(frame: self.view.frame)
+        self.view.addSubview(loadingView)
+    }
+
+    func removeLoadingView() {
+        if let loadingView = self.view.subviews.first(where: { $0 is LoadingView }) {
+            loadingView.removeFromSuperview()
+        }
+    }
+
     func hideKeyboardWhenTappedAround() {
         let tap = UITapGestureRecognizer(target: self, action: #selector(UIViewController.dismissKeyboard))
         tap.cancelsTouchesInView = false

--- a/TelnyxWebRTCDemo/Views/LoadingView.swift
+++ b/TelnyxWebRTCDemo/Views/LoadingView.swift
@@ -1,0 +1,36 @@
+//
+//  LoadingView.swift
+//  TelnyxWebRTCDemo
+//
+//  Created by Guillermo Battistel on 09/08/2021.
+//  Copyright © 2021 Telnyx LLC. All rights reserved.
+
+import UIKit
+
+class LoadingView: UIView {
+
+    var background: UIVisualEffectView?
+
+    override init(frame: CGRect) {
+        let blurEffect = UIBlurEffect(style: .dark)
+        let background = UIVisualEffectView(effect: blurEffect)
+        background.frame = frame
+        background.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        self.background = background
+        super.init(frame: frame)
+        addSubview(background)
+        addLoader()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func addLoader() {
+        guard let background = background else { return }
+        let activityIndicator = UIActivityIndicatorView(style: .white)
+        background.contentView.addSubview(activityIndicator)
+        activityIndicator.center = background.contentView.center
+        activityIndicator.startAnimating()
+    }
+}


### PR DESCRIPTION
<!-- Ticket details and link -->
[WEBRTC-646 - Handle Gateway states](https://telnyx.atlassian.net/browse/WEBRTC-646)
---
<!-- Describe your change here -->
When the client logs in, the `telnyx_rtc.clientReady` message is received and it indicates that we have successfully logged in, but it not determines if the client can receive or place calls. 
In order to receive or make calls, the gateway must register the client after it logs in, and this process can take some time. If the user try to make a call as soon is logged in, but before the gateway registers it, the error `GATEWAY_DOWN` will be received.

Now on, after the `clientReady` is received, we start a process to request the gateway state and wait until its state is REGED (Registered). 

If the state is different than REGED, we retry requesting the state after 3 seconds, and this process is repeated until we have retried 3 times. If we have retried 3 times and the state is different than REGED, we rise an error.

A few more changes:
1. A loading view will be visible until the registering process is completed or failed.
2. An alert dialog is displayed if an error is received from the SDK.

## :older_man: :baby: Behaviors
### Before changes
- Gateway states were not handled.

### After changes
- Gateway states are handled.

## NOTES: This change require backend changes. DO NOT MERGE until those changes are merged.

## ✋ Manual testing
1. Change the `InternalConfig` to target to the DEVELOPMENT_HOST instead of PROD_HOST.
2. Build the SDK
3. Build and run the APP.
4. Login with development credentials.


