### PR TITLE
Add Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "TelnyxRTC",
+    platforms: [
+        .iOS(.v10)
+    ],
+    products: [
+        .library(
+            name: "TelnyxRTC",
+            targets: ["TelnyxRTC"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/bugsnag/bugsnag-cocoa.git", .upToNextMajor(from: "6.9.1")),
+        .package(url: "https://github.com/daltoniam/Starscream.git", .upToNextMajor(from: "4.0.4")),
+        .package(url: "https://github.com/alexpiezo/WebRTC.git", .upToNextMajor(from: "1.1.31567"))
+    ],
+    targets: [
+        .target(
+            name: "TelnyxRTC",
+            dependencies: [
+                .product(name: "Bugsnag", package: "bugsnag-cocoa"),
+                "Starscream",
+                "WebRTC"
+            ],
+            path: "TelnyxRTC"),
+        .testTarget(
+            name: "TelnyxRTCTests",
+            dependencies: [
+                "TelnyxRTC"
+            ],
+            path: "TelnyxRTCTests"
+        )
+    ]
+)


### PR DESCRIPTION
This PR adds support for **Swift Package Manager**.

## :older_man: :baby: Behaviors
### Before changes
- _Swift Package Manager_ was not supported.

### After changes
- _Swift Package Manager_ support was added

## Known Issues
- Apple Silicon is not supported because TelnyxRTC depend on an old version of WebRTC (1.1.31999)
- This PR use a third-party [WebRTC](https://github.com/alexpiezo/WebRTC.git) build rather than an in-home built one.
- CI won't trigger tests for SPM environment because it was not added to Fastlane manifest.
