### PR TITLE
Webrtc 649 improve GitHub action script that runs unit tests

### DIFF
--- a/.github/workflows/ios_fastlane_tests.yml
+++ b/.github/workflows/ios_fastlane_tests.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Select Xcode Version
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '12.5'
+        xcode-version: '12.4'
     
     - name: Setup ruby
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/ios_fastlane_tests.yml
+++ b/.github/workflows/ios_fastlane_tests.yml
@@ -6,6 +6,11 @@ jobs:
   tests:
     name: ios_fastlane_tests
     runs-on: macos-latest
+    env:
+        TELNYX_SIP_API_KEY: ${{ secrets.TELNYX_SIP_API_KEY }}
+        TELNYX_SIP_CONNECTION_ID: ${{ secrets.TELNYX_SIP_CONNECTION_ID }}
+        TELNYX_SIP_USER: ${{ secrets.TELNYX_SIP_USER }}
+        TELNYX_SIP_PASSWORD: ${{ secrets.TELNYX_SIP_PASSWORD }}
       
     steps:      
     - name: Checkout
@@ -21,13 +26,29 @@ jobs:
         ruby-version: 2.7.0
         bundler-cache: true
 
+    - name: On-demand Credentials
+      id: ondemand_creds
+      run: |
+        echo "::set-output name=response::$(curl -X POST \
+        --header "Content-Type: application/json" \
+        --header "Authorization: Bearer $TELNYX_SIP_API_KEY" \
+        --data '{
+          "connection_id": "$TELNYX_SIP_CONNECTION_ID"
+        }' \
+        --url 'https://api.telnyx.com/v2/telephony_credentials')"
+
+    - name: Generate Token
+      id: generate_token
+      run: |
+        echo "::set-output name=response::$(curl -X POST \
+        --header "Content-Type: application/json" \
+        --header "Authorization: Bearer $TELNYX_SIP_API_KEY" \
+        --data '{}' \
+        --url "https://api.telnyx.com/v2/telephony_credentials/${{ fromJson(steps.ondemand_creds.outputs.response).data.id }}/token")"
+
     - shell: bash
-      env:
-          TELNYX_SIP_USER: ${{ secrets.TELNYX_SIP_USER }}
-          TELNYX_SIP_PASSWORD: ${{ secrets.TELNYX_SIP_PASSWORD }}
-          TELNYX_SIP_TOKEN: ${{ secrets.TELNYX_SIP_TOKEN }}
       run:  |
-          sh scripts/setup_env.sh -u "$TELNYX_SIP_USER" -p "$TELNYX_SIP_PASSWORD" -t "$TELNYX_SIP_TOKEN"
+          sh scripts/setup_env.sh -u "$TELNYX_SIP_USER" -p "$TELNYX_SIP_PASSWORD" -t "${{ steps.generate_token.outputs.response }}"
           
     - name: Setup Fastlane
       run:  |

--- a/.github/workflows/ios_fastlane_tests.yml
+++ b/.github/workflows/ios_fastlane_tests.yml
@@ -35,9 +35,9 @@ jobs:
         --header "Content-Type: application/json" \
         --header "Authorization: Bearer $TELNYX_SIP_API_KEY" \
         --data '{
-          "connection_id": "$TELNYX_SIP_CONNECTION_ID"
+            "connection_id": "${{ env.TELNYX_SIP_CONNECTION_ID }}"
         }' \
-        --url 'https://api.telnyx.com/v2/telephony_credentials')"
+        https://api.telnyx.com/v2/telephony_credentials)"
 
     - name: Generate Token
       id: generate_token

--- a/.github/workflows/ios_fastlane_tests.yml
+++ b/.github/workflows/ios_fastlane_tests.yml
@@ -2,6 +2,8 @@ name: ios_fastlane_tests
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  pull_request:
+
 jobs:
   tests:
     name: ios_fastlane_tests

--- a/TelnyxRTC.xcodeproj/xcshareddata/xcschemes/TelnyxRTCSDK.xcscheme
+++ b/TelnyxRTC.xcodeproj/xcshareddata/xcschemes/TelnyxRTCSDK.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1220"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B368BEBF25EDDB610032AE52"
+               BuildableName = "TelnyxRTC.framework"
+               BlueprintName = "TelnyxRTC"
+               ReferencedContainer = "container:TelnyxRTC.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B368BED025EDDBC90032AE52"
+               BuildableName = "TelnyxRTCTests.xctest"
+               BlueprintName = "TelnyxRTCTests"
+               ReferencedContainer = "container:TelnyxRTC.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B368BEBF25EDDB610032AE52"
+            BuildableName = "TelnyxRTC.framework"
+            BlueprintName = "TelnyxRTC"
+            ReferencedContainer = "container:TelnyxRTC.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -19,5 +19,5 @@ desc "Run unit tests."
 lane :tests do
    run_tests(workspace: "TelnyxRTC.xcworkspace",
             devices: ["iPhone 8"],
-            scheme: "TelnyxRTC")
+            scheme: "TelnyxRTCSDK")
 end


### PR DESCRIPTION
<!-- Ticket details and link -->
[WEBRTC-649 - Improve GitHub action script that runs unit tests](https://telnyx.atlassian.net/browse/WEBRTC-649)
---
<!-- Describe your change here -->
Improve GitHub action script that runs unit tests. Auto run the action on every PR. Generate on-demend credentials for token login.

## :older_man: :baby: Behaviors
### Before changes
- The github action that runs the unit tests was triggered manually.
- Token for login was not generated each time and tokens expire.

### After changes
- After adding the pull request trigger, this action will now trigger on every PR
- Token is now generated when this action is triggered

## ✋ Manual testing
1. Creating a pull request should trigger this action.

