### PR TITLE
WEBRTC-661 - Send app environment inside the Login message

### DIFF
--- a/TelnyxRTC/Telnyx/Verto/LoginMessage.swift
+++ b/TelnyxRTC/Telnyx/Verto/LoginMessage.swift
@@ -8,6 +8,11 @@
 
 import Foundation
 
+enum environments: String {
+    case production = "production"
+    case debug = "debug"
+}
+
 class LoginMessage : Message {
         
     //user and password login
@@ -32,9 +37,9 @@ class LoginMessage : Message {
         // This new field is required to allow our PN service to determine
         // if the push has to be send to APNS Sandbox (app is in debug mode) or production
         #if DEBUG
-        userVariables["environment"] = "debug"
+        userVariables["environment"] = environments.debug.rawValue
         #else
-        userVariables["environment"] = "production"
+        userVariables["environment"] = environments.production.rawValue
         #endif
 
         params["loginParams"] = [String: String]()

--- a/TelnyxRTC/Telnyx/Verto/LoginMessage.swift
+++ b/TelnyxRTC/Telnyx/Verto/LoginMessage.swift
@@ -37,9 +37,9 @@ class LoginMessage : Message {
         // This new field is required to allow our PN service to determine
         // if the push has to be send to APNS Sandbox (app is in debug mode) or production
         #if DEBUG
-        userVariables["environment"] = appMode.debug.rawValue
+        userVariables["push_notification_environment"] = appMode.debug.rawValue
         #else
-        userVariables["environment"] = appMode.production.rawValue
+        userVariables["push_notification_environment"] = appMode.production.rawValue
         #endif
 
         params["loginParams"] = [String: String]()

--- a/TelnyxRTC/Telnyx/Verto/LoginMessage.swift
+++ b/TelnyxRTC/Telnyx/Verto/LoginMessage.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-enum environments: String {
+enum appMode: String {
     case production = "production"
     case debug = "debug"
 }
@@ -37,9 +37,9 @@ class LoginMessage : Message {
         // This new field is required to allow our PN service to determine
         // if the push has to be send to APNS Sandbox (app is in debug mode) or production
         #if DEBUG
-        userVariables["environment"] = environments.debug.rawValue
+        userVariables["environment"] = appMode.debug.rawValue
         #else
-        userVariables["environment"] = environments.production.rawValue
+        userVariables["environment"] = appMode.production.rawValue
         #endif
 
         params["loginParams"] = [String: String]()

--- a/TelnyxRTC/Telnyx/Verto/LoginMessage.swift
+++ b/TelnyxRTC/Telnyx/Verto/LoginMessage.swift
@@ -28,6 +28,15 @@ class LoginMessage : Message {
             userVariables["push_notification_provider"] = provider
         }
 
+        // Add device environment debug/ production
+        // This new field is required to allow our PN service to determine
+        // if the push has to be send to APNS Sandbox (app is in debug mode) or production
+        #if DEBUG
+        userVariables["environment"] = "debug"
+        #else
+        userVariables["environment"] = "production"
+        #endif
+
         params["loginParams"] = [String: String]()
         params["userVariables"] = userVariables
         super.init(params, method: .LOGIN)

--- a/TelnyxRTCTests/Verto/VertoMessagesTests.swift
+++ b/TelnyxRTCTests/Verto/VertoMessagesTests.swift
@@ -70,7 +70,7 @@ class VertoMessagesTests: XCTestCase {
         let userVariables = loginWithUserAndPassoword.params?["userVariables"] as? [String: Any]
         let loginEncodedPushToken : String = userVariables?["push_device_token"] as! String
         let loginEncodedPushProvider : String = userVariables?["push_notification_provider"] as! String
-        let environment : String = userVariables?["environment"] as! String
+        let environment : String = userVariables?["push_notification_environment"] as! String
 
         XCTAssertEqual(loginUser, userName)
         XCTAssertEqual(loginPassword, password)
@@ -90,7 +90,7 @@ class VertoMessagesTests: XCTestCase {
         let userVariablesDecoded = decodeLogin?.params?["userVariables"] as? [String: Any]
         let decodedPushToken : String = userVariablesDecoded?["push_device_token"] as! String
         let decodedPushProvider : String = userVariablesDecoded?["push_notification_provider"] as! String
-        let decodedEnvironment : String = userVariablesDecoded?["environment"] as! String
+        let decodedEnvironment : String = userVariablesDecoded?["push_notification_environment"] as! String
 
         #if DEBUG
         XCTAssertEqual(decodedEnvironment, "debug")

--- a/TelnyxRTCTests/Verto/VertoMessagesTests.swift
+++ b/TelnyxRTCTests/Verto/VertoMessagesTests.swift
@@ -70,11 +70,17 @@ class VertoMessagesTests: XCTestCase {
         let userVariables = loginWithUserAndPassoword.params?["userVariables"] as? [String: Any]
         let loginEncodedPushToken : String = userVariables?["push_device_token"] as! String
         let loginEncodedPushProvider : String = userVariables?["push_notification_provider"] as! String
+        let environment : String = userVariables?["environment"] as! String
 
         XCTAssertEqual(loginUser, userName)
         XCTAssertEqual(loginPassword, password)
         XCTAssertEqual(loginEncodedPushToken, pushDeviceToken)
         XCTAssertEqual(loginEncodedPushProvider, pushNotificationProvider)
+        #if DEBUG
+        XCTAssertEqual(environment, "debug")
+        #else
+        XCTAssertEqual(environment, "production")
+        #endif
 
         let encodedLogin: String = loginWithUserAndPassoword.encode() ?? ""
         let decodeLogin = Message().decode(message: encodedLogin)
@@ -84,6 +90,13 @@ class VertoMessagesTests: XCTestCase {
         let userVariablesDecoded = decodeLogin?.params?["userVariables"] as? [String: Any]
         let decodedPushToken : String = userVariablesDecoded?["push_device_token"] as! String
         let decodedPushProvider : String = userVariablesDecoded?["push_notification_provider"] as! String
+        let decodedEnvironment : String = userVariablesDecoded?["environment"] as! String
+
+        #if DEBUG
+        XCTAssertEqual(decodedEnvironment, "debug")
+        #else
+        XCTAssertEqual(decodedEnvironment, "production")
+        #endif
 
         XCTAssertEqual(decodedUser, userName)
         XCTAssertEqual(decodedPassword, password)


### PR DESCRIPTION
<!-- Ticket details and link -->
[WEBRTC-661 - Send app push_notification_environment inside the Login message](https://telnyx.atlassian.net/browse/WEBRTC-661)
---
<!-- Describe your change here -->
On this PR we are adding the `push_notification_environment ` field to send the app mode. If the app is in debug mode or production (app is signed). 
This is required to our PNS to determine if the PN has to be sent to **APNS sandbox** (app in debug mode) or **production** (app signed).

- App in `debug` mode: `push_notification_environment ="debug"`
- App `singed`: `push_notification_environment ="production"`


## :older_man: :baby: Behaviors
### Before changes
- No `push_notification_environment ` field was sent in the login message

### After changes
- `push_notification_environment ` field send in the login message.

## ✋ Manual testing
1. Run the app in debug mode.
2. Login using SIP credentials.
3. Check the logs and verify that we are sending `push_notification_environment =debug`
