### PR TITLE
Is/enhancement/attach calls - Release Candidate 0.1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,15 +404,29 @@ extension AppDelegate: PKPushRegistryDelegate {
             let callerName = (metadata["caller_name"] as? String) ?? ""
             let callerNumber = (metadata["caller_number"] as? String) ?? ""
             let caller = callerName.isEmpty ? (callerNumber.isEmpty ? "Unknown" : callerNumber) : callerName
+            
+            // Get rtc_ip and rct_port to setup TxPushServerConfig
+            let rtc_ip = (metadata["rtc_ip"] as? String) ?? ""
+            let rtc_port = (metadata["rtc_port"] as? Int) ?? 0
+            
+            //Use rtc_ip and rct_port for TxPushIPConfig
+            let pushIPConfig = TxPushIPConfig(rtc_ip: rtc_ip, rtc_port: rtc_port)
+            
             let uuid = UUID(uuidString: callId)
             
             // Re-connect the client and process the push notification when is received.
-            // You will need tu use the credentials of the same user that is receiving the call. 
+            // You will need to use the credentials of the same user that is receiving the call. 
             let txConfig = TxConfig(sipUser: sipUser,
                                 password: password,
                                 pushDeviceToken: "APNS_PUSH_TOKEN")
-                             
-            try? telnyxClient?.processVoIPNotification(txConfig: txConfig)
+                                
+                        
+            //Declare TxServerConfiguration with the pushIPConfig param
+            let serverConfig = TxServerConfiguration(pushIPConfig: pushIPConfig)
+        
+            try telnyxClient?.processVoIPNotification(txConfig: txConfig, serverConfiguration: serverConfig)
+
+            
 
             
             // Report the incoming call to CallKit framework.
@@ -455,6 +469,7 @@ For more information about Pushkit you can check the official [Apple docs](https
 
 __*Important*__:
 - You will need to login at least once to send your device token to Telnyx before start getting Push notifications. 
+- You will need to provide `TxPushIPConfig(rtc_ip: .., rtc_port: ..)` to `TxServerConfiguration(pushIPConfig:..)` to get Push calls to work. 
 - You will need to implement 'CallKit' to report an incoming call when there’s a VoIP push notification. On iOS 13.0 and later, if you fail to report a call to CallKit, the system will terminate your app. More information on [Apple docs](https://developer.apple.com/documentation/pushkit/pkpushregistrydelegate/2875784-pushregistry) 
 
 

--- a/TelnyxRTC.xcodeproj/project.pbxproj
+++ b/TelnyxRTC.xcodeproj/project.pbxproj
@@ -7,11 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		3B1BE6F72AA9A467000B7962 /* TxPushServerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1BE6F62AA9A467000B7962 /* TxPushServerConfig.swift */; };
+		066A5442E76DEE412FC61072 /* Pods_TelnyxWebRTCDemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5467FDE196C1DA5575C9587 /* Pods_TelnyxWebRTCDemo.framework */; };
+		292CD7D99FE94568B04E06AE /* Pods_TelnyxRTC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A3E658CF2E8931FF2A49145 /* Pods_TelnyxRTC.framework */; };
+		3B1BE6F72AA9A467000B7962 /* TxPushIPConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1BE6F62AA9A467000B7962 /* TxPushIPConfig.swift */; };
 		3B49B7152AA9B0A20026D36D /* AttachCallMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B49B7142AA9B0A20026D36D /* AttachCallMessage.swift */; };
 		3B72695D2A9396BF00D2A602 /* DisablePushMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B72695C2A9396BF00D2A602 /* DisablePushMessage.swift */; };
-		5344D3BC45B3F58E0EA04655 /* Pods_TelnyxRTC_TelnyxRTCTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F7BD9AFB0171FC02B1C9D32B /* Pods_TelnyxRTC_TelnyxRTCTests.framework */; };
-		A5B04B04B8EB128EE54576F1 /* Pods_TelnyxRTC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 515285571CF0656848F7F0BB /* Pods_TelnyxRTC.framework */; };
+		5B012B1D0A856512A1782221 /* Pods_TelnyxRTC_TelnyxRTCTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0AAEC3D1649055A057D6179E /* Pods_TelnyxRTC_TelnyxRTCTests.framework */; };
 		B309D13D25EF119E00A2AADF /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B309D11125EF107F00A2AADF /* Starscream.framework */; };
 		B309D1D625F020B300A2AADF /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D1D525F020B300A2AADF /* Message.swift */; };
 		B309D1DB25F020D400A2AADF /* Method.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D1DA25F020D400A2AADF /* Method.swift */; };
@@ -26,8 +27,8 @@
 		B309D24025F06EA600A2AADF /* InviteMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D23F25F06EA600A2AADF /* InviteMessage.swift */; };
 		B309D24E25F0717B00A2AADF /* UICallScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = B309D24D25F0717B00A2AADF /* UICallScreen.xib */; };
 		B309D25325F071DD00A2AADF /* UICallScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D25225F071DD00A2AADF /* UICallScreen.swift */; };
-		B309D26225F1574C00A2AADF /* (null) in Frameworks */ = {isa = PBXBuildFile; };
-		B309D26325F1574C00A2AADF /* (null) in Embed Frameworks */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		B309D26225F1574C00A2AADF /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
+		B309D26325F1574C00A2AADF /* BuildFile in Embed Frameworks */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B309D27B25F17C1700A2AADF /* UIIncomingCallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D27925F17C1700A2AADF /* UIIncomingCallView.swift */; };
 		B309D27C25F17C1700A2AADF /* UIIncomingCallView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B309D27A25F17C1700A2AADF /* UIIncomingCallView.xib */; };
 		B309D28225F1838700A2AADF /* ByeMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D28125F1838700A2AADF /* ByeMessage.swift */; };
@@ -69,7 +70,6 @@
 		B3E1029A25F2C16500227DCE /* ModifyMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E1029925F2C16500227DCE /* ModifyMessage.swift */; };
 		B3E1033225F7F94900227DCE /* incoming_call.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = B3E1033025F7F94900227DCE /* incoming_call.mp3 */; };
 		B3E1033325F7F94900227DCE /* ringback_tone.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = B3E1033125F7F94900227DCE /* ringback_tone.mp3 */; };
-		DC037D970E3C7C15501F1ECF /* Pods_TelnyxWebRTCDemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 56BFABD786323F03A70F6C97 /* Pods_TelnyxWebRTCDemo.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -89,7 +89,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				B309D26325F1574C00A2AADF /* (null) in Embed Frameworks */,
+				B309D26325F1574C00A2AADF /* BuildFile in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -97,15 +97,15 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		3B1BE6F62AA9A467000B7962 /* TxPushServerConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxPushServerConfig.swift; sourceTree = "<group>"; };
+		0AAEC3D1649055A057D6179E /* Pods_TelnyxRTC_TelnyxRTCTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxRTC_TelnyxRTCTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		14099467D50ED0F462033118 /* Pods-TelnyxWebRTCDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxWebRTCDemo.debug.xcconfig"; path = "Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo.debug.xcconfig"; sourceTree = "<group>"; };
+		296891F2069B88A18B27B508 /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig"; sourceTree = "<group>"; };
+		36EB11467A9949D7EFC705D9 /* Pods-TelnyxWebRTCDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxWebRTCDemo.release.xcconfig"; path = "Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo.release.xcconfig"; sourceTree = "<group>"; };
+		3B1BE6F62AA9A467000B7962 /* TxPushIPConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxPushIPConfig.swift; sourceTree = "<group>"; };
 		3B49B7142AA9B0A20026D36D /* AttachCallMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachCallMessage.swift; sourceTree = "<group>"; };
 		3B72695C2A9396BF00D2A602 /* DisablePushMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisablePushMessage.swift; sourceTree = "<group>"; };
-		515285571CF0656848F7F0BB /* Pods_TelnyxRTC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxRTC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		56BFABD786323F03A70F6C97 /* Pods_TelnyxWebRTCDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxWebRTCDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		5C16E48FCC265B55D546444A /* Pods-TelnyxRTC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC.debug.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC/Pods-TelnyxRTC.debug.xcconfig"; sourceTree = "<group>"; };
-		7A5E4038778AD18438417FD9 /* Pods-TelnyxWebRTCDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxWebRTCDemo.release.xcconfig"; path = "Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo.release.xcconfig"; sourceTree = "<group>"; };
-		8AE5F966C445938F4224CA6A /* Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig"; sourceTree = "<group>"; };
-		8DE9E2ED3C21DDB7522D96C4 /* Pods-TelnyxWebRTCDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxWebRTCDemo.debug.xcconfig"; path = "Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo.debug.xcconfig"; sourceTree = "<group>"; };
+		4A3E658CF2E8931FF2A49145 /* Pods_TelnyxRTC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxRTC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6235DDFD84627AF8025C7A79 /* Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig"; sourceTree = "<group>"; };
 		B309D11125EF107F00A2AADF /* Starscream.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Starscream.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B309D1D525F020B300A2AADF /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		B309D1DA25F020D400A2AADF /* Method.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Method.swift; sourceTree = "<group>"; };
@@ -167,9 +167,9 @@
 		B3E1029925F2C16500227DCE /* ModifyMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyMessage.swift; sourceTree = "<group>"; };
 		B3E1033025F7F94900227DCE /* incoming_call.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = incoming_call.mp3; sourceTree = "<group>"; };
 		B3E1033125F7F94900227DCE /* ringback_tone.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = ringback_tone.mp3; sourceTree = "<group>"; };
-		B71613CF413A8BEDF1CE19AC /* Pods-TelnyxRTC.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC.release.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC/Pods-TelnyxRTC.release.xcconfig"; sourceTree = "<group>"; };
-		D0E7429E889D9B84F5E9A561 /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig"; sourceTree = "<group>"; };
-		F7BD9AFB0171FC02B1C9D32B /* Pods_TelnyxRTC_TelnyxRTCTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxRTC_TelnyxRTCTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C80C2C5CE0F9BD82821214D0 /* Pods-TelnyxRTC.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC.release.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC/Pods-TelnyxRTC.release.xcconfig"; sourceTree = "<group>"; };
+		D46045D14C6B4621B4B7F20B /* Pods-TelnyxRTC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC.debug.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC/Pods-TelnyxRTC.debug.xcconfig"; sourceTree = "<group>"; };
+		D5467FDE196C1DA5575C9587 /* Pods_TelnyxWebRTCDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxWebRTCDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -178,8 +178,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				B309D13D25EF119E00A2AADF /* Starscream.framework in Frameworks */,
-				B309D26225F1574C00A2AADF /* (null) in Frameworks */,
-				A5B04B04B8EB128EE54576F1 /* Pods_TelnyxRTC.framework in Frameworks */,
+				B309D26225F1574C00A2AADF /* BuildFile in Frameworks */,
+				292CD7D99FE94568B04E06AE /* Pods_TelnyxRTC.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -188,7 +188,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B368BED625EDDBC90032AE52 /* TelnyxRTC.framework in Frameworks */,
-				5344D3BC45B3F58E0EA04655 /* Pods_TelnyxRTC_TelnyxRTCTests.framework in Frameworks */,
+				5B012B1D0A856512A1782221 /* Pods_TelnyxRTC_TelnyxRTCTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -196,7 +196,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DC037D970E3C7C15501F1ECF /* Pods_TelnyxWebRTCDemo.framework in Frameworks */,
+				066A5442E76DEE412FC61072 /* Pods_TelnyxWebRTCDemo.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -206,12 +206,12 @@
 		8AB3A6A2ADA6A9FAC6C77491 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				5C16E48FCC265B55D546444A /* Pods-TelnyxRTC.debug.xcconfig */,
-				B71613CF413A8BEDF1CE19AC /* Pods-TelnyxRTC.release.xcconfig */,
-				D0E7429E889D9B84F5E9A561 /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */,
-				8AE5F966C445938F4224CA6A /* Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig */,
-				8DE9E2ED3C21DDB7522D96C4 /* Pods-TelnyxWebRTCDemo.debug.xcconfig */,
-				7A5E4038778AD18438417FD9 /* Pods-TelnyxWebRTCDemo.release.xcconfig */,
+				D46045D14C6B4621B4B7F20B /* Pods-TelnyxRTC.debug.xcconfig */,
+				C80C2C5CE0F9BD82821214D0 /* Pods-TelnyxRTC.release.xcconfig */,
+				296891F2069B88A18B27B508 /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */,
+				6235DDFD84627AF8025C7A79 /* Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig */,
+				14099467D50ED0F462033118 /* Pods-TelnyxWebRTCDemo.debug.xcconfig */,
+				36EB11467A9949D7EFC705D9 /* Pods-TelnyxWebRTCDemo.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -229,7 +229,6 @@
 				B3E0B0652656ED73005E7431 /* InfoMessage.swift */,
 				B3BB8F9F26BC076000DDCB84 /* GatewayMessage.swift */,
 				3B72695C2A9396BF00D2A602 /* DisablePushMessage.swift */,
-				3B1BE6F62AA9A467000B7962 /* TxPushServerConfig.swift */,
 				3B49B7142AA9B0A20026D36D /* AttachCallMessage.swift */,
 			);
 			path = Verto;
@@ -238,6 +237,7 @@
 		B309D1E225F023F400A2AADF /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				3B1BE6F62AA9A467000B7962 /* TxPushIPConfig.swift */,
 				B309D1E325F0240200A2AADF /* TxConfig.swift */,
 				B309D23525F06D2100A2AADF /* TxCallInfo.swift */,
 				B309D23A25F06DC000A2AADF /* TxCallOptions.swift */,
@@ -427,9 +427,9 @@
 			isa = PBXGroup;
 			children = (
 				B309D11125EF107F00A2AADF /* Starscream.framework */,
-				515285571CF0656848F7F0BB /* Pods_TelnyxRTC.framework */,
-				F7BD9AFB0171FC02B1C9D32B /* Pods_TelnyxRTC_TelnyxRTCTests.framework */,
-				56BFABD786323F03A70F6C97 /* Pods_TelnyxWebRTCDemo.framework */,
+				4A3E658CF2E8931FF2A49145 /* Pods_TelnyxRTC.framework */,
+				0AAEC3D1649055A057D6179E /* Pods_TelnyxRTC_TelnyxRTCTests.framework */,
+				D5467FDE196C1DA5575C9587 /* Pods_TelnyxWebRTCDemo.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -452,7 +452,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = B368BEC825EDDB610032AE52 /* Build configuration list for PBXNativeTarget "TelnyxRTC" */;
 			buildPhases = (
-				37B18E93EA7D0090D207079D /* [CP] Check Pods Manifest.lock */,
+				BFE828EDE06733E1EB3BBBF2 /* [CP] Check Pods Manifest.lock */,
 				B368BEBB25EDDB610032AE52 /* Headers */,
 				B368BEBC25EDDB610032AE52 /* Sources */,
 				B368BEBD25EDDB610032AE52 /* Frameworks */,
@@ -472,11 +472,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = B368BEDB25EDDBC90032AE52 /* Build configuration list for PBXNativeTarget "TelnyxRTCTests" */;
 			buildPhases = (
-				968B614DCDCF9DA1458EC1B2 /* [CP] Check Pods Manifest.lock */,
+				230E948AC2282B7D08B292EE /* [CP] Check Pods Manifest.lock */,
 				B368BECD25EDDBC90032AE52 /* Sources */,
 				B368BECE25EDDBC90032AE52 /* Frameworks */,
 				B368BECF25EDDBC90032AE52 /* Resources */,
-				B32DBA092F364D1AD3B40390 /* [CP] Embed Pods Frameworks */,
+				00B7701BE812FCB4B0E133C8 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -492,11 +492,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = B368BEF925EDDD070032AE52 /* Build configuration list for PBXNativeTarget "TelnyxWebRTCDemo" */;
 			buildPhases = (
-				E82A024E9DE7041044DCB1BB /* [CP] Check Pods Manifest.lock */,
+				CBE1AD5CD5B02BBBFCBA2AF0 /* [CP] Check Pods Manifest.lock */,
 				B368BEE425EDDD060032AE52 /* Sources */,
 				B368BEE525EDDD060032AE52 /* Frameworks */,
 				B368BEE625EDDD060032AE52 /* Resources */,
-				0D64131DC048CB58CE40CC20 /* [CP] Embed Pods Frameworks */,
+				136CAF2B439F6EED55621269 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -582,7 +582,24 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0D64131DC048CB58CE40CC20 /* [CP] Embed Pods Frameworks */ = {
+		00B7701BE812FCB4B0E133C8 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		136CAF2B439F6EED55621269 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -599,29 +616,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		37B18E93EA7D0090D207079D /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-TelnyxRTC-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		968B614DCDCF9DA1458EC1B2 /* [CP] Check Pods Manifest.lock */ = {
+		230E948AC2282B7D08B292EE /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -643,24 +638,29 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		B32DBA092F364D1AD3B40390 /* [CP] Embed Pods Frameworks */ = {
+		BFE828EDE06733E1EB3BBBF2 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			name = "[CP] Embed Pods Frameworks";
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-TelnyxRTC-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests-frameworks.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E82A024E9DE7041044DCB1BB /* [CP] Check Pods Manifest.lock */ = {
+		CBE1AD5CD5B02BBBFCBA2AF0 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -698,7 +698,7 @@
 				B32AE8B326CD4F9200C7C6F4 /* TxServerConfiguration.swift in Sources */,
 				B368BEE125EDDC7D0032AE52 /* TxClient.swift in Sources */,
 				B309D28625F184A100A2AADF /* AnswerMessage.swift in Sources */,
-				3B1BE6F72AA9A467000B7962 /* TxPushServerConfig.swift in Sources */,
+				3B1BE6F72AA9A467000B7962 /* TxPushIPConfig.swift in Sources */,
 				B309D23125F06CA800A2AADF /* Peer.swift in Sources */,
 				B309D1E425F0240200A2AADF /* TxConfig.swift in Sources */,
 				B3AF248025EE7B1F0062EDA9 /* TxClientDelegate.swift in Sources */,
@@ -906,7 +906,7 @@
 		};
 		B368BEC925EDDB610032AE52 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5C16E48FCC265B55D546444A /* Pods-TelnyxRTC.debug.xcconfig */;
+			baseConfigurationReference = D46045D14C6B4621B4B7F20B /* Pods-TelnyxRTC.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -942,7 +942,7 @@
 		};
 		B368BECA25EDDB610032AE52 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B71613CF413A8BEDF1CE19AC /* Pods-TelnyxRTC.release.xcconfig */;
+			baseConfigurationReference = C80C2C5CE0F9BD82821214D0 /* Pods-TelnyxRTC.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -974,7 +974,7 @@
 		};
 		B368BED925EDDBC90032AE52 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D0E7429E889D9B84F5E9A561 /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */;
+			baseConfigurationReference = 296891F2069B88A18B27B508 /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CODE_SIGN_STYLE = Automatic;
@@ -993,7 +993,7 @@
 		};
 		B368BEDA25EDDBC90032AE52 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8AE5F966C445938F4224CA6A /* Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig */;
+			baseConfigurationReference = 6235DDFD84627AF8025C7A79 /* Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CODE_SIGN_STYLE = Automatic;
@@ -1012,7 +1012,7 @@
 		};
 		B368BEFA25EDDD070032AE52 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8DE9E2ED3C21DDB7522D96C4 /* Pods-TelnyxWebRTCDemo.debug.xcconfig */;
+			baseConfigurationReference = 14099467D50ED0F462033118 /* Pods-TelnyxWebRTCDemo.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -1036,7 +1036,7 @@
 		};
 		B368BEFB25EDDD070032AE52 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7A5E4038778AD18438417FD9 /* Pods-TelnyxWebRTCDemo.release.xcconfig */;
+			baseConfigurationReference = 36EB11467A9949D7EFC705D9 /* Pods-TelnyxWebRTCDemo.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/TelnyxRTC.xcodeproj/project.pbxproj
+++ b/TelnyxRTC.xcodeproj/project.pbxproj
@@ -7,10 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1A6B53CF37B49CBD976E24B4 /* Pods_TelnyxRTC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61705FF06D84BC459B1A73C1 /* Pods_TelnyxRTC.framework */; };
+		3B1BE6F72AA9A467000B7962 /* TxPushServerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1BE6F62AA9A467000B7962 /* TxPushServerConfig.swift */; };
 		3B72695D2A9396BF00D2A602 /* DisablePushMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B72695C2A9396BF00D2A602 /* DisablePushMessage.swift */; };
-		60B87A3C6FEFD46180875FDF /* Pods_TelnyxWebRTCDemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F4E69824E7EBA4C85ED904E8 /* Pods_TelnyxWebRTCDemo.framework */; };
-		870556F0BFCBF5DAA2A2184F /* Pods_TelnyxRTC_TelnyxRTCTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84A13D10894BC43B2EEB90C7 /* Pods_TelnyxRTC_TelnyxRTCTests.framework */; };
+		5344D3BC45B3F58E0EA04655 /* Pods_TelnyxRTC_TelnyxRTCTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F7BD9AFB0171FC02B1C9D32B /* Pods_TelnyxRTC_TelnyxRTCTests.framework */; };
+		A5B04B04B8EB128EE54576F1 /* Pods_TelnyxRTC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 515285571CF0656848F7F0BB /* Pods_TelnyxRTC.framework */; };
 		B309D13D25EF119E00A2AADF /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B309D11125EF107F00A2AADF /* Starscream.framework */; };
 		B309D1D625F020B300A2AADF /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D1D525F020B300A2AADF /* Message.swift */; };
 		B309D1DB25F020D400A2AADF /* Method.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D1DA25F020D400A2AADF /* Method.swift */; };
@@ -25,8 +25,8 @@
 		B309D24025F06EA600A2AADF /* InviteMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D23F25F06EA600A2AADF /* InviteMessage.swift */; };
 		B309D24E25F0717B00A2AADF /* UICallScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = B309D24D25F0717B00A2AADF /* UICallScreen.xib */; };
 		B309D25325F071DD00A2AADF /* UICallScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D25225F071DD00A2AADF /* UICallScreen.swift */; };
-		B309D26225F1574C00A2AADF /* (null) in Frameworks */ = {isa = PBXBuildFile; };
-		B309D26325F1574C00A2AADF /* (null) in Embed Frameworks */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		B309D26225F1574C00A2AADF /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
+		B309D26325F1574C00A2AADF /* BuildFile in Embed Frameworks */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B309D27B25F17C1700A2AADF /* UIIncomingCallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D27925F17C1700A2AADF /* UIIncomingCallView.swift */; };
 		B309D27C25F17C1700A2AADF /* UIIncomingCallView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B309D27A25F17C1700A2AADF /* UIIncomingCallView.xib */; };
 		B309D28225F1838700A2AADF /* ByeMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D28125F1838700A2AADF /* ByeMessage.swift */; };
@@ -68,6 +68,7 @@
 		B3E1029A25F2C16500227DCE /* ModifyMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E1029925F2C16500227DCE /* ModifyMessage.swift */; };
 		B3E1033225F7F94900227DCE /* incoming_call.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = B3E1033025F7F94900227DCE /* incoming_call.mp3 */; };
 		B3E1033325F7F94900227DCE /* ringback_tone.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = B3E1033125F7F94900227DCE /* ringback_tone.mp3 */; };
+		DC037D970E3C7C15501F1ECF /* Pods_TelnyxWebRTCDemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 56BFABD786323F03A70F6C97 /* Pods_TelnyxWebRTCDemo.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -87,7 +88,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				B309D26325F1574C00A2AADF /* (null) in Embed Frameworks */,
+				B309D26325F1574C00A2AADF /* BuildFile in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -95,14 +96,14 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		0FEA558BEFB58901E8E79A73 /* Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig"; sourceTree = "<group>"; };
-		19D83E5D9EC7293621E7C15B /* Pods-TelnyxRTC.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC.release.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC/Pods-TelnyxRTC.release.xcconfig"; sourceTree = "<group>"; };
-		2A8EB4E91B886E3D6975A654 /* Pods-TelnyxWebRTCDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxWebRTCDemo.release.xcconfig"; path = "Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo.release.xcconfig"; sourceTree = "<group>"; };
+		3B1BE6F62AA9A467000B7962 /* TxPushServerConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxPushServerConfig.swift; sourceTree = "<group>"; };
 		3B72695C2A9396BF00D2A602 /* DisablePushMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisablePushMessage.swift; sourceTree = "<group>"; };
-		61705FF06D84BC459B1A73C1 /* Pods_TelnyxRTC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxRTC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		6710D78B923409C254BBC2C9 /* Pods-TelnyxWebRTCDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxWebRTCDemo.debug.xcconfig"; path = "Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo.debug.xcconfig"; sourceTree = "<group>"; };
-		84A13D10894BC43B2EEB90C7 /* Pods_TelnyxRTC_TelnyxRTCTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxRTC_TelnyxRTCTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		88B7BA1B960143560EBFB0E1 /* Pods-TelnyxRTC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC.debug.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC/Pods-TelnyxRTC.debug.xcconfig"; sourceTree = "<group>"; };
+		515285571CF0656848F7F0BB /* Pods_TelnyxRTC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxRTC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		56BFABD786323F03A70F6C97 /* Pods_TelnyxWebRTCDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxWebRTCDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5C16E48FCC265B55D546444A /* Pods-TelnyxRTC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC.debug.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC/Pods-TelnyxRTC.debug.xcconfig"; sourceTree = "<group>"; };
+		7A5E4038778AD18438417FD9 /* Pods-TelnyxWebRTCDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxWebRTCDemo.release.xcconfig"; path = "Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo.release.xcconfig"; sourceTree = "<group>"; };
+		8AE5F966C445938F4224CA6A /* Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig"; sourceTree = "<group>"; };
+		8DE9E2ED3C21DDB7522D96C4 /* Pods-TelnyxWebRTCDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxWebRTCDemo.debug.xcconfig"; path = "Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo.debug.xcconfig"; sourceTree = "<group>"; };
 		B309D11125EF107F00A2AADF /* Starscream.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Starscream.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B309D1D525F020B300A2AADF /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		B309D1DA25F020D400A2AADF /* Method.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Method.swift; sourceTree = "<group>"; };
@@ -164,8 +165,9 @@
 		B3E1029925F2C16500227DCE /* ModifyMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyMessage.swift; sourceTree = "<group>"; };
 		B3E1033025F7F94900227DCE /* incoming_call.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = incoming_call.mp3; sourceTree = "<group>"; };
 		B3E1033125F7F94900227DCE /* ringback_tone.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = ringback_tone.mp3; sourceTree = "<group>"; };
-		C4A8FC81E448AC9A8DACFFC5 /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig"; sourceTree = "<group>"; };
-		F4E69824E7EBA4C85ED904E8 /* Pods_TelnyxWebRTCDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxWebRTCDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B71613CF413A8BEDF1CE19AC /* Pods-TelnyxRTC.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC.release.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC/Pods-TelnyxRTC.release.xcconfig"; sourceTree = "<group>"; };
+		D0E7429E889D9B84F5E9A561 /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig"; sourceTree = "<group>"; };
+		F7BD9AFB0171FC02B1C9D32B /* Pods_TelnyxRTC_TelnyxRTCTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxRTC_TelnyxRTCTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -174,8 +176,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				B309D13D25EF119E00A2AADF /* Starscream.framework in Frameworks */,
-				B309D26225F1574C00A2AADF /* (null) in Frameworks */,
-				1A6B53CF37B49CBD976E24B4 /* Pods_TelnyxRTC.framework in Frameworks */,
+				B309D26225F1574C00A2AADF /* BuildFile in Frameworks */,
+				A5B04B04B8EB128EE54576F1 /* Pods_TelnyxRTC.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -184,7 +186,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B368BED625EDDBC90032AE52 /* TelnyxRTC.framework in Frameworks */,
-				870556F0BFCBF5DAA2A2184F /* Pods_TelnyxRTC_TelnyxRTCTests.framework in Frameworks */,
+				5344D3BC45B3F58E0EA04655 /* Pods_TelnyxRTC_TelnyxRTCTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -192,7 +194,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				60B87A3C6FEFD46180875FDF /* Pods_TelnyxWebRTCDemo.framework in Frameworks */,
+				DC037D970E3C7C15501F1ECF /* Pods_TelnyxWebRTCDemo.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -202,12 +204,12 @@
 		8AB3A6A2ADA6A9FAC6C77491 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				88B7BA1B960143560EBFB0E1 /* Pods-TelnyxRTC.debug.xcconfig */,
-				19D83E5D9EC7293621E7C15B /* Pods-TelnyxRTC.release.xcconfig */,
-				C4A8FC81E448AC9A8DACFFC5 /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */,
-				0FEA558BEFB58901E8E79A73 /* Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig */,
-				6710D78B923409C254BBC2C9 /* Pods-TelnyxWebRTCDemo.debug.xcconfig */,
-				2A8EB4E91B886E3D6975A654 /* Pods-TelnyxWebRTCDemo.release.xcconfig */,
+				5C16E48FCC265B55D546444A /* Pods-TelnyxRTC.debug.xcconfig */,
+				B71613CF413A8BEDF1CE19AC /* Pods-TelnyxRTC.release.xcconfig */,
+				D0E7429E889D9B84F5E9A561 /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */,
+				8AE5F966C445938F4224CA6A /* Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig */,
+				8DE9E2ED3C21DDB7522D96C4 /* Pods-TelnyxWebRTCDemo.debug.xcconfig */,
+				7A5E4038778AD18438417FD9 /* Pods-TelnyxWebRTCDemo.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -225,6 +227,7 @@
 				B3E0B0652656ED73005E7431 /* InfoMessage.swift */,
 				B3BB8F9F26BC076000DDCB84 /* GatewayMessage.swift */,
 				3B72695C2A9396BF00D2A602 /* DisablePushMessage.swift */,
+				3B1BE6F62AA9A467000B7962 /* TxPushServerConfig.swift */,
 			);
 			path = Verto;
 			sourceTree = "<group>";
@@ -421,9 +424,9 @@
 			isa = PBXGroup;
 			children = (
 				B309D11125EF107F00A2AADF /* Starscream.framework */,
-				61705FF06D84BC459B1A73C1 /* Pods_TelnyxRTC.framework */,
-				84A13D10894BC43B2EEB90C7 /* Pods_TelnyxRTC_TelnyxRTCTests.framework */,
-				F4E69824E7EBA4C85ED904E8 /* Pods_TelnyxWebRTCDemo.framework */,
+				515285571CF0656848F7F0BB /* Pods_TelnyxRTC.framework */,
+				F7BD9AFB0171FC02B1C9D32B /* Pods_TelnyxRTC_TelnyxRTCTests.framework */,
+				56BFABD786323F03A70F6C97 /* Pods_TelnyxWebRTCDemo.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -446,7 +449,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = B368BEC825EDDB610032AE52 /* Build configuration list for PBXNativeTarget "TelnyxRTC" */;
 			buildPhases = (
-				B11F2BF0662831D7971FF3B5 /* [CP] Check Pods Manifest.lock */,
+				37B18E93EA7D0090D207079D /* [CP] Check Pods Manifest.lock */,
 				B368BEBB25EDDB610032AE52 /* Headers */,
 				B368BEBC25EDDB610032AE52 /* Sources */,
 				B368BEBD25EDDB610032AE52 /* Frameworks */,
@@ -466,11 +469,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = B368BEDB25EDDBC90032AE52 /* Build configuration list for PBXNativeTarget "TelnyxRTCTests" */;
 			buildPhases = (
-				6DBA9076618B8A64A81A4684 /* [CP] Check Pods Manifest.lock */,
+				968B614DCDCF9DA1458EC1B2 /* [CP] Check Pods Manifest.lock */,
 				B368BECD25EDDBC90032AE52 /* Sources */,
 				B368BECE25EDDBC90032AE52 /* Frameworks */,
 				B368BECF25EDDBC90032AE52 /* Resources */,
-				48814E5BFFE706D4F1E065BA /* [CP] Embed Pods Frameworks */,
+				B32DBA092F364D1AD3B40390 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -486,11 +489,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = B368BEF925EDDD070032AE52 /* Build configuration list for PBXNativeTarget "TelnyxWebRTCDemo" */;
 			buildPhases = (
-				BEF64CE03CDA89814E7EA5E8 /* [CP] Check Pods Manifest.lock */,
+				E82A024E9DE7041044DCB1BB /* [CP] Check Pods Manifest.lock */,
 				B368BEE425EDDD060032AE52 /* Sources */,
 				B368BEE525EDDD060032AE52 /* Frameworks */,
 				B368BEE625EDDD060032AE52 /* Resources */,
-				67BF40BB3E5BAEF363D9A799 /* [CP] Embed Pods Frameworks */,
+				0D64131DC048CB58CE40CC20 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -576,24 +579,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		48814E5BFFE706D4F1E065BA /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		67BF40BB3E5BAEF363D9A799 /* [CP] Embed Pods Frameworks */ = {
+		0D64131DC048CB58CE40CC20 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -610,29 +596,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6DBA9076618B8A64A81A4684 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-TelnyxRTC-TelnyxRTCTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		B11F2BF0662831D7971FF3B5 /* [CP] Check Pods Manifest.lock */ = {
+		37B18E93EA7D0090D207079D /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -654,7 +618,46 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		BEF64CE03CDA89814E7EA5E8 /* [CP] Check Pods Manifest.lock */ = {
+		968B614DCDCF9DA1458EC1B2 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-TelnyxRTC-TelnyxRTCTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B32DBA092F364D1AD3B40390 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E82A024E9DE7041044DCB1BB /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -691,6 +694,7 @@
 				B32AE8B326CD4F9200C7C6F4 /* TxServerConfiguration.swift in Sources */,
 				B368BEE125EDDC7D0032AE52 /* TxClient.swift in Sources */,
 				B309D28625F184A100A2AADF /* AnswerMessage.swift in Sources */,
+				3B1BE6F72AA9A467000B7962 /* TxPushServerConfig.swift in Sources */,
 				B309D23125F06CA800A2AADF /* Peer.swift in Sources */,
 				B309D1E425F0240200A2AADF /* TxConfig.swift in Sources */,
 				B3AF248025EE7B1F0062EDA9 /* TxClientDelegate.swift in Sources */,
@@ -898,7 +902,7 @@
 		};
 		B368BEC925EDDB610032AE52 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 88B7BA1B960143560EBFB0E1 /* Pods-TelnyxRTC.debug.xcconfig */;
+			baseConfigurationReference = 5C16E48FCC265B55D546444A /* Pods-TelnyxRTC.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -934,7 +938,7 @@
 		};
 		B368BECA25EDDB610032AE52 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 19D83E5D9EC7293621E7C15B /* Pods-TelnyxRTC.release.xcconfig */;
+			baseConfigurationReference = B71613CF413A8BEDF1CE19AC /* Pods-TelnyxRTC.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -966,7 +970,7 @@
 		};
 		B368BED925EDDBC90032AE52 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C4A8FC81E448AC9A8DACFFC5 /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */;
+			baseConfigurationReference = D0E7429E889D9B84F5E9A561 /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CODE_SIGN_STYLE = Automatic;
@@ -985,7 +989,7 @@
 		};
 		B368BEDA25EDDBC90032AE52 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0FEA558BEFB58901E8E79A73 /* Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig */;
+			baseConfigurationReference = 8AE5F966C445938F4224CA6A /* Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CODE_SIGN_STYLE = Automatic;
@@ -1004,7 +1008,7 @@
 		};
 		B368BEFA25EDDD070032AE52 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6710D78B923409C254BBC2C9 /* Pods-TelnyxWebRTCDemo.debug.xcconfig */;
+			baseConfigurationReference = 8DE9E2ED3C21DDB7522D96C4 /* Pods-TelnyxWebRTCDemo.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -1028,7 +1032,7 @@
 		};
 		B368BEFB25EDDD070032AE52 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2A8EB4E91B886E3D6975A654 /* Pods-TelnyxWebRTCDemo.release.xcconfig */;
+			baseConfigurationReference = 7A5E4038778AD18438417FD9 /* Pods-TelnyxWebRTCDemo.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/TelnyxRTC.xcodeproj/project.pbxproj
+++ b/TelnyxRTC.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		3B1BE6F72AA9A467000B7962 /* TxPushServerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1BE6F62AA9A467000B7962 /* TxPushServerConfig.swift */; };
+		3B49B7152AA9B0A20026D36D /* AttachCallMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B49B7142AA9B0A20026D36D /* AttachCallMessage.swift */; };
 		3B72695D2A9396BF00D2A602 /* DisablePushMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B72695C2A9396BF00D2A602 /* DisablePushMessage.swift */; };
 		5344D3BC45B3F58E0EA04655 /* Pods_TelnyxRTC_TelnyxRTCTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F7BD9AFB0171FC02B1C9D32B /* Pods_TelnyxRTC_TelnyxRTCTests.framework */; };
 		A5B04B04B8EB128EE54576F1 /* Pods_TelnyxRTC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 515285571CF0656848F7F0BB /* Pods_TelnyxRTC.framework */; };
@@ -25,8 +26,8 @@
 		B309D24025F06EA600A2AADF /* InviteMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D23F25F06EA600A2AADF /* InviteMessage.swift */; };
 		B309D24E25F0717B00A2AADF /* UICallScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = B309D24D25F0717B00A2AADF /* UICallScreen.xib */; };
 		B309D25325F071DD00A2AADF /* UICallScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D25225F071DD00A2AADF /* UICallScreen.swift */; };
-		B309D26225F1574C00A2AADF /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
-		B309D26325F1574C00A2AADF /* BuildFile in Embed Frameworks */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		B309D26225F1574C00A2AADF /* (null) in Frameworks */ = {isa = PBXBuildFile; };
+		B309D26325F1574C00A2AADF /* (null) in Embed Frameworks */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B309D27B25F17C1700A2AADF /* UIIncomingCallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D27925F17C1700A2AADF /* UIIncomingCallView.swift */; };
 		B309D27C25F17C1700A2AADF /* UIIncomingCallView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B309D27A25F17C1700A2AADF /* UIIncomingCallView.xib */; };
 		B309D28225F1838700A2AADF /* ByeMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D28125F1838700A2AADF /* ByeMessage.swift */; };
@@ -88,7 +89,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				B309D26325F1574C00A2AADF /* BuildFile in Embed Frameworks */,
+				B309D26325F1574C00A2AADF /* (null) in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -97,6 +98,7 @@
 
 /* Begin PBXFileReference section */
 		3B1BE6F62AA9A467000B7962 /* TxPushServerConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxPushServerConfig.swift; sourceTree = "<group>"; };
+		3B49B7142AA9B0A20026D36D /* AttachCallMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachCallMessage.swift; sourceTree = "<group>"; };
 		3B72695C2A9396BF00D2A602 /* DisablePushMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisablePushMessage.swift; sourceTree = "<group>"; };
 		515285571CF0656848F7F0BB /* Pods_TelnyxRTC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxRTC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		56BFABD786323F03A70F6C97 /* Pods_TelnyxWebRTCDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxWebRTCDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -176,7 +178,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B309D13D25EF119E00A2AADF /* Starscream.framework in Frameworks */,
-				B309D26225F1574C00A2AADF /* BuildFile in Frameworks */,
+				B309D26225F1574C00A2AADF /* (null) in Frameworks */,
 				A5B04B04B8EB128EE54576F1 /* Pods_TelnyxRTC.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -228,6 +230,7 @@
 				B3BB8F9F26BC076000DDCB84 /* GatewayMessage.swift */,
 				3B72695C2A9396BF00D2A602 /* DisablePushMessage.swift */,
 				3B1BE6F62AA9A467000B7962 /* TxPushServerConfig.swift */,
+				3B49B7142AA9B0A20026D36D /* AttachCallMessage.swift */,
 			);
 			path = Verto;
 			sourceTree = "<group>";
@@ -686,6 +689,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3B49B7152AA9B0A20026D36D /* AttachCallMessage.swift in Sources */,
 				B36FC8C02612794A00A30BC4 /* Logger.swift in Sources */,
 				B3AF248B25EE7C350062EDA9 /* Socket.swift in Sources */,
 				B3BB8FA026BC076000DDCB84 /* GatewayMessage.swift in Sources */,

--- a/TelnyxRTC/Telnyx/Models/TxPushIPConfig.swift
+++ b/TelnyxRTC/Telnyx/Models/TxPushIPConfig.swift
@@ -8,13 +8,13 @@
 import Foundation
 
 /// This class contains all the properties related to Server Confuguration from Push
-public struct TxPushServerConfig {
+public struct TxPushIPConfig {
     
 
     public internal(set) var rtc_ip:String
-    public internal(set) var rtc_port:String
+    public internal(set) var rtc_port:Int
     
-    public init(rtc_ip: String, rtc_port: String) {
+    public init(rtc_ip: String, rtc_port: Int) {
         self.rtc_ip = rtc_ip
         self.rtc_port = rtc_port
     }

--- a/TelnyxRTC/Telnyx/Models/TxServerConfiguration.swift
+++ b/TelnyxRTC/Telnyx/Models/TxServerConfiguration.swift
@@ -23,15 +23,35 @@ public struct TxServerConfiguration {
     /// - Parameters:
     ///   - signalingServer: To define the signaling server URL `wss://address:port`
     ///   - webRTCIceServers: To define custom ICE servers
-    public init(signalingServer: URL? = nil, webRTCIceServers: [RTCIceServer]? = nil, environment: WebRTCEnvironment = .production) {
+    public init(signalingServer: URL? = nil, webRTCIceServers: [RTCIceServer]? = nil, environment: WebRTCEnvironment = .production,pushIPConfig:TxPushIPConfig? = nil) {
         Logger.log.i(message: "TxServerConfiguration:: signalingServer [\(String(describing: signalingServer))] webRTCIceServers [\(String(describing: webRTCIceServers))] environment [\(String(describing: environment))]")
         if let signalingServer = signalingServer {
             self.signalingServer = signalingServer
         } else {
             if environment == .production {
-                self.signalingServer = InternalConfig.default.prodSignalingServer
+                // Set signalingServer for push notifications
+                if let pushConfigSettings = pushIPConfig {
+                    let query = "?rtc_ip=\(pushConfigSettings.rtc_ip)&rtc_port=\(pushConfigSettings.rtc_port)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+                    let pushRtcServer = "\(InternalConfig.default.prodSignalingServer)\(query)"
+                    self.signalingServer = URL(string: pushRtcServer ) ??  InternalConfig.default.prodSignalingServer
+                    
+                }else {
+                    self.signalingServer = InternalConfig.default.prodSignalingServer
+                }
+                
             } else {
-                self.signalingServer = InternalConfig.default.developmentSignalingServer
+                
+                // Set signalingServer for push notifications
+                if let pushConfigSettings = pushIPConfig {
+                    let query = "?rtc_ip=\(pushConfigSettings.rtc_ip)&rtc_port=\(pushConfigSettings.rtc_port)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+                    
+                    let pushRtcServer = "\(InternalConfig.default.developmentSignalingServer)\(query)"
+                    self.signalingServer = URL(string: pushRtcServer ) ?? InternalConfig.default.developmentSignalingServer
+                    
+                }else {
+                    self.signalingServer = InternalConfig.default.developmentSignalingServer
+                }
+                
             }
             self.environment = environment
         }

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -431,9 +431,10 @@ extension TxClient {
     ///  You will need to
     /// - Parameters:
     ///   - txConfig: The desired configuration to login to B2B2UA. User credentials must be the same as the
+    ///   - serverConfiguration : required to setup rtc_ip and rtc_port from   VoIP push notification metadata.
     /// - Throws: Error during the connection process
     public func processVoIPNotification(txConfig: TxConfig,
-                                        serverConfiguration: TxServerConfiguration = TxServerConfiguration()) throws {
+                                        serverConfiguration: TxServerConfiguration) throws {
         Logger.log.i(message: "TxClient:: push flow voIPUUID")
         // Check if we are already connected and logged in
         if isConnected() {

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -225,7 +225,6 @@ public class TxClient {
 
         if let sipUser = self.txConfig?.sipUser {
             let pushToken = self.txConfig?.pushNotificationConfig?.pushDeviceToken
-            let password = self.txConfig?.password
             let disablePushMessage = DisablePushMessage(user: sipUser,pushDeviceToken: pushToken,pushNotificationProvider: pushProvider)
             let message = disablePushMessage.encode() ?? ""
             self.socket?.sendMessage(message: message)
@@ -234,7 +233,6 @@ public class TxClient {
         
         if let token = self.txConfig?.token {
             let pushToken = self.txConfig?.pushNotificationConfig?.pushDeviceToken
-            let password = self.txConfig?.password
             let disablePushMessage = DisablePushMessage(loginToken:token,pushDeviceToken: pushToken,pushNotificationProvider: pushProvider)
             let message = disablePushMessage.encode() ?? ""
             self.socket?.sendMessage(message: message)
@@ -450,7 +448,10 @@ extension TxClient {
             Logger.log.e(message: "TxClient:: push flow connect error \(error.localizedDescription)")
         }
         Logger.log.i(message: "TxClient:: push flow: waitInviteTimer started")
-        self.waitInviteTimer()
+        //TxPushConfig
+        TxPushServerConfig(rtc_ip: "String", rtc_port: "String")
+        
+        //PushConfig(rtc_ip: "String", rtc_port: "String")
     }
 
     /// This function starts a timer to wait the INVITE message after receiving a PN.

--- a/TelnyxRTC/Telnyx/Verto/AttachCallMessage.swift
+++ b/TelnyxRTC/Telnyx/Verto/AttachCallMessage.swift
@@ -1,0 +1,35 @@
+//
+//  AttachCallMessage.swift
+//  TelnyxRTC
+//
+//  Created by Isaac Akakpo on 07/09/2023.
+//
+
+import Foundation
+
+
+class AttachCallMessage : Message {
+    
+    init(
+            pushNotificationProvider: String? = nil) {
+           var params = [String: Any]()
+
+           //Setup push variables
+           var userVariables = [String: Any]()
+           
+           if let provider = pushNotificationProvider {
+               params["push_notification_provider"] = provider
+           }
+           
+           #if DEBUG
+           userVariables["push_notification_environment"] = appMode.debug.rawValue
+           #else
+           userVariables["push_notification_environment"] = appMode.production.rawValue
+           #endif
+
+
+           params["loginParams"] = [String: String]()
+           params["userVariables"] = userVariables
+           super.init(params, method: .ATTACH_CALL)
+       }
+}

--- a/TelnyxRTC/Telnyx/Verto/LoginMessage.swift
+++ b/TelnyxRTC/Telnyx/Verto/LoginMessage.swift
@@ -20,6 +20,7 @@ class LoginMessage : Message {
          password: String,
          pushDeviceToken: String? = nil,
          pushNotificationProvider: String? = nil) {
+        
         var params = [String: Any]()
         params["login"] = user
         params["passwd"] = password
@@ -41,11 +42,12 @@ class LoginMessage : Message {
         #else
         userVariables["push_notification_environment"] = appMode.production.rawValue
         #endif
-
+        
         var loginParams = [String: Any]()
         loginParams["attach_call"] = true.description
         params["loginParams"] = loginParams
 
+        
         params["userVariables"] = userVariables
         super.init(params, method: .LOGIN)
     }
@@ -56,6 +58,10 @@ class LoginMessage : Message {
          pushNotificationProvider: String? = nil) {
         var params = [String: Any]()
         params["login_token"] = token
+        
+        var loginParams = [String: Any]()
+        loginParams["attach_call"] = true.description
+        params["loginParams"] = loginParams
 
         //Setup push variables
         var userVariables = [String: Any]()
@@ -66,9 +72,7 @@ class LoginMessage : Message {
             userVariables["push_notification_provider"] = provider
         }
 
-        var loginParams = [String: Any]()
-        loginParams["attach_call"] = true.description
-        params["loginParams"] = loginParams
+      
 
         params["userVariables"] = userVariables
         super.init(params, method: .LOGIN)

--- a/TelnyxRTC/Telnyx/Verto/LoginMessage.swift
+++ b/TelnyxRTC/Telnyx/Verto/LoginMessage.swift
@@ -42,7 +42,10 @@ class LoginMessage : Message {
         userVariables["push_notification_environment"] = appMode.production.rawValue
         #endif
 
-        params["loginParams"] = [String: String]()
+        var loginParams = [String: Any]()
+        loginParams["attach_call"] = true.description
+        params["loginParams"] = loginParams
+
         params["userVariables"] = userVariables
         super.init(params, method: .LOGIN)
     }
@@ -63,7 +66,10 @@ class LoginMessage : Message {
             userVariables["push_notification_provider"] = provider
         }
 
-		params["loginParams"] = [String: String]()
+        var loginParams = [String: Any]()
+        loginParams["attach_call"] = true.description
+        params["loginParams"] = loginParams
+
         params["userVariables"] = userVariables
         super.init(params, method: .LOGIN)
     }

--- a/TelnyxRTC/Telnyx/Verto/Method.swift
+++ b/TelnyxRTC/Telnyx/Verto/Method.swift
@@ -29,5 +29,6 @@ enum Method : String {
     case BROADCAST = "telnyx_rtc.broadcast"
     case UNSUBSCRIBE = "telnyx_rtc.unsubscribe"
     case ECHO = "echo" //this is for testing
+    case ATTACH_CALL = "telnyx_rtc.attachCalls"
     case DISABLE_PUSH = "telnyx_rtc.disable_push_notification"  // "telnyx_rtc.disablePush"
 }

--- a/TelnyxRTC/Telnyx/Verto/TxPushServerConfig.swift
+++ b/TelnyxRTC/Telnyx/Verto/TxPushServerConfig.swift
@@ -1,0 +1,22 @@
+//
+//  PushConfig.swift
+//  TelnyxRTC
+//
+//  Created by Isaac Akakpo on 07/09/2023.
+//
+
+import Foundation
+
+/// This class contains all the properties related to Server Confuguration from Push
+public struct TxPushServerConfig {
+    
+
+    public internal(set) var rtc_ip:String
+    public internal(set) var rtc_port:String
+    
+    public init(rtc_ip: String, rtc_port: String) {
+        self.rtc_ip = rtc_ip
+        self.rtc_port = rtc_port
+    }
+    
+}

--- a/TelnyxWebRTCDemo/AppDelegate.swift
+++ b/TelnyxWebRTCDemo/AppDelegate.swift
@@ -30,6 +30,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var telnyxClient : TxClient?
     var currentCall: Call?
     var callKitUUID: UUID?
+    var callAnswerPendingFromPush:Bool = false
 
     private var pushRegistry = PKPushRegistry.init(queue: DispatchQueue.main)
     weak var voipDelegate: VoIPDelegate?
@@ -134,14 +135,21 @@ extension AppDelegate: PKPushRegistryDelegate {
             }
             let callerName = (metadata["caller_name"] as? String) ?? ""
             let callerNumber = (metadata["caller_number"] as? String) ?? ""
+            
+            // Get rtc_ip and rct_port to setup TxPushServerConfig
+            let rtc_ip = (metadata["rtc_ip"] as? String) ?? ""
+            let rtc_port = (metadata["rtc_port"] as? Int) ?? 0
+            
+            let pushIPConfig = TxPushIPConfig(rtc_ip: rtc_ip, rtc_port: rtc_port)
+            
             let caller = callerName.isEmpty ? (callerNumber.isEmpty ? "Unknown" : callerNumber) : callerName
             let uuid = UUID(uuidString: callID)
-            self.processVoIPNotification(callUUID: uuid!)
+            self.processVoIPNotification(callUUID: uuid!,pushIPConfig: pushIPConfig)
             self.newIncomingCall(from: caller, uuid: uuid!)
         } else {
             // If there's no available metadata, let's create the notification with dummy data.
             let uuid = UUID.init()
-            self.processVoIPNotification(callUUID: uuid)
+            self.processVoIPNotification(callUUID: uuid,pushIPConfig: TxPushIPConfig(rtc_ip: "", rtc_port: 433))
             self.newIncomingCall(from: "Incoming call", uuid: uuid)
         }
     }

--- a/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
@@ -145,7 +145,11 @@ extension AppDelegate : CXProviderDelegate {
 
     func provider(_ provider: CXProvider, perform action: CXAnswerCallAction) {
         print("AppDelegate:: ANSWER call action: callKitUUID [\(String(describing: self.callKitUUID))] action [\(action.callUUID)]")
-        self.currentCall?.answer()
+        if(currentCall != nil){
+            self.currentCall?.answer()
+        }else {
+            self.callAnswerPendingFromPush = true
+        }
         action.fulfill()
     }
 
@@ -185,15 +189,15 @@ extension AppDelegate : CXProviderDelegate {
         print("provider:performSetMutedAction:")
     }
     
-    func processVoIPNotification(callUUID: UUID) {
+    func processVoIPNotification(callUUID: UUID,pushIPConfig:TxPushIPConfig) {
         print("AppDelegate:: processVoIPNotification \(callUUID)")
         self.callKitUUID = callUUID
         var serverConfig: TxServerConfiguration
         let userDefaults = UserDefaults.init()
         if userDefaults.getEnvironment() == .development {
-            serverConfig = TxServerConfiguration(environment: .development)
+            serverConfig = TxServerConfiguration(environment: .development,pushIPConfig: pushIPConfig)
         } else {
-            serverConfig = TxServerConfiguration()
+            serverConfig = TxServerConfiguration(environment: .production,pushIPConfig: pushIPConfig)
         }
         
         let sipUser = userDefaults.getSipUser()

--- a/TelnyxWebRTCDemo/Extensions/AppDelegateTelnyxVoIPExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/AppDelegateTelnyxVoIPExtension.swift
@@ -63,6 +63,11 @@ extension AppDelegate: TxClientDelegate {
     func onPushCall(call: Call) {
         print("AppDelegate:: TxClientDelegate onPushCall() \(call)")
         self.currentCall = call //Update the current call with the incoming call
+        if(self.callAnswerPendingFromPush){
+            self.voipDelegate?.onIncomingCall(call: call)
+            self.callAnswerPendingFromPush = false
+        }
+        
     }
     
     func onRemoteCallEnded(callId: UUID) {


### PR DESCRIPTION
<!-- Ticket details and link -->
[WEBRTC-25284 - Ticket iOS SDK Answering from Push Notification Issue](https://telnyx.atlassian.net/browse/ENGDESK-25284)
---
<!-- Describe your change here -->
- Added new method attachCalls
- The SDK now sends attachCalls rtc message when a PN is received
- Push Notifications now sends `rtc_ip` and `rtc_port` in meta data. This is used to setup `TxPushIPConfig` which directs rtc messages to the required instance the PN was initiated. 
- Update `0.1.8` will now require the `TxServerConfiguration(..)` param for `processVoIPNotification(..)` method

## :older_man: :baby: Behaviors
### Before changes
- PN Calls were not sending the INVITE message

### After changes
- PN Calls work, and INVITE message is received

## TODO
- Login param `attach_call` should later be removed and a version param sent instead

## ✋ Manual testing
1. User Login - :white_check_mark:
2. Call is in Foreground - :white_check_mark:
3. Call is In Background (Answer Push Notifications) - :white_check_mark:
4. Ending Call - :white_check_mark:
5. Make Call - :white_check_mark:

