### PR TITLE
WEBRTC-660 - Fix pod lib lint warning

### DIFF
--- a/TelnyxRTC/Telnyx/Models/TxError.swift
+++ b/TelnyxRTC/Telnyx/Models/TxError.swift
@@ -168,7 +168,7 @@ extension TxError.ServerErrorReason {
         switch self {
             case .signalingServerError(message: let message, code: let code):
                 return "Server error: \(message), code: \(code)"
-            case let .gatewayNotRegistered:
+            case .gatewayNotRegistered:
                 return "Gateway not registered."
         }
     }


### PR DESCRIPTION
<!-- Ticket details and link -->
[WEBRTC-660 - Fix pod lib lint warning](https://telnyx.atlassian.net/browse/WEBRTC-660)
---
<!-- Describe your change here -->
There was a lint error that was producing a warning when running `pod lib lint`

## :older_man: :baby: Behaviors
### Before changes
- `pod lib lint` was failing

<img width="1440" alt="Screen Shot 2021-08-13 at 16 26 54" src="https://user-images.githubusercontent.com/75636882/129409849-b93f30e2-839f-4108-ac11-3ab67c1f2172.png">

### After changes
- `pod lib lint` is working

<img width="1440" alt="Screen Shot 2021-08-13 at 16 37 04" src="https://user-images.githubusercontent.com/75636882/129410137-f02fbf82-11f8-48c8-bdca-54b79f803c2c.png">


