### PR TITLE
Is/enhancement/pn refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,13 +405,7 @@ extension AppDelegate: PKPushRegistryDelegate {
             let callerNumber = (metadata["caller_number"] as? String) ?? ""
             let caller = callerName.isEmpty ? (callerNumber.isEmpty ? "Unknown" : callerNumber) : callerName
             
-            // Get rtc_ip and rct_port to setup TxPushServerConfig
-            let rtc_ip = (metadata["rtc_ip"] as? String) ?? ""
-            let rtc_port = (metadata["rtc_port"] as? Int) ?? 0
-            
-            //Use rtc_ip and rct_port for TxPushIPConfig
-            let pushIPConfig = TxPushIPConfig(rtc_ip: rtc_ip, rtc_port: rtc_port)
-            
+
             let uuid = UUID(uuidString: callId)
             
             // Re-connect the client and process the push notification when is received.
@@ -421,11 +415,9 @@ extension AppDelegate: PKPushRegistryDelegate {
                                 pushDeviceToken: "APNS_PUSH_TOKEN")
                                 
                         
-            //Declare TxServerConfiguration with the pushIPConfig param
-            let serverConfig = TxServerConfiguration(pushIPConfig: pushIPConfig)
+            //Call processVoIPNotification method 
         
-            try telnyxClient?.processVoIPNotification(txConfig: txConfig, serverConfiguration: serverConfig)
-
+            try telnyxClient?.processVoIPNotification(txConfig: txConfig, serverConfiguration: serverConfig,pushMetaData: metadata)
             
 
             

--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ For more information about Pushkit you can check the official [Apple docs](https
 
 __*Important*__:
 - You will need to login at least once to send your device token to Telnyx before start getting Push notifications. 
-- You will need to provide `TxPushIPConfig(rtc_ip: .., rtc_port: ..)` to `TxServerConfiguration(pushIPConfig:..)` to get Push calls to work. 
+- You will need to provide `pushMetaData` to `processVoIPNotification()` to get Push calls to work. 
 - You will need to implement 'CallKit' to report an incoming call when there’s a VoIP push notification. On iOS 13.0 and later, if you fail to report a call to CallKit, the system will terminate your app. More information on [Apple docs](https://developer.apple.com/documentation/pushkit/pkpushregistrydelegate/2875784-pushregistry) 
 
 

--- a/TelnyxRTC.podspec
+++ b/TelnyxRTC.podspec
@@ -2,7 +2,7 @@
 Pod::Spec.new do |spec|
 
   spec.name = "TelnyxRTC"
-  spec.version = "0.1.9"
+  spec.version = "0.1.10"
   spec.summary = "Enable Telnyx real-time communication services on iOS."
   spec.description = "The Telnyx iOS WebRTC Client SDK provides all the functionality you need to start making voice calls from an iPhone."
   spec.homepage = "https://github.com/team-telnyx/telnyx-webrtc-ios"

--- a/TelnyxRTC.xcodeproj/project.pbxproj
+++ b/TelnyxRTC.xcodeproj/project.pbxproj
@@ -27,8 +27,8 @@
 		B309D24025F06EA600A2AADF /* InviteMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D23F25F06EA600A2AADF /* InviteMessage.swift */; };
 		B309D24E25F0717B00A2AADF /* UICallScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = B309D24D25F0717B00A2AADF /* UICallScreen.xib */; };
 		B309D25325F071DD00A2AADF /* UICallScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D25225F071DD00A2AADF /* UICallScreen.swift */; };
-		B309D26225F1574C00A2AADF /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
-		B309D26325F1574C00A2AADF /* BuildFile in Embed Frameworks */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		B309D26225F1574C00A2AADF /* (null) in Frameworks */ = {isa = PBXBuildFile; };
+		B309D26325F1574C00A2AADF /* (null) in Embed Frameworks */ = {isa = PBXBuildFile; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B309D27B25F17C1700A2AADF /* UIIncomingCallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D27925F17C1700A2AADF /* UIIncomingCallView.swift */; };
 		B309D27C25F17C1700A2AADF /* UIIncomingCallView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B309D27A25F17C1700A2AADF /* UIIncomingCallView.xib */; };
 		B309D28225F1838700A2AADF /* ByeMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D28125F1838700A2AADF /* ByeMessage.swift */; };
@@ -89,7 +89,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				B309D26325F1574C00A2AADF /* BuildFile in Embed Frameworks */,
+				B309D26325F1574C00A2AADF /* (null) in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -178,7 +178,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B309D13D25EF119E00A2AADF /* Starscream.framework in Frameworks */,
-				B309D26225F1574C00A2AADF /* BuildFile in Frameworks */,
+				B309D26225F1574C00A2AADF /* (null) in Frameworks */,
 				292CD7D99FE94568B04E06AE /* Pods_TelnyxRTC.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -928,7 +928,7 @@
 					"@loader_path/Frameworks",
 					"$(BUILT_PRODUCTS_DIR)/Starscream",
 				);
-				MARKETING_VERSION = 0.1.5;
+				MARKETING_VERSION = 0.1.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.WebRTCSDK;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -961,7 +961,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.5;
+				MARKETING_VERSION = 0.1.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.WebRTCSDK;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -1026,7 +1026,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.5;
+				MARKETING_VERSION = 0.1.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.webrtcapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -1050,7 +1050,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.5;
+				MARKETING_VERSION = 0.1.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.webrtcapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/TelnyxRTC/Telnyx/Models/TxServerConfiguration.swift
+++ b/TelnyxRTC/Telnyx/Models/TxServerConfiguration.swift
@@ -23,15 +23,26 @@ public struct TxServerConfiguration {
     /// - Parameters:
     ///   - signalingServer: To define the signaling server URL `wss://address:port`
     ///   - webRTCIceServers: To define custom ICE servers
-    public init(signalingServer: URL? = nil, webRTCIceServers: [RTCIceServer]? = nil, environment: WebRTCEnvironment = .production,pushIPConfig:TxPushIPConfig? = nil) {
+    ///   - pushMetaData: Contains push info when a PN is received
+    public init(signalingServer: URL? = nil, webRTCIceServers: [RTCIceServer]? = nil, environment: WebRTCEnvironment = .production,pushMetaData:[String: Any]? = nil) {
+        
+        
+        let rtcId = (pushMetaData?["rtc_id"] as? String)
+        
+        // Get rtc_ip and rct_port to setup TxPushServerConfig
+        let rtc_ip = (pushMetaData?["rtc_ip"] as? String)
+        let rtc_port = (pushMetaData?["rtc_port"] as? Int) ?? 0
+        
+        
+        
         Logger.log.i(message: "TxServerConfiguration:: signalingServer [\(String(describing: signalingServer))] webRTCIceServers [\(String(describing: webRTCIceServers))] environment [\(String(describing: environment))]")
         if let signalingServer = signalingServer {
             self.signalingServer = signalingServer
         } else {
             if environment == .production {
                 // Set signalingServer for push notifications
-                if let pushConfigSettings = pushIPConfig {
-                    let query = "?rtc_ip=\(pushConfigSettings.rtc_ip)&rtc_port=\(pushConfigSettings.rtc_port)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+                if let pushId = rtc_ip {
+                    let query = "?rtc_ip=\(pushId)&rtc_port=\(rtc_port)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
                     let pushRtcServer = "\(InternalConfig.default.prodSignalingServer)\(query)"
                     self.signalingServer = URL(string: pushRtcServer ) ??  InternalConfig.default.prodSignalingServer
                     
@@ -42,9 +53,8 @@ public struct TxServerConfiguration {
             } else {
                 
                 // Set signalingServer for push notifications
-                if let pushConfigSettings = pushIPConfig {
-                    let query = "?rtc_ip=\(pushConfigSettings.rtc_ip)&rtc_port=\(pushConfigSettings.rtc_port)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-                    
+                if let pushId = rtc_ip {
+                    let query = "?rtc_ip=\(pushId)&rtc_port=\(rtc_port)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
                     let pushRtcServer = "\(InternalConfig.default.developmentSignalingServer)\(query)"
                     self.signalingServer = URL(string: pushRtcServer ) ?? InternalConfig.default.developmentSignalingServer
                     

--- a/TelnyxRTC/Telnyx/Models/TxServerConfiguration.swift
+++ b/TelnyxRTC/Telnyx/Models/TxServerConfiguration.swift
@@ -26,16 +26,13 @@ public struct TxServerConfiguration {
     ///   - pushMetaData: Contains push info when a PN is received
     public init(signalingServer: URL? = nil, webRTCIceServers: [RTCIceServer]? = nil, environment: WebRTCEnvironment = .production,pushMetaData:[String: Any]? = nil) {
         
-        
-        let rtcId = (pushMetaData?["rtc_id"] as? String)
-        
         // Get rtc_ip and rct_port to setup TxPushServerConfig
         let rtc_ip = (pushMetaData?["rtc_ip"] as? String)
         let rtc_port = (pushMetaData?["rtc_port"] as? Int) ?? 0
         
         
         
-        Logger.log.i(message: "TxServerConfiguration:: signalingServer [\(String(describing: signalingServer))] webRTCIceServers [\(String(describing: webRTCIceServers))] environment [\(String(describing: environment))]")
+        Logger.log.i(message: "TxServerConfiguration:: signalingServer [\(String(describing: signalingServer))] webRTCIceServers [\(String(describing: webRTCIceServers))] environment [\(String(describing: environment))] ip - [\(String(describing: rtc_ip))]")
         if let signalingServer = signalingServer {
             self.signalingServer = signalingServer
         } else {

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -437,8 +437,9 @@ extension TxClient {
                                         serverConfiguration: TxServerConfiguration,pushMetaData:[String: Any]) throws {
         Logger.log.i(message: "TxClient:: push flow voIPUUID")
         
+        
         let pnServerConfig = TxServerConfiguration(
-            signalingServer: serverConfiguration.signalingServer,
+            signalingServer:nil,
             webRTCIceServers: serverConfiguration.webRTCIceServers,
             environment: serverConfiguration.environment,
             pushMetaData: pushMetaData)

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -434,8 +434,14 @@ extension TxClient {
     ///   - serverConfiguration : required to setup rtc_ip and rtc_port from   VoIP push notification metadata.
     /// - Throws: Error during the connection process
     public func processVoIPNotification(txConfig: TxConfig,
-                                        serverConfiguration: TxServerConfiguration) throws {
+                                        serverConfiguration: TxServerConfiguration,pushMetaData:[String: Any]) throws {
         Logger.log.i(message: "TxClient:: push flow voIPUUID")
+        
+        let pnServerConfig = TxServerConfiguration(
+            signalingServer: serverConfiguration.signalingServer,
+            webRTCIceServers: serverConfiguration.webRTCIceServers,
+            environment: serverConfiguration.environment,
+            pushMetaData: pushMetaData)
         // Check if we are already connected and logged in
         if isConnected() {
             Logger.log.i(message: "TxClient:: push flow socket already connected: disconnect")
@@ -444,7 +450,7 @@ extension TxClient {
 
         Logger.log.i(message: "TxClient:: push flow connect")
         do {
-            try self.connect(txConfig: txConfig, serverConfiguration: serverConfiguration)
+            try self.connect(txConfig: txConfig, serverConfiguration: pnServerConfig)
         } catch let error {
             Logger.log.e(message: "TxClient:: push flow connect error \(error.localizedDescription)")
         }

--- a/TelnyxRTC/Telnyx/Verto/AttachCallMessage.swift
+++ b/TelnyxRTC/Telnyx/Verto/AttachCallMessage.swift
@@ -10,8 +10,7 @@ import Foundation
 
 class AttachCallMessage : Message {
     
-    init(
-            pushNotificationProvider: String? = nil) {
+    init(pushNotificationProvider: String? = nil) {
            var params = [String: Any]()
 
            //Setup push variables

--- a/TelnyxWebRTCDemo/AppDelegate.swift
+++ b/TelnyxWebRTCDemo/AppDelegate.swift
@@ -136,20 +136,16 @@ extension AppDelegate: PKPushRegistryDelegate {
             let callerName = (metadata["caller_name"] as? String) ?? ""
             let callerNumber = (metadata["caller_number"] as? String) ?? ""
             
-            // Get rtc_ip and rct_port to setup TxPushServerConfig
-            let rtc_ip = (metadata["rtc_ip"] as? String) ?? ""
-            let rtc_port = (metadata["rtc_port"] as? Int) ?? 0
-            
-            let pushIPConfig = TxPushIPConfig(rtc_ip: rtc_ip, rtc_port: rtc_port)
+          
             
             let caller = callerName.isEmpty ? (callerNumber.isEmpty ? "Unknown" : callerNumber) : callerName
             let uuid = UUID(uuidString: callID)
-            self.processVoIPNotification(callUUID: uuid!,pushIPConfig: pushIPConfig)
+            self.processVoIPNotification(callUUID: uuid!,pushMetaData: metadata)
             self.newIncomingCall(from: caller, uuid: uuid!)
         } else {
             // If there's no available metadata, let's create the notification with dummy data.
             let uuid = UUID.init()
-            self.processVoIPNotification(callUUID: uuid,pushIPConfig: TxPushIPConfig(rtc_ip: "", rtc_port: 433))
+            self.processVoIPNotification(callUUID: uuid,pushMetaData: [String: Any]())
             self.newIncomingCall(from: "Incoming call", uuid: uuid)
         }
     }

--- a/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
@@ -195,9 +195,9 @@ extension AppDelegate : CXProviderDelegate {
         var serverConfig: TxServerConfiguration
         let userDefaults = UserDefaults.init()
         if userDefaults.getEnvironment() == .development {
-            serverConfig = TxServerConfiguration(environment: .development,pushMetaData: pushMetaData)
+            serverConfig = TxServerConfiguration(environment: .development)
         } else {
-            serverConfig = TxServerConfiguration(environment: .production,pushMetaData: pushMetaData)
+            serverConfig = TxServerConfiguration(environment: .production)
         }
         
         let sipUser = userDefaults.getSipUser()

--- a/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
@@ -189,15 +189,15 @@ extension AppDelegate : CXProviderDelegate {
         print("provider:performSetMutedAction:")
     }
     
-    func processVoIPNotification(callUUID: UUID,pushIPConfig:TxPushIPConfig) {
+    func processVoIPNotification(callUUID: UUID,pushMetaData:[String: Any]) {
         print("AppDelegate:: processVoIPNotification \(callUUID)")
         self.callKitUUID = callUUID
         var serverConfig: TxServerConfiguration
         let userDefaults = UserDefaults.init()
         if userDefaults.getEnvironment() == .development {
-            serverConfig = TxServerConfiguration(environment: .development,pushIPConfig: pushIPConfig)
+            serverConfig = TxServerConfiguration(environment: .development,pushMetaData: pushMetaData)
         } else {
-            serverConfig = TxServerConfiguration(environment: .production,pushIPConfig: pushIPConfig)
+            serverConfig = TxServerConfiguration(environment: .production,pushMetaData: pushMetaData)
         }
         
         let sipUser = userDefaults.getSipUser()
@@ -214,7 +214,7 @@ extension AppDelegate : CXProviderDelegate {
                                 logLevel: .all)
         
         do {
-            try telnyxClient?.processVoIPNotification(txConfig: txConfig, serverConfiguration: serverConfig)
+            try telnyxClient?.processVoIPNotification(txConfig: txConfig, serverConfiguration: serverConfig,pushMetaData: pushMetaData)
         } catch let error {
             print("ViewController:: processVoIPNotification Error \(error)")
         }

--- a/TelnyxWebRTCDemo/Extensions/AppDelegateTelnyxVoIPExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/AppDelegateTelnyxVoIPExtension.swift
@@ -63,8 +63,13 @@ extension AppDelegate: TxClientDelegate {
     func onPushCall(call: Call) {
         print("AppDelegate:: TxClientDelegate onPushCall() \(call)")
         self.currentCall = call //Update the current call with the incoming call
-        if(self.callAnswerPendingFromPush){
-            self.voipDelegate?.onIncomingCall(call: call)
+        
+        //Answer Call if call was answered from callkit
+        //This happens when there's a race condition between login and receiving PN
+        // when User answer's the call from PN and there's no Call or INVITE message yet. Set callAnswerPendingFromPush = true
+        // Whilst we wait fot onPushCall Method to be called
+         if(self.callAnswerPendingFromPush){
+            self.currentCall?.answer()
             self.callAnswerPendingFromPush = false
         }
         

--- a/TelnyxWebRTCDemo/Extensions/ViewControllerVoIPExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/ViewControllerVoIPExtension.swift
@@ -47,15 +47,10 @@ extension ViewController : VoIPDelegate {
             
             /** - TODO Error Shouldn't popup if client is diconnected by OS. Create another method for Socket Errors */
             if(error.self is NWError){
-                //DO Nothing
                 print("ERROR: socket connectiontion error \(error)")
             } else {
                 print("ERROR: client error \(error)")
-                /* let alert = UIAlertController(title: "WebRTC error", message: error.localizedDescription, preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: "OK", style: .cancel, handler: {_ in
-                    self.navigationController?.popViewController(animated: true)
-                }))
-                self.present(alert, animated: true) */
+               
             }
            
         }

--- a/TelnyxWebRTCDemo/Extensions/ViewControllerVoIPExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/ViewControllerVoIPExtension.swift
@@ -10,6 +10,7 @@ import UIKit
 import AVFoundation
 import PushKit
 import TelnyxRTC
+import Network
 
 // MARK: - VoIPDelegate
 extension ViewController : VoIPDelegate {
@@ -44,11 +45,19 @@ extension ViewController : VoIPDelegate {
             self.incomingCallView.isHidden = true
             self.telnyxClient?.disconnect()
             
-            let alert = UIAlertController(title: "WebRTC error", message: error.localizedDescription, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: "OK", style: .cancel, handler: {_ in
-                self.navigationController?.popViewController(animated: true)
-            }))
-            self.present(alert, animated: true)
+            /** - TODO Error Shouldn't popup if client is diconnected by OS. Create another method for Socket Errors */
+            if(error.self is NWError){
+                //DO Nothing
+                print("ERROR: socket connectiontion error \(error)")
+            } else {
+                print("ERROR: client error \(error)")
+                /* let alert = UIAlertController(title: "WebRTC error", message: error.localizedDescription, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "OK", style: .cancel, handler: {_ in
+                    self.navigationController?.popViewController(animated: true)
+                }))
+                self.present(alert, animated: true) */
+            }
+           
         }
     }
     
@@ -59,7 +68,9 @@ extension ViewController : VoIPDelegate {
             self.socketStateLabel.text = "Client ready"
             self.settingsView.isHidden = true
             self.callView.isHidden = false
-            self.incomingCallView.isHidden = true
+            if(!self.incomingCall){
+                self.incomingCallView.isHidden = true
+            }
         }
     }
     

--- a/TelnyxWebRTCDemo/ViewController.swift
+++ b/TelnyxWebRTCDemo/ViewController.swift
@@ -101,7 +101,12 @@ class ViewController: UIViewController {
 
     func updateEnvironment() {
         DispatchQueue.main.async {
-            self.environment.text = (self.serverConfig?.environment == .development) ? "Development" : "Production"
+            let plistInfo = Bundle(for: TxClient.self).infoDictionary?["CFBundleShortVersionString"] as? String
+            
+            self.environment.text = (self.serverConfig?.environment == .development) ? "Development" : "Production " +
+            (plistInfo ?? "")
+           
+
         }
     }
 


### PR DESCRIPTION
<!-- Ticket details and link -->
[WEBRTC-25284 - Ticket iOS SDK Answering from Push Notification Issue](https://telnyx.atlassian.net/browse/ENGDESK-25284)
---
<!-- Describe your change here -->
- Added new method attachCalls
- Update `0.1.10` will now require the  `pushMetaData` param for `processVoIPNotification(..)` method.
- Removed TxIPConfig  from `handlePushNotification`

## :older_man: :baby: Behaviors
### Before changes
- TxIPConfig Exposed port and IP
- Race Condition caused failures when answering from PN

### After changes
- PN Calls work, and INVITE message is received
- IP and port handled by sdk
- PN call answer race condition fixed. 

## TODO
- Login param `attach_call` should later be removed and a version param sent instead

## ✋ Manual testing
1. User Login - :white_check_mark:
2. Call is in Foreground - :white_check_mark:
3. Call is In Background (Answer Push Notifications) - :white_check_mark:
4. Ending Call - :white_check_mark:
5. Make Call - :white_check_mark:

