### PR TITLE
fix: (WEBRTC-2104) Update call state to ACTIVE when remote answer the call

### DIFF
--- a/TelnyxRTC/Telnyx/WebRTC/Call.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call.swift
@@ -211,11 +211,13 @@ public class Call {
     private func answered(sdp: String) {
         let remoteDescription = RTCSessionDescription(type: .answer, sdp: sdp)
         self.peer?.connection.setRemoteDescription(remoteDescription, completionHandler: { (error) in
-            guard let error = error else {
+            if let error = error  {
+                Logger.log.e(message: "Call:: Error setting remote description: \(error)")
                 return
             }
             
-            Logger.log.e(message: "Call:: Error setting remote description: \(error)")
+            self.updateCallState(callState: .ACTIVE)
+            Logger.log.e(message: "Call:: connected")
         })
     }
 
@@ -238,6 +240,7 @@ public class Call {
     }
 
     private func updateCallState(callState: CallState) {
+        debugPrint("Call State: \(callState)")
         self.callState = callState
         self.delegate?.callStateUpdated(call: self)
     }

--- a/TelnyxRTC/Telnyx/WebRTC/Call.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call.swift
@@ -240,7 +240,7 @@ public class Call {
     }
 
     private func updateCallState(callState: CallState) {
-        debugPrint("Call State: \(callState)")
+        Logger.log.i(message: "Call state updated: \(callState)")
         self.callState = callState
         self.delegate?.callStateUpdated(call: self)
     }


### PR DESCRIPTION
[WEBRTC-2104 - Call state is not updated to ACTIVE when remote answers the call](https://telnyx.atlassian.net/browse/WEBRTC-2104)
---

## :older_man: :baby: Behaviors
### Before changes
- When the call is answered by the remote participant, the call state was not transitioning to ACTIVE.

### After changes
- Call state transitions to ACTIVE when the remote SDP is received (call was answered and connected)

## ✋ Manual testing
1. Run the demo app in debug mode
2. Login with `User A` sip credentials or token on the app
3. Login with `User B` on the web dialer: [https://webrtc.telnyx.com/](https://webrtc.telnyx.com/)
4. Call `User B` from the app.
5. Answer the call from the web dialer.

Filter the logs on the app side with the following text `Call state updated` and you should see the following output:
<img width="737" alt="Screen Shot 2022-08-16 at 14 58 41" src="https://user-images.githubusercontent.com/75636882/184959959-18b2fdf6-b1ca-4ef5-a1ce-1a2489cf6cbf.png">
