### PR TITLE
WEBRTC-655 - Fix unit tests

### DIFF
--- a/TelnyxRTCTests/Verto/VertoMessagesTests.swift
+++ b/TelnyxRTCTests/Verto/VertoMessagesTests.swift
@@ -25,8 +25,9 @@ class VertoMessagesTests: XCTestCase {
                                                         pushDeviceToken: pushDeviceToken,
                                                         pushNotificationProvider: pushNotificationProvider)
         let loginEncodedToken : String = loginWithToken.params?["login_token"] as! String
-        let loginEncodedPushToken : String = loginWithToken.params?["push_device_token"] as! String
-        let loginEncodedPushProvider : String = loginWithToken.params?["push_notification_provider"] as! String
+        let userVariables = loginWithToken.params?["userVariables"] as? [String: Any]
+        let loginEncodedPushToken : String = userVariables?["push_device_token"] as! String
+        let loginEncodedPushProvider : String = userVariables?["push_notification_provider"] as! String
 
         XCTAssertEqual(loginEncodedToken, loginToken)
         XCTAssertEqual(loginEncodedPushToken, pushDeviceToken)
@@ -35,8 +36,10 @@ class VertoMessagesTests: XCTestCase {
         let encodedLogin: String = loginWithToken.encode() ?? ""
         let decodeLogin = Message().decode(message: encodedLogin)
         let decodedToken : String  = decodeLogin?.params?["login_token"] as! String
-        let decodedPushToken : String = decodeLogin?.params?["push_device_token"] as! String
-        let decodedPushProvider : String = decodeLogin?.params?["push_notification_provider"] as! String
+
+        let userVariablesDecoded = decodeLogin?.params?["userVariables"] as? [String: Any]
+        let decodedPushToken : String = userVariablesDecoded?["push_device_token"] as! String
+        let decodedPushProvider : String = userVariablesDecoded?["push_notification_provider"] as! String
 
         XCTAssertEqual(decodedToken, loginToken)
         XCTAssertEqual(decodedPushToken, pushDeviceToken)

--- a/TelnyxRTCTests/Verto/VertoMessagesTests.swift
+++ b/TelnyxRTCTests/Verto/VertoMessagesTests.swift
@@ -66,8 +66,10 @@ class VertoMessagesTests: XCTestCase {
                                                                     pushNotificationProvider: pushNotificationProvider)
         let loginUser : String = loginWidthUserAndPassoword.params?["login"] as! String
         let loginPassword : String = loginWidthUserAndPassoword.params?["passwd"] as! String
-        let loginEncodedPushToken : String = loginWidthUserAndPassoword.params?["push_device_token"] as! String
-        let loginEncodedPushProvider : String = loginWidthUserAndPassoword.params?["push_notification_provider"] as! String
+
+        let userVariables = loginWidthUserAndPassoword.params?["userVariables"] as? [String: Any]
+        let loginEncodedPushToken : String = userVariables?["push_device_token"] as! String
+        let loginEncodedPushProvider : String = userVariables?["push_notification_provider"] as! String
 
         XCTAssertEqual(loginUser, userName)
         XCTAssertEqual(loginPassword, password)
@@ -78,8 +80,10 @@ class VertoMessagesTests: XCTestCase {
         let decodeLogin = Message().decode(message: encodedLogin)
         let decodedUser : String = decodeLogin?.params?["login"] as! String
         let decodedPassword : String = decodeLogin?.params?["passwd"] as! String
-        let decodedPushToken : String = decodeLogin?.params?["push_device_token"] as! String
-        let decodedPushProvider : String = decodeLogin?.params?["push_notification_provider"] as! String
+
+        let userVariablesDecoded = decodeLogin?.params?["userVariables"] as? [String: Any]
+        let decodedPushToken : String = userVariablesDecoded?["push_device_token"] as! String
+        let decodedPushProvider : String = userVariablesDecoded?["push_notification_provider"] as! String
 
         XCTAssertEqual(decodedUser, userName)
         XCTAssertEqual(decodedPassword, password)

--- a/TelnyxRTCTests/Verto/VertoMessagesTests.swift
+++ b/TelnyxRTCTests/Verto/VertoMessagesTests.swift
@@ -60,14 +60,14 @@ class VertoMessagesTests: XCTestCase {
         let pushNotificationProvider = TxPushConfig.PUSH_NOTIFICATION_PROVIDER
 
         print("VertoMessagesTest :: Testing LoginMessage username and password constructor")
-        let loginWidthUserAndPassoword: LoginMessage = LoginMessage(user: userName,
+        let loginWithUserAndPassoword: LoginMessage = LoginMessage(user: userName,
                                                                     password: password,
                                                                     pushDeviceToken: pushDeviceToken,
                                                                     pushNotificationProvider: pushNotificationProvider)
-        let loginUser : String = loginWidthUserAndPassoword.params?["login"] as! String
-        let loginPassword : String = loginWidthUserAndPassoword.params?["passwd"] as! String
+        let loginUser : String = loginWithUserAndPassoword.params?["login"] as! String
+        let loginPassword : String = loginWithUserAndPassoword.params?["passwd"] as! String
 
-        let userVariables = loginWidthUserAndPassoword.params?["userVariables"] as? [String: Any]
+        let userVariables = loginWithUserAndPassoword.params?["userVariables"] as? [String: Any]
         let loginEncodedPushToken : String = userVariables?["push_device_token"] as! String
         let loginEncodedPushProvider : String = userVariables?["push_notification_provider"] as! String
 
@@ -76,7 +76,7 @@ class VertoMessagesTests: XCTestCase {
         XCTAssertEqual(loginEncodedPushToken, pushDeviceToken)
         XCTAssertEqual(loginEncodedPushProvider, pushNotificationProvider)
 
-        let encodedLogin: String = loginWidthUserAndPassoword.encode() ?? ""
+        let encodedLogin: String = loginWithUserAndPassoword.encode() ?? ""
         let decodeLogin = Message().decode(message: encodedLogin)
         let decodedUser : String = decodeLogin?.params?["login"] as! String
         let decodedPassword : String = decodeLogin?.params?["passwd"] as! String

--- a/TelnyxRTCTests/WebRTC/CallTests.swift
+++ b/TelnyxRTCTests/WebRTC/CallTests.swift
@@ -13,12 +13,14 @@ import WebRTC
 class CallTests: XCTestCase {
     private weak var expectation: XCTestExpectation!
     private var call: Call?
+    private var socket: Socket?
 
     override func setUpWithError() throws {
         print("CallTests:: setUpWithError")
-        let socket = Socket()
-        socket.connect()
-        socket.delegate = self
+        self.socket = Socket()
+        self.socket?.delegate = self
+        self.socket?.connect()
+        guard let socket = self.socket else { return }
         self.call = Call(callId: UUID.init(), sessionId: "<sessionId>", socket: socket, delegate: self)
     }
 


### PR DESCRIPTION
<!-- Ticket details and link -->
[WEBRTC-655 - Fix unit tests](https://telnyx.atlassian.net/browse/WEBRTC-655)
---
<!-- Describe your change here -->
Two test cases were fixed: 
- **Login Verto messages:** There was an issue related to the push notification variables. These variables has to be send inside the property "userVariables".
- **CallTests:** We were creating a socket object inside the setUpWithError function, now we move it as a property of the class CallTests. 

## :older_man: :baby: Behaviors
### Before changes
- Some unit tests were not working.

### After changes
- Unit tests are working

## ✋ Manual testing
1. Replace your SIP credentials and token on TestConstants.swift file.
2. Run` fastlane tests` 
3. Wait until all tests pass.
