### PR TITLE
WEBRTC-666 - Add hidden option to use dev TE

### DIFF
--- a/TelnyxRTC.xcodeproj/project.pbxproj
+++ b/TelnyxRTC.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		B309D27C25F17C1700A2AADF /* UIIncomingCallView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B309D27A25F17C1700A2AADF /* UIIncomingCallView.xib */; };
 		B309D28225F1838700A2AADF /* ByeMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D28125F1838700A2AADF /* ByeMessage.swift */; };
 		B309D28625F184A100A2AADF /* AnswerMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D28525F184A100A2AADF /* AnswerMessage.swift */; };
+		B32AE8B326CD4F9200C7C6F4 /* TxServerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B32AE8B226CD4F9200C7C6F4 /* TxServerConfiguration.swift */; };
 		B366D3FB26150D1100156FE1 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B366D3FA26150D1100156FE1 /* StringExtension.swift */; };
 		B368BEC525EDDB610032AE52 /* TelnyxRTC.h in Headers */ = {isa = PBXBuildFile; fileRef = B368BEC325EDDB610032AE52 /* TelnyxRTC.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B368BED425EDDBC90032AE52 /* TelnyxRTCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B368BED325EDDBC90032AE52 /* TelnyxRTCTests.swift */; };
@@ -118,6 +119,7 @@
 		B309D27A25F17C1700A2AADF /* UIIncomingCallView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = UIIncomingCallView.xib; sourceTree = "<group>"; };
 		B309D28125F1838700A2AADF /* ByeMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ByeMessage.swift; sourceTree = "<group>"; };
 		B309D28525F184A100A2AADF /* AnswerMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnswerMessage.swift; sourceTree = "<group>"; };
+		B32AE8B226CD4F9200C7C6F4 /* TxServerConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxServerConfiguration.swift; sourceTree = "<group>"; };
 		B366D3FA26150D1100156FE1 /* StringExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
 		B368BEC025EDDB610032AE52 /* TelnyxRTC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TelnyxRTC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B368BEC325EDDB610032AE52 /* TelnyxRTC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TelnyxRTC.h; sourceTree = "<group>"; };
@@ -235,6 +237,7 @@
 				B309D23A25F06DC000A2AADF /* TxCallOptions.swift */,
 				B39121AE25FFCE680051E076 /* TxError.swift */,
 				B3B1D9A026542860008D28C9 /* TxPushConfig.swift */,
+				B32AE8B226CD4F9200C7C6F4 /* TxServerConfiguration.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -683,6 +686,7 @@
 				B3BB8FA026BC076000DDCB84 /* GatewayMessage.swift in Sources */,
 				B309D1DB25F020D400A2AADF /* Method.swift in Sources */,
 				B39121AF25FFCE680051E076 /* TxError.swift in Sources */,
+				B32AE8B326CD4F9200C7C6F4 /* TxServerConfiguration.swift in Sources */,
 				B368BEE125EDDC7D0032AE52 /* TxClient.swift in Sources */,
 				B309D28625F184A100A2AADF /* AnswerMessage.swift in Sources */,
 				B309D23125F06CA800A2AADF /* Peer.swift in Sources */,

--- a/TelnyxRTC/Telnyx/InternalConfig.swift
+++ b/TelnyxRTC/Telnyx/InternalConfig.swift
@@ -23,9 +23,11 @@ fileprivate let defaultIceServers = [DEFAULT_TURN, DEFAULT_STUN]
 
 struct InternalConfig {
     let bugsnagKey = "046a0602ac5080aee24906a0191f867d"
-    let signalingServerUrl: URL
+    let prodSignalingServer: URL
+    let developmentSignalingServer: URL
     let webRTCIceServers: [RTCIceServer]
     
-    static let `default` = InternalConfig(signalingServerUrl: defaultSignalingServerUrl,
-                                  webRTCIceServers: defaultIceServers)
+    static let `default` = InternalConfig(prodSignalingServer: URL(string: PROD_HOST)!,
+                                          developmentSignalingServer: URL(string: DEVELOPMENT_HOST)!,
+                                          webRTCIceServers: defaultIceServers)
 }

--- a/TelnyxRTC/Telnyx/Models/TxConfig.swift
+++ b/TelnyxRTC/Telnyx/Models/TxConfig.swift
@@ -20,7 +20,6 @@ public struct TxConfig {
     public internal(set) var ringBackTone: String?
     public internal(set) var ringtone: String?
 
-
     // MARK: - Initializers
 
     /// Constructor of the Telnyx SDK configuration: Login using sip user  and password.
@@ -54,6 +53,7 @@ public struct TxConfig {
     ///   - ringtone: (Optional) The audio file name to be played when receiving an incoming call. e.g.: "my-ringtone.mp3"
     ///   - ringBackTone: (Optional) The audio file name to be played when calling. e.g.: "my-ringbacktone.mp3"
     ///   - logLevel: (Optional) Can select the verbosity level of the SDK logs. Is set to `.none` as default
+    ///   - serverConfiguration: (Optional) To define a custom `signaling server` and `TURN/ STUN servers`. As default we use the internal Telnyx Production servers.
     public init(token: String,
                 pushDeviceToken: String? = nil,
                 ringtone: String? = nil,

--- a/TelnyxRTC/Telnyx/Models/TxServerConfiguration.swift
+++ b/TelnyxRTC/Telnyx/Models/TxServerConfiguration.swift
@@ -33,6 +33,7 @@ public struct TxServerConfiguration {
             } else {
                 self.signalingServer = InternalConfig.default.developmentSignalingServer
             }
+            self.environment = environment
         }
 
         if let webRTCIceServers = webRTCIceServers {

--- a/TelnyxRTC/Telnyx/Models/TxServerConfiguration.swift
+++ b/TelnyxRTC/Telnyx/Models/TxServerConfiguration.swift
@@ -1,0 +1,34 @@
+//
+//  TxServerConfiguration.swift
+//  TelnyxRTC
+//
+//  Created by Guillermo Battistel on 18/08/2021.
+//  Copyright © 2021 Telnyx LLC. All rights reserved.
+//
+
+import WebRTC
+
+/// This class contains all the properties related to: Signaling server URL and  STUN / TURN servers
+public struct TxServerConfiguration {
+
+    public internal(set) var signalingServer: URL
+    public internal(set) var webRTCIceServers: [RTCIceServer]
+
+    /// Constructor for the Server configuration parameters.
+    /// - Parameters:
+    ///   - signalingServer: To define the signaling server URL `wss://address:port`
+    ///   - webRTCIceServers: To define custom ICE servers
+    public init(signalingServer: URL? = nil, webRTCIceServers: [RTCIceServer]? = nil) {
+        if let signalingServer = signalingServer {
+            self.signalingServer = signalingServer
+        } else {
+            self.signalingServer = InternalConfig.default.signalingServerUrl
+        }
+
+        if let webRTCIceServers = webRTCIceServers {
+            self.webRTCIceServers = webRTCIceServers
+        } else {
+            self.webRTCIceServers = InternalConfig.default.webRTCIceServers
+        }
+    }
+}

--- a/TelnyxRTC/Telnyx/Models/TxServerConfiguration.swift
+++ b/TelnyxRTC/Telnyx/Models/TxServerConfiguration.swift
@@ -8,9 +8,14 @@
 
 import WebRTC
 
+public enum WebRTCEnvironment {
+    case development
+    case production
+}
 /// This class contains all the properties related to: Signaling server URL and  STUN / TURN servers
 public struct TxServerConfiguration {
 
+    public internal(set) var environment: WebRTCEnvironment = .production
     public internal(set) var signalingServer: URL
     public internal(set) var webRTCIceServers: [RTCIceServer]
 
@@ -18,11 +23,16 @@ public struct TxServerConfiguration {
     /// - Parameters:
     ///   - signalingServer: To define the signaling server URL `wss://address:port`
     ///   - webRTCIceServers: To define custom ICE servers
-    public init(signalingServer: URL? = nil, webRTCIceServers: [RTCIceServer]? = nil) {
+    public init(signalingServer: URL? = nil, webRTCIceServers: [RTCIceServer]? = nil, environment: WebRTCEnvironment = .production) {
+        Logger.log.i(message: "TxServerConfiguration:: signalingServer [\(String(describing: signalingServer))] webRTCIceServers [\(String(describing: webRTCIceServers))] environment [\(String(describing: environment))]")
         if let signalingServer = signalingServer {
             self.signalingServer = signalingServer
         } else {
-            self.signalingServer = InternalConfig.default.signalingServerUrl
+            if environment == .production {
+                self.signalingServer = InternalConfig.default.prodSignalingServer
+            } else {
+                self.signalingServer = InternalConfig.default.developmentSignalingServer
+            }
         }
 
         if let webRTCIceServers = webRTCIceServers {

--- a/TelnyxRTC/Telnyx/Services/Socket.swift
+++ b/TelnyxRTC/Telnyx/Services/Socket.swift
@@ -14,12 +14,11 @@ class Socket {
     weak var delegate: SocketDelegate?
     var isConnected : Bool = false
 
-    private let config = InternalConfig.default
     private var socket : WebSocket?
-    
-    func connect() {
+
+    func connect(signalingServer: URL) {
         Logger.log.i(message: "Socket:: connect()")
-        var request = URLRequest(url: config.signalingServerUrl)
+        var request = URLRequest(url: signalingServer)
         request.timeoutInterval = 5
         let pinner = FoundationSecurity(allowSelfSigned: true) // don't validate SSL certificates
         

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -158,7 +158,7 @@ public class TxClient {
     ///   - txConfig: The desired login credentials. See TxConfig docummentation for more information.
     ///   - serverConfiguration: (Optional) To define a custom `signaling server` and `TURN/ STUN servers`. As default we use the internal Telnyx Production servers.
     /// - Throws: TxConfig parameters errors
-    public func connect(txConfig: TxConfig, serverConfiguration: TxServerConfiguration? = nil) throws {
+    public func connect(txConfig: TxConfig, serverConfiguration: TxServerConfiguration = TxServerConfiguration()) throws {
         Logger.log.i(message: "TxClient:: connect()")
         //Check connetion parameters
         try txConfig.validateParams()
@@ -167,11 +167,8 @@ public class TxClient {
         self.gatewayState = .NOREG
         self.txConfig = txConfig
 
-        if let serverConfiguration = serverConfiguration {
-            self.serverConfiguration = serverConfiguration
-        } else {
-            self.serverConfiguration = TxServerConfiguration()
-        }
+        self.serverConfiguration = serverConfiguration
+
         Logger.log.i(message: "TxClient:: serverConfiguration server: [\(self.serverConfiguration.signalingServer)] ICE Servers [\(self.serverConfiguration.webRTCIceServers)]")
 
         self.socket = Socket()
@@ -389,7 +386,7 @@ extension TxClient {
     /// - Parameters:
     ///   - txConfig: The desired configuration to login to B2B2UA. User credentials must be the same as the
     /// - Throws: Error during the connection process
-    public func processVoIPNotification(txConfig: TxConfig, serverConfiguration: TxServerConfiguration? = nil) throws {
+    public func processVoIPNotification(txConfig: TxConfig, serverConfiguration: TxServerConfiguration = TxServerConfiguration()) throws {
         Logger.log.i(message: "TxClient:: processVoIPNotification()")
         // Check if we are already connected and logged in
         if !isConnected() &&

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -132,6 +132,7 @@ public class TxClient {
 
     private var sessionId : String?
     private var txConfig: TxConfig?
+    private var serverConfiguration: TxServerConfiguration
 
     private var registerRetryCount: Int = MAX_REGISTER_RETRY
     private var registerTimer: Timer = Timer()
@@ -147,14 +148,17 @@ public class TxClient {
     // MARK: - Initializers
     /// TxClient has to be instantiated.
     public init() {
+        self.serverConfiguration = TxServerConfiguration()
         self.configure()
     }
 
     // MARK: - Connection handling
     /// Connects to the iOS client to the Telnyx signaling server using the desired login credentials.
-    /// - Parameter txConfig: The desired login credentials. See TxConfig docummentation for more information.
+    /// - Parameters:
+    ///   - txConfig: The desired login credentials. See TxConfig docummentation for more information.
+    ///   - serverConfiguration: (Optional) To define a custom `signaling server` and `TURN/ STUN servers`. As default we use the internal Telnyx Production servers.
     /// - Throws: TxConfig parameters errors
-    public func connect(txConfig: TxConfig) throws {
+    public func connect(txConfig: TxConfig, serverConfiguration: TxServerConfiguration? = nil) throws {
         Logger.log.i(message: "TxClient:: connect()")
         //Check connetion parameters
         try txConfig.validateParams()
@@ -162,9 +166,15 @@ public class TxClient {
         self.registerRetryCount = TxClient.MAX_REGISTER_RETRY
         self.gatewayState = .NOREG
         self.txConfig = txConfig
+
+        if let serverConfiguration = serverConfiguration {
+            self.serverConfiguration = serverConfiguration
+            Logger.log.i(message: "TxClient:: serverConfiguration server: [\(serverConfiguration.signalingServer)] ICE Servers [\(serverConfiguration.webRTCIceServers)]")
+        }
+
         self.socket = Socket()
         self.socket?.delegate = self
-        self.socket?.connect()
+        self.socket?.connect(signalingServer: self.serverConfiguration.signalingServer)
     }
 
     /// Disconnects the TxClient from the Telnyx signaling server.
@@ -319,7 +329,8 @@ extension TxClient {
                         socket: socket,
                         delegate: self,
                         ringtone: self.txConfig?.ringtone,
-                        ringbackTone: self.txConfig?.ringBackTone)
+                        ringbackTone: self.txConfig?.ringBackTone,
+                        iceServers: self.serverConfiguration.webRTCIceServers)
         call.newCall(callerName: callerName, callerNumber: callerNumber, destinationNumber: destinationNumber, clientState: clientState)
 
         self.calls[callId] = call
@@ -354,7 +365,8 @@ extension TxClient {
                         telnyxSessionId: UUID(uuidString: telnyxSessionId),
                         telnyxLegId: UUID(uuidString: telnyxLegId),
                         ringtone: self.txConfig?.ringtone,
-                        ringbackTone: self.txConfig?.ringBackTone)
+                        ringbackTone: self.txConfig?.ringBackTone,
+                        iceServers: self.serverConfiguration.webRTCIceServers)
         call.callInfo?.callerName = callerName
         call.callInfo?.callerNumber = callerNumber
         call.callOptions = TxCallOptions(audio: true)
@@ -375,12 +387,12 @@ extension TxClient {
     /// - Parameters:
     ///   - txConfig: The desired configuration to login to B2B2UA. User credentials must be the same as the
     /// - Throws: Error during the connection process
-    public func processVoIPNotification(txConfig: TxConfig) throws {
+    public func processVoIPNotification(txConfig: TxConfig, serverConfiguration: TxServerConfiguration? = nil) throws {
         Logger.log.i(message: "TxClient:: processVoIPNotification()")
         // Check if we are already connected and logged in
         if !isConnected() &&
             getSessionId().isEmpty {
-            try self.connect(txConfig: txConfig)
+            try self.connect(txConfig: txConfig, serverConfiguration: serverConfiguration)
         }
     }
 }

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -169,8 +169,10 @@ public class TxClient {
 
         if let serverConfiguration = serverConfiguration {
             self.serverConfiguration = serverConfiguration
-            Logger.log.i(message: "TxClient:: serverConfiguration server: [\(serverConfiguration.signalingServer)] ICE Servers [\(serverConfiguration.webRTCIceServers)]")
+        } else {
+            self.serverConfiguration = TxServerConfiguration()
         }
+        Logger.log.i(message: "TxClient:: serverConfiguration server: [\(self.serverConfiguration.signalingServer)] ICE Servers [\(self.serverConfiguration.webRTCIceServers)]")
 
         self.socket = Socket()
         self.socket?.delegate = self

--- a/TelnyxRTCTests/Socket/SocketTests.swift
+++ b/TelnyxRTCTests/Socket/SocketTests.swift
@@ -43,7 +43,7 @@ class SocketTests : XCTestCase, SocketDelegate {
         socketConnectedExpectation = expectation(description: "socketConnection")
         let socket = Socket()
         socket.delegate = self
-        socket.connect()
+        socket.connect(signalingServer: InternalConfig.default.prodSignalingServer)
         waitForExpectations(timeout: 5)
         XCTAssertTrue(socket.isConnected)
 

--- a/TelnyxRTCTests/WebRTC/CallTests.swift
+++ b/TelnyxRTCTests/WebRTC/CallTests.swift
@@ -19,9 +19,9 @@ class CallTests: XCTestCase {
         print("CallTests:: setUpWithError")
         self.socket = Socket()
         self.socket?.delegate = self
-        self.socket?.connect()
+        self.socket?.connect(signalingServer: InternalConfig.default.prodSignalingServer)
         guard let socket = self.socket else { return }
-        self.call = Call(callId: UUID.init(), sessionId: "<sessionId>", socket: socket, delegate: self)
+        self.call = Call(callId: UUID.init(), sessionId: "<sessionId>", socket: socket, delegate: self, iceServers: InternalConfig.default.webRTCIceServers)
     }
 
     override func tearDownWithError() throws {

--- a/TelnyxWebRTCDemo/Base.lproj/Main.storyboard
+++ b/TelnyxWebRTCDemo/Base.lproj/Main.storyboard
@@ -140,6 +140,7 @@
                         <outlet property="callView" destination="qhD-Ar-bVI" id="mIz-Bj-zmd"/>
                         <outlet property="connectButton" destination="HDL-DH-v9R" id="DDG-vM-oNk"/>
                         <outlet property="incomingCallView" destination="z4d-Kt-WJs" id="xkP-lK-Kxj"/>
+                        <outlet property="logo" destination="wzw-DY-Om3" id="5Uq-64-HAS"/>
                         <outlet property="sessionIdLabel" destination="QiW-C2-v1t" id="1Jq-zS-Mt2"/>
                         <outlet property="settingsView" destination="Sq2-dL-w4H" id="5cZ-1a-8aP"/>
                         <outlet property="socketStateLabel" destination="lhJ-I7-FaD" id="fPk-4D-Rhb"/>

--- a/TelnyxWebRTCDemo/Base.lproj/Main.storyboard
+++ b/TelnyxWebRTCDemo/Base.lproj/Main.storyboard
@@ -106,6 +106,12 @@
                                     <action selector="connectButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="wAP-ng-15X"/>
                                 </connections>
                             </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Environment" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="V6p-hr-IUE">
+                                <rect key="frame" x="10" y="840" width="394" height="12"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="10"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -116,8 +122,10 @@
                             <constraint firstItem="qhD-Ar-bVI" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="2t6-Ye-670"/>
                             <constraint firstItem="z4d-Kt-WJs" firstAttribute="top" secondItem="GfE-v1-Dfm" secondAttribute="bottom" constant="10" id="5Fw-t4-0AB"/>
                             <constraint firstItem="MLh-Ll-Ryr" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="30" id="9am-oo-xrB"/>
+                            <constraint firstItem="V6p-hr-IUE" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" constant="-10" id="CrX-Dy-c99"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="MLh-Ll-Ryr" secondAttribute="trailing" constant="30" id="CwS-bk-NGg"/>
                             <constraint firstItem="HDL-DH-v9R" firstAttribute="top" secondItem="z4d-Kt-WJs" secondAttribute="bottom" constant="30" id="H7G-et-nzB"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="V6p-hr-IUE" secondAttribute="trailing" constant="10" id="I7O-jO-cOJ"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="HDL-DH-v9R" secondAttribute="trailing" constant="30" id="IMG-fp-iXT"/>
                             <constraint firstItem="z4d-Kt-WJs" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="MgJ-gZ-gtY"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="GfE-v1-Dfm" secondAttribute="trailing" constant="30" id="UJE-Ni-Txm"/>
@@ -134,11 +142,13 @@
                             <constraint firstItem="HDL-DH-v9R" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="30" id="pzO-jA-MTe"/>
                             <constraint firstItem="wzw-DY-Om3" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="50" id="uQg-B1-8tM"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Sq2-dL-w4H" secondAttribute="trailing" id="yZv-r3-hGl"/>
+                            <constraint firstItem="V6p-hr-IUE" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="10" id="yuE-rw-NKO"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="callView" destination="qhD-Ar-bVI" id="mIz-Bj-zmd"/>
                         <outlet property="connectButton" destination="HDL-DH-v9R" id="DDG-vM-oNk"/>
+                        <outlet property="environment" destination="V6p-hr-IUE" id="lrC-vY-gWt"/>
                         <outlet property="incomingCallView" destination="z4d-Kt-WJs" id="xkP-lK-Kxj"/>
                         <outlet property="logo" destination="wzw-DY-Om3" id="5Uq-64-HAS"/>
                         <outlet property="sessionIdLabel" destination="QiW-C2-v1t" id="1Jq-zS-Mt2"/>

--- a/TelnyxWebRTCDemo/Extensions/UserDefaultExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/UserDefaultExtension.swift
@@ -6,12 +6,14 @@
 //
 
 import Foundation
+import TelnyxRTC
 
 fileprivate let PUSH_DEVICE_TOKEN = ""
 
 fileprivate let SIP_USER = "SIP_USER"
 fileprivate let SIP_USER_PASSWORD = "SIP_USER_PASSWORD"
 fileprivate let CALL_DESTINATION = "CALL_DESTINATION"
+fileprivate let WEBRTC_ENVIRONMENT = "WEBRTC_ENVIRONMENT"
 
 extension UserDefaults {
 
@@ -53,5 +55,16 @@ extension UserDefaults {
     func getSipUserPassword() -> String {
         let userDefaults = UserDefaults.standard
         return userDefaults.string(forKey: SIP_USER_PASSWORD) ?? ""
+    }
+
+    func saveEnvironment(environment: WebRTCEnvironment) {
+        let userDefaults = UserDefaults.standard
+        userDefaults.set((environment == .development) ? "development" : "production", forKey: WEBRTC_ENVIRONMENT)
+        userDefaults.synchronize()
+    }
+
+    func getEnvironment() -> WebRTCEnvironment {
+        let userDefaults = UserDefaults.standard
+        return (userDefaults.string(forKey: WEBRTC_ENVIRONMENT) == "development") ? .development : .production
     }
 }

--- a/TelnyxWebRTCDemo/Extensions/ViewControllerCallKitExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/ViewControllerCallKitExtension.swift
@@ -241,7 +241,11 @@ extension ViewController : PushKitDelegate {
                                 logLevel: .all)
 
         do {
-            try self.telnyxClient?.processVoIPNotification(txConfig: txConfig)
+            if let serverConfig = serverConfig {
+                try telnyxClient?.processVoIPNotification(txConfig: txConfig, serverConfiguration: serverConfig)
+            } else {
+                try telnyxClient?.processVoIPNotification(txConfig: txConfig)
+            }
         } catch let error {
             print("ViewController:: processVoIPNotification Error \(error)")
         }

--- a/TelnyxWebRTCDemo/ViewController.swift
+++ b/TelnyxWebRTCDemo/ViewController.swift
@@ -22,6 +22,7 @@ class ViewController: UIViewController {
     let callKitCallController = CXCallController()
     var loadingView: UIAlertController?
 
+    @IBOutlet weak var environment: UILabel!
     @IBOutlet weak var logo: UIImageView!
     @IBOutlet weak var sessionIdLabel: UILabel!
     @IBOutlet weak var socketStateLabel: UILabel!
@@ -70,6 +71,7 @@ class ViewController: UIViewController {
         let longPressRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(self.handleLongPress))
         self.logo.addGestureRecognizer(longPressRecognizer)
         self.logo.isUserInteractionEnabled = true
+        self.updateEnvironment()
     }
     
     @objc func handleLongPress(gesture: UILongPressGestureRecognizer) {
@@ -83,12 +85,20 @@ class ViewController: UIViewController {
         let alert = UIAlertController(title: "Select WebRTC environment", message: "", preferredStyle: .actionSheet)
         alert.addAction(UIAlertAction(title: "Development", style: .default , handler:{ (UIAlertAction)in
             self.serverConfig = TxServerConfiguration(environment: .development)
+            self.updateEnvironment()
         }))
         
         alert.addAction(UIAlertAction(title: "Production", style: .default , handler:{ (UIAlertAction)in
             self.serverConfig = nil
+            self.updateEnvironment()
         }))
         self.present(alert, animated: true, completion: nil)
+    }
+
+    func updateEnvironment() {
+        DispatchQueue.main.async {
+            self.environment.text = (self.serverConfig?.environment == .development) ? "Development" : "Production"
+        }
     }
 
     func updateButtonsState() {

--- a/TelnyxWebRTCDemo/ViewController.swift
+++ b/TelnyxWebRTCDemo/ViewController.swift
@@ -71,6 +71,10 @@ class ViewController: UIViewController {
         let longPressRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(self.handleLongPress))
         self.logo.addGestureRecognizer(longPressRecognizer)
         self.logo.isUserInteractionEnabled = true
+
+        if self.userDefaults.getEnvironment() == .development {
+            self.serverConfig = TxServerConfiguration(environment: .development)
+        }
         self.updateEnvironment()
     }
     
@@ -85,11 +89,13 @@ class ViewController: UIViewController {
         let alert = UIAlertController(title: "Options", message: "", preferredStyle: .actionSheet)
         alert.addAction(UIAlertAction(title: "Development Environment", style: .default , handler:{ (UIAlertAction)in
             self.serverConfig = TxServerConfiguration(environment: .development)
+            self.userDefaults.saveEnvironment(environment: .development)
             self.updateEnvironment()
         }))
         
         alert.addAction(UIAlertAction(title: "Production Environment", style: .default , handler:{ (UIAlertAction)in
             self.serverConfig = nil
+            self.userDefaults.saveEnvironment(environment: .production)
             self.updateEnvironment()
         }))
 

--- a/TelnyxWebRTCDemo/ViewController.swift
+++ b/TelnyxWebRTCDemo/ViewController.swift
@@ -77,20 +77,26 @@ class ViewController: UIViewController {
     @objc func handleLongPress(gesture: UILongPressGestureRecognizer) {
         if gesture.state == UIGestureRecognizer.State.began {
             // Internal use only
-            self.showWebRTCEnvironmentSelector()
+            self.showHiddenOptions()
         }
     }
 
-    func showWebRTCEnvironmentSelector() {
-        let alert = UIAlertController(title: "Select WebRTC environment", message: "", preferredStyle: .actionSheet)
-        alert.addAction(UIAlertAction(title: "Development", style: .default , handler:{ (UIAlertAction)in
+    func showHiddenOptions() {
+        let alert = UIAlertController(title: "Options", message: "", preferredStyle: .actionSheet)
+        alert.addAction(UIAlertAction(title: "Development Environment", style: .default , handler:{ (UIAlertAction)in
             self.serverConfig = TxServerConfiguration(environment: .development)
             self.updateEnvironment()
         }))
         
-        alert.addAction(UIAlertAction(title: "Production", style: .default , handler:{ (UIAlertAction)in
+        alert.addAction(UIAlertAction(title: "Production Environment", style: .default , handler:{ (UIAlertAction)in
             self.serverConfig = nil
             self.updateEnvironment()
+        }))
+
+        alert.addAction(UIAlertAction(title: "Copy APNS token", style: .default , handler:{ (UIAlertAction)in
+            // To copy the APNS push token to pasteboard
+            let token = UserDefaults.init().getPushToken()
+            UIPasteboard.general.string = token
         }))
         self.present(alert, animated: true, completion: nil)
     }

--- a/TelnyxWebRTCDemo/ViewController.swift
+++ b/TelnyxWebRTCDemo/ViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 import CallKit
 import TelnyxRTC
 
+
 class ViewController: UIViewController {
 
     var userDefaults: UserDefaults = UserDefaults.init()
@@ -21,6 +22,7 @@ class ViewController: UIViewController {
     let callKitCallController = CXCallController()
     var loadingView: UIAlertController?
 
+    @IBOutlet weak var logo: UIImageView!
     @IBOutlet weak var sessionIdLabel: UILabel!
     @IBOutlet weak var socketStateLabel: UILabel!
     @IBOutlet weak var callView: UICallScreen!
@@ -28,6 +30,8 @@ class ViewController: UIViewController {
     @IBOutlet weak var incomingCallView: UIIncomingCallView!
     @IBOutlet weak var connectButton: UIButton!
     
+    var serverConfig: TxServerConfiguration?
+
     override func viewDidLoad() {
         super.viewDidLoad()
         print("ViewController:: viewDidLoad()")
@@ -61,6 +65,30 @@ class ViewController: UIViewController {
         self.settingsView.isHidden = false
         self.settingsView.sipUsernameLabel.text = userDefaults.getSipUser()
         self.settingsView.passwordUserNameLabel.text = userDefaults.getSipUserPassword()
+
+        // Environment Selector
+        let longPressRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(self.handleLongPress))
+        self.logo.addGestureRecognizer(longPressRecognizer)
+        self.logo.isUserInteractionEnabled = true
+    }
+    
+    @objc func handleLongPress(gesture: UILongPressGestureRecognizer) {
+        if gesture.state == UIGestureRecognizer.State.began {
+            // Internal use only
+            self.showWebRTCEnvironmentSelector()
+        }
+    }
+
+    func showWebRTCEnvironmentSelector() {
+        let alert = UIAlertController(title: "Select WebRTC environment", message: "", preferredStyle: .actionSheet)
+        alert.addAction(UIAlertAction(title: "Development", style: .default , handler:{ (UIAlertAction)in
+            self.serverConfig = TxServerConfiguration(environment: .development)
+        }))
+        
+        alert.addAction(UIAlertAction(title: "Production", style: .default , handler:{ (UIAlertAction)in
+            self.serverConfig = nil
+        }))
+        self.present(alert, animated: true, completion: nil)
     }
 
     func updateButtonsState() {
@@ -119,7 +147,7 @@ class ViewController: UIViewController {
             }
 
             do {
-                try telnyxClient.connect(txConfig: txConfig!)
+                try telnyxClient.connect(txConfig: txConfig!, serverConfiguration: self.serverConfig)
                 self.showLoadingView()
             } catch let error {
                 print("ViewController:: connect Error \(error)")

--- a/TelnyxWebRTCDemo/ViewController.swift
+++ b/TelnyxWebRTCDemo/ViewController.swift
@@ -163,7 +163,11 @@ class ViewController: UIViewController {
             }
 
             do {
-                try telnyxClient.connect(txConfig: txConfig!, serverConfiguration: self.serverConfig)
+                if let serverConfig = serverConfig {
+                    try telnyxClient.connect(txConfig: txConfig!, serverConfiguration: serverConfig)
+                } else {
+                    try telnyxClient.connect(txConfig: txConfig!)
+                }
                 self.showLoadingView()
             } catch let error {
                 print("ViewController:: connect Error \(error)")


### PR DESCRIPTION
<!-- Ticket details and link -->
[WEBRTC-666 - Add hidden option to use dev TE](https://telnyx.atlassian.net/browse/WEBRTC-666)
---
<!-- Describe your change here -->
- The `TxServerConfiguration` structure has been created to enable the developer to use their custom signaling server URL and custom TURN / STUN ICE servers when calling the `connect() `function of the TxClient.
- If the TxServerConfiguration is not specified when calling the `connect()` function, the default production Telnyx Servers will be used: Check `InternalConfig.swift` file.
- We can also pass the Telnyx environment thought the `TxServerConfiguration` (**production / development**). If no environment is specified, the production environment will be used as default.

- In the demo app a hidden menu has been implemented: To access to it, you must do a long press over the Telnyx logo. 
- Inside the hidden menu, we can select the WebRTC environment: Development / production. There's also an extra option to copy the APNS token into the pasteboard. 

**NOTES:** In order to use the development environment, you need to be connected to the VPN.

## :older_man: :baby: Behaviors
### Before changes
It was not possible to:
- configure custom TURN / STUN servers 
- select signaling server environments (prod/ dev). 
- Copy APNs token to pasteboard.

### After changes
It's now possible to:
- configure custom TURN / STUN servers 
- select signaling server environments (prod/dev).
- Open a hidden menu and select environments or copy the APNS token to the pasteboard. 

## TODO
- Add documentation showing how to configure custom signaling servers and TURN / STUN servers.

## ✋ Manual testing

**Test production environment:**
1. Connect your device to the VPN
2. Run the app
2. Do a long press over the Telnyx logo.
3. Select the **Production** environment.
4. Use a sip credential from the portal (production).
5. Press the connect button
6. Verify you are connected. 
7. Login on the web dialer with a different SIP credential (production url and SIP credentials)
8. Make calls between both SIP users.

**Test development environment:**
1. Connect your device to the VPN
2. Run the app
2. Do a long press over the Telnyx logo.
3. Select the **Development** environment.
4. Use a sip credential from portaldev.
5. Press the connect button
6. Verify you are connected. 
7. Login on the web dialer with a different SIP credential (development url and SIP credentials)
8. Make calls between both SIP users.

**Copy APNS token to pasteboard**
1. Run the app
2. Do a long press over the Telnyx logo.
3. Press the **Copy APNS token** option
4. You can paste the token on any device that is using your same apple ID.

## Screenshots
<img width="448" alt="Screen Shot 2021-08-18 at 16 13 51" src="https://user-images.githubusercontent.com/75636882/129958254-77005b8a-5044-4c76-83e1-f0575d77f2e8.png">
