### PR TITLE
WEBRTC-715 - CI/CD Generate change-log and trigger Slack notification

### DIFF
--- a/.github/workflows/release_02_create_gh_release.yml
+++ b/.github/workflows/release_02_create_gh_release.yml
@@ -19,12 +19,43 @@ jobs:
       uses: actions/checkout@v2
       with:
         ref: ${{ github.event.pull_request.head.ref }}
-    - name: Select Xcode Version
+
+    - name: "🤖 Select Xcode Version"
       uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
 
-    - name: Create GH Release
+    - name: "🤖 Setup ruby"
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7.0
+        bundler-cache: true
+
+    - name: "🤖 Setup Fastlane"
+      run:  |
+          bundle install
+
+    - name: "✏️ Get last created TAG"
+      id: get-last-tag
+      run:  echo "::set-output name=LAST_TAG::$(git describe --tags $(git rev-list --tags --max-count=1))"
+
+
+    - name: "✏️  Generate changelog from last TAG"
+      id: get-changelog
+      run: |
+          bundle exec fastlane changelog tag:${{ steps.get-last-tag.outputs.LAST_TAG }}
+
+    - name: "✏️ Read changelog.txt"
+      id: changelog-file
+      uses: juliangruber/read-file-action@v1
+      with:
+        path: ./fastlane/changelog.txt
+
+    - name: "✏️ Print Changelog"
+      run: |
+          echo "${{ steps.changelog-file.outputs.content }}"
+
+    - name: "🚀 Create GH Release"
       id: release
       uses: zendesk/action-create-release@v1
       env:
@@ -33,7 +64,6 @@ jobs:
         tag_name: ${{ github.event.inputs.version }}
         release_name: Release ${{ github.event.inputs.version }}
         body: |
-          Auto generated release. 
-          Update code changes here.
+          ${{ steps.changelog-file.outputs.content }}
         draft: false
         prerelease: false

--- a/.github/workflows/release_03_deploy_cocoapods.yml
+++ b/.github/workflows/release_03_deploy_cocoapods.yml
@@ -11,12 +11,57 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Ryb Podspec lint
+      with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+
+    - name: "🤖 Setup ruby"
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7.0
+        bundler-cache: true
+
+    - name: "🤖 Setup Fastlane"
+      run:  |
+          bundle install
+
+    - name: "✏️ Get previous created TAG"
+      id: get-previous-tag
+      run:  echo "::set-output name=LAST_TAG::$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))"
+
+    - name: "✏️  Generate changelog from previous TAG and HEAD"
+      id: get-changelog
+      run: |
+          bundle exec fastlane changelog tag:${{ steps.get-previous-tag.outputs.LAST_TAG }}
+
+    - name: "✏️ Read changelog.txt"
+      id: changelog-file
+      uses: juliangruber/read-file-action@v1
+      with:
+        path: ./fastlane/changelog.txt
+
+    - name: "✏️ Print Changelog"
+      run: |
+          echo "${{ steps.changelog-file.outputs.content }}"
+
+    - name: "🤖 Podspec lint"
       run: |
         pod lib lint
-    - name: Publish to CocoaPod register
+
+    - name: "🚀  Publish to CocoaPods register"
       env:
         COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
       run: |
         pod trunk push TelnyxRTC.podspec
+    
+    - name: "✏️ Get Current TAG"
+      id: get-current-tag
+      run:  echo "::set-output name=CURRENT_TAG::$(git describe --tags $(git rev-list --tags --max-count=1))"
 
+    - name: "🎉  Send release to Slack"
+      uses: homeday-de/slack-release-bot-action@main
+      with:
+        webhook_url: ${{ secrets.SLACK_RELEASE_BOT_WEBHOOK_URL }}
+        title: "Telnyx iOS WebRTC SDK release v${{ steps.get-current-tag.outputs.CURRENT_TAG }}"
+        body: "${{ steps.changelog-file.outputs.content }}"
+        context: Telnyx iOS WebRTC SDK

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,3 +21,18 @@ lane :tests do
             devices: ["iPhone 8"],
             scheme: "TelnyxRTCSDK")
 end
+
+desc "Create a file with the Changelog output between a specific TAG and HEAD"
+lane :changelog do |options|
+changelog_from_git_commits(
+	between: [options[:tag],"HEAD"],
+  	pretty: "* %b [%aN]",# Optional, lets you provide a custom format to apply to each commit when generating the changelog text
+  	date_format: "short",# Optional, lets you provide an additional date format to dates within the pretty-formatted string
+  	match_lightweight_tag: false,  # Optional, lets you ignore lightweight (non-annotated) tags when searching for the last tag
+  	merge_commit_filtering: "only_include_merges" # Optional, lets you filter out merge commits
+)
+#store changelog in a external file
+changelog = lane_context[SharedValues::FL_CHANGELOG]
+File.open("changelog.txt", 'w') { |file| file.write("#{changelog}") }
+
+end


### PR DESCRIPTION
<!-- Ticket details and link -->
[WEBRTC-715 - CI/CD Generate change-log and trigger Slack notification](https://telnyx.atlassian.net/browse/WEBRTC-715)
---
<!-- Describe your change here -->
Release workflows updated:
- Change-log will be generated and added as a description when generating a new GitHub release.
- After a new SDK release is deployed to cocoapods a Slack notification will be triggered to an internal Slack channel.

## :older_man: :baby: Behaviors
### Before changes
- Change-log was not been generated.
- No Slack notifications.

### After changes
- Change log is generated
- Slack notification is triggered when a new release is sent to Cocoapods.

## TODO
Please mention pending items if any.

