### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
                 .product(name: "WebRTC", package: "WebRTC")
             ],
             path: "TelnyxRTC",
-            sources: ["Info.plist"],
+            exclude: ["Info.plist"],
             resources: [.copy("PrivacyInfo.xcprivacy")]
         )
     ],


### PR DESCRIPTION
<!-- Ticket details and link -->
[WEBRTC-XXX - Ticket title](https://telnyx.atlassian.net/browse/WEBRTC-XXX)
---
<!-- Describe your change here -->
Please provide a summary of the change / issue with a proper context.

## :older_man: :baby: Behaviors
### Before changes
- The info.plist was included in the Package.swift file, causing Xcode to throw the following error:
`"public headers ("include") directory path for 'TelnyxRTC' is invalid or not contained in the target"`
- This error prevented the SPM package from resolving/loading correctly.

### After changes
- The info.plist has been excluded from the Package.swift file.
- Manually tested and confirmed that the package resolves without an error now.
- Xcode no longer throws the "public headers ("include") directory path for 'TelnyxRTC' is invalid or not contained in the target" error.

## TODO
No pending items.

## ✋ Manual testing
1. Open the project in Xcode.
2. Ensure that the info.plist is not included in the Package.swift file.
3. Build the project.
4. Verify that the package resolves without any errors.
5. Confirm that the SPM packages are loading correctly.


## Known Issues
No known issues.

## Screenshots
![Screenshot 2024-06-29 at 21 36 36](https://github.com/team-telnyx/telnyx-webrtc-ios/assets/43815766/4717ad45-c8f3-4d04-b17a-4fcea86ed5d9)
