### PR TITLE
Fix Race Condition for Early Bye Message

### DIFF
--- a/TelnyxRTC.podspec
+++ b/TelnyxRTC.podspec
@@ -2,7 +2,7 @@
 Pod::Spec.new do |spec|
 
   spec.name = "TelnyxRTC"
-  spec.version = "0.1.35"
+  spec.version = "0.1.36"
   spec.summary = "Enable Telnyx real-time communication services on iOS."
   spec.description = "The Telnyx iOS WebRTC Client SDK provides all the functionality you need to start making voice calls from an iPhone."
   spec.homepage = "https://github.com/team-telnyx/telnyx-webrtc-ios"

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -563,6 +563,13 @@ extension TxClient {
             do {
                 Logger.log.i(message: "TxClient:: No Active Calls Connecting Again")
                 try self.connect(txConfig: txConfig, serverConfiguration: pnServerConfig)
+                // Create an initial call_object to handle early bye message
+                if let socket = self.socket {
+                    if let newCallId = (pushMetaData["call_id"] as? String) {
+                        self.calls[UUID(uuidString: newCallId)!] = Call(callId: UUID(uuidString: newCallId)! , sessionId: newCallId, socket: socket, delegate: self, iceServers: self.serverConfiguration.webRTCIceServers)
+                    }
+                }
+                
             } catch let error {
                 Logger.log.e(message: "TxClient:: push flow connect error \(error.localizedDescription)")
             }

--- a/TelnyxWebRTCDemo/Extensions/AppDelegateTelnyxVoIPExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/AppDelegateTelnyxVoIPExtension.swift
@@ -69,13 +69,14 @@ extension AppDelegate: TxClientDelegate {
     
     func onRemoteCallEnded(callId: UUID) {
         print("AppDelegate:: TxClientDelegate onRemoteCallEnded() callKitUUID [\(String(describing: self.callKitUUID))] callId [\(callId)]")
+        reportCallEnd(callId: callId)
+
+        // There can be a race condition, where remote peer ends call before previousCall or currentCall is set
         if (previousCall?.callInfo?.callId == callId) {
-            reportCallEnd(callId: callId)
             self.previousCall = nil
         }
         
         if (currentCall?.callInfo?.callId == callId) {
-            reportCallEnd(callId: callId)
             self.currentCall = nil
             
         }


### PR DESCRIPTION
<!-- Ticket details and link -->
[ENGDESK-34578 - Ticket title](https://telnyx.atlassian.net/browse/ENGDESK-34578)
---
<!-- Describe your change here -->
- Initialisead an early  call object to handle early Byes. 
- Handle `reportEnd` method for earlybye race conditions.

## :older_man: :baby: Behaviors
### Before changes
- Call continuos to ring for early byes 

## TODO
Refactor Bye to happen without call object

## ✋ Manual testing
1. Call/Pn WOrks

