### PR TITLE
WEBRTC-710 -  Fix REGISTRATION issue from ld6/sy1 in Telnyx WebRTC SDK

### DIFF
--- a/TelnyxRTC/Telnyx/Models/TxConfig.swift
+++ b/TelnyxRTC/Telnyx/Models/TxConfig.swift
@@ -19,6 +19,7 @@ public struct TxConfig {
 
     public internal(set) var ringBackTone: String?
     public internal(set) var ringtone: String?
+    public internal(set) var autoReconnect: Bool
 
     // MARK: - Initializers
 
@@ -30,11 +31,14 @@ public struct TxConfig {
     ///   - ringtone: (Optional) The audio file name to be played when receiving an incoming call. e.g.: "my-ringtone.mp3"
     ///   - ringBackTone: (Optional) The audio file to be played when calling. e.g.: "my-ringbacktone.mp3"
     ///   - logLevel: (Optional) Can select the verbosity level of the SDK logs. Is set to `.none` as default
+    ///   - autoReconnect: (Optional) Determine if the SDK has to re-connect automatically when detecting a gateway connection failure. This is set to`true` as default
     public init(sipUser: String, password: String,
                 pushDeviceToken: String? = nil,
                 ringtone: String? = nil,
                 ringBackTone: String? = nil,
-                logLevel: LogLevel = .none) {
+                logLevel: LogLevel = .none,
+                autoReconnect: Bool = true) {
+        self.autoReconnect = autoReconnect
         self.sipUser = sipUser
         self.password = password
         if let pushToken = pushDeviceToken {
@@ -54,11 +58,14 @@ public struct TxConfig {
     ///   - ringBackTone: (Optional) The audio file name to be played when calling. e.g.: "my-ringbacktone.mp3"
     ///   - logLevel: (Optional) Can select the verbosity level of the SDK logs. Is set to `.none` as default
     ///   - serverConfiguration: (Optional) To define a custom `signaling server` and `TURN/ STUN servers`. As default we use the internal Telnyx Production servers.
+    ///   - autoReconnect: (Optional) Determine if the SDK has to re-connect automatically when detecting a gateway connection failure. This is set to`true` as default
     public init(token: String,
                 pushDeviceToken: String? = nil,
                 ringtone: String? = nil,
                 ringBackTone: String? = nil,
-                logLevel: LogLevel = .none) {
+                logLevel: LogLevel = .none,
+                autoReconnect: Bool = true) {
+        self.autoReconnect = true
         self.token = token
         if let pushToken = pushDeviceToken {
             //Create a notification configuration if there's an available a device push notification token

--- a/TelnyxRTC/Telnyx/Models/TxConfig.swift
+++ b/TelnyxRTC/Telnyx/Models/TxConfig.swift
@@ -30,14 +30,14 @@ public struct TxConfig {
     ///   - pushDeviceToken: (Optional) the device push notification token. This is required to receive Inbound calls notifications.
     ///   - ringtone: (Optional) The audio file name to be played when receiving an incoming call. e.g.: "my-ringtone.mp3"
     ///   - ringBackTone: (Optional) The audio file to be played when calling. e.g.: "my-ringbacktone.mp3"
-    ///   - logLevel: (Optional) Can select the verbosity level of the SDK logs. Is set to `.none` as default
     ///   - autoReconnect: (Optional) Determine if the SDK has to re-connect automatically when detecting a gateway connection failure. This is set to`true` as default
+    ///   - logLevel: (Optional) Can select the verbosity level of the SDK logs. Is set to `.none` as default
     public init(sipUser: String, password: String,
                 pushDeviceToken: String? = nil,
                 ringtone: String? = nil,
                 ringBackTone: String? = nil,
-                logLevel: LogLevel = .none,
-                autoReconnect: Bool = true) {
+                autoReconnect: Bool = true,
+                logLevel: LogLevel = .none) {
         self.autoReconnect = autoReconnect
         self.sipUser = sipUser
         self.password = password
@@ -57,14 +57,13 @@ public struct TxConfig {
     ///   - ringtone: (Optional) The audio file name to be played when receiving an incoming call. e.g.: "my-ringtone.mp3"
     ///   - ringBackTone: (Optional) The audio file name to be played when calling. e.g.: "my-ringbacktone.mp3"
     ///   - logLevel: (Optional) Can select the verbosity level of the SDK logs. Is set to `.none` as default
-    ///   - serverConfiguration: (Optional) To define a custom `signaling server` and `TURN/ STUN servers`. As default we use the internal Telnyx Production servers.
     ///   - autoReconnect: (Optional) Determine if the SDK has to re-connect automatically when detecting a gateway connection failure. This is set to`true` as default
     public init(token: String,
                 pushDeviceToken: String? = nil,
                 ringtone: String? = nil,
                 ringBackTone: String? = nil,
-                logLevel: LogLevel = .none,
-                autoReconnect: Bool = true) {
+                autoReconnect: Bool = true,
+                logLevel: LogLevel = .none) {
         self.autoReconnect = true
         self.token = token
         if let pushToken = pushDeviceToken {

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -297,8 +297,11 @@ public class TxClient {
         }
     }
     
+    /// Starts the timer to retry reconnecting.
     private func retryReconnectProcedure() {
         Logger.log.i(message: "TxClient:: retryReconnectProcedure()")
+        
+        // Validate if the autoReconnect property is true.
         if !(self.txConfig?.autoReconnect ?? false) {
             let notRegisteredError = TxError.serverError(reason: .gatewayNotRegistered)
             self.delegate?.onClientError(error: notRegisteredError)


### PR DESCRIPTION
[WebRTC-710 - Fix REGISTRATION issue from ld6/sy1 in Telnyx WebRTC SDK](https://telnyx.atlassian.net/browse/WEBRTC-710)
---

<!-- Describe your changed here -->
This PR implements a boolean value `autoReconnect` to our login methods that will automatically try reconnect and log into our socket connection up to 3 times if set to true in the instance of receiving a `FAIL_WAIT` or `FAILED` response from the gateway.

This is a temporary workaround to tackle the `480 SIP error` we are receiving as a result of invalid gateway registrations

**Extra changes on this PR:**
- The `onSocketDisconnected() callback`  was being called twice: When the `disconnect()` function is called and after the socket was successfully disconnected. To avoid this issue on this PR we are removing the callback from the `disconnect()` function, in order to send the event in the correct moment.
- On this PR we are keeping the logic for retry registering, and we are moving it inside the function `retryRegisterProcedure`


## :older_man: :baby: Behaviors
### Before changes
FAIL_WAIT message would simply return an error. Often customers would then try login again without reconnecting to the socket, which would cause issues. (480 SIP error).

### After changes
If `autoReconnect` is set to true, we will automatically disconnect and reconnect to the socket and attempt the login again in the instance of receiving a FAIL_WAIT gateway response.

## ✋ Manual testing
1. Attempt a login with an invalid username (forcing a `FAIL_WAIT` response)
2. See logs as connect -> login is attempted 3 times 
(will eventually fail because of invalid credentials. Customer scenario will eventually pass if credentials are valid, this is the only way we can test it because `FAIL_WAIT` happens with valid credentials very rarely but is still an issue)
