### PR TITLE
Telapps 4386 spm package fix

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/daltoniam/Starscream.git",
       "state" : {
-        "revision" : "a063fda2b8145a231953c20e7a646be254365396",
-        "version" : "3.1.2"
+        "revision" : "df8d82047f6654d8e4b655d1b1525c64e1059d21",
+        "version" : "4.0.4"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stasel/WebRTC.git",
       "state" : {
-        "revision" : "8ce70d799bc637be04489376ebae7334061a1db0",
-        "version" : "94.0.0"
+        "revision" : "32526e6758a3c5827d871f5a931d20b9132bd1ea",
+        "version" : "113.0.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -8,12 +8,12 @@ let package = Package(
     products: [
         .library(
             name: "telnyx-webrtc-ios",
-            targets: ["TelnyxRTC", "TelnyxRTCTests"]),
+            targets: ["TelnyxRTC"]),
     ],
     dependencies: [
         .package(url: "https://github.com/bugsnag/bugsnag-cocoa.git", from: "6.26.2"),
-        .package(url: "https://github.com/daltoniam/Starscream.git", from: "3.1.1"),
-        .package(url: "https://github.com/stasel/WebRTC.git", from: "94.0.0")
+        .package(url: "https://github.com/daltoniam/Starscream.git", from: "4.0.0"),
+        .package(url: "https://github.com/stasel/WebRTC.git", from: "113.0.0")
     ],
     targets: [
         .target(
@@ -25,12 +25,7 @@ let package = Package(
             ],
             path: "TelnyxRTC",
             exclude: ["Info.plist"]
-        ),
-        .testTarget(
-            name: "TelnyxRTCTests",
-            dependencies: ["TelnyxRTC"],
-            path: "TelnyxRTCTests",
-            exclude: ["Info.plist"]),
+        )
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Xcode has a built-in support for Swift package manager. To add a package :
 
 1. Select Files > Add Packages
 2. On the Swift Package Manager Screen, Search for the https://github.com/team-telnyx/telnyx-webrtc-ios.git package.
-3. Select the ** main brach ** and click Add Package
+3. Select the **main brach** and click Add Package
 
 <p align="center">
 <img width="911" alt="Screen Shot 2021-05-07 at 17 48 17" src="https://github.com/isaacakakpo1/telnyx-webrtc-ios-smp/assets/134492608/39be0ab7-222f-478c-bba9-cb2813bcb81d">

--- a/README.md
+++ b/README.md
@@ -105,6 +105,25 @@ import TelnyxRTC
 8. You are all set!
 </br>
 
+### Swift Package Manager
+
+Xcode has a built-in support for Swift package manager. To add a package : 
+
+1. Select Files > Add Packages
+2. On the Swift Package Manager Screen, Search for the https://github.com/team-telnyx/telnyx-webrtc-ios.git package.
+3. Select the ** main brach ** and click Add Package
+
+<p align="center">
+<img width="911" alt="Screen Shot 2021-05-07 at 17 48 17" src="https://github.com/isaacakakpo1/telnyx-webrtc-ios-smp/assets/134492608/39be0ab7-222f-478c-bba9-cb2813bcb81d">
+</p>
+
+NB: if Add Package is stuck downloading try File > Packages > Reset Package Caches or Run the command
+`rm -rf ~/Library/Caches/org.swift.swiftpm/`  in terminal
+
+Read more in [Apple documentation](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app)
+
+**Hint: Use either Cocoapods or Swift Package Manager for Individual Packages to avoid Duplicate binaries**
+
 ## Usage
 
 ### Telnyx client setup
@@ -483,6 +502,8 @@ extension AppDelegate : CXProviderDelegate {
 }
 ```
 </br>
+
+
 
 ### Documentation:
 For more information you can:


### PR DESCRIPTION
<!-- Ticket details and link -->
[WEBRTC- Telapps 4386 ](https://telnyx.atlassian.net/browse/TELAPPS-4386)
---
<!-- Describe your change here -->
Version Bump for SPM Package 
- StarScream **3.1.1 - 4.1.1**
- WebRTC **94.0.0 - 113.0.0**

Read Me Update for SPM


## :older_man: :baby: Behaviors
### Before changes
- StarScream Package was not on the same version as the Cocoapods Version


### After changes
- SPM Works fine in Consuming Applications

## TODO
Please mention pending items if any.
- TestTarget was causing build issues in client app. (Will fix this on later releases)
- Using Tags for SPM results in **Could not resolve url exception** (Not Fixed Yet) Client Apps would need to pull form main Branch when using SPM



## ✋ Manual testing
1. Added TelnyxWebRTC using SPM to  https://github.com/team-telnyx/telnyx-webrtc-ios-examples.git. Works just as with cocoapods

CallKit Running using TelnyxWebRTC from SPM

## Screenshots
<p align="center">
<img width="153" align="center" alt="Screen Shot 2021-03-03 at 10 04 05" src="https://github.com/team-telnyx/telnyx-webrtc-ios/assets/134492608/c452c39c-f5ca-4534-aaa2-d6dd84e40389">
</p>

