### PR TITLE
[WEBRTC-2351] [Feat] Support Multiple credentials in demo app

### DIFF
--- a/TelnyxRTC.xcodeproj/project.pbxproj
+++ b/TelnyxRTC.xcodeproj/project.pbxproj
@@ -1030,7 +1030,7 @@
 					"@loader_path/Frameworks",
 					"$(BUILT_PRODUCTS_DIR)/Starscream",
 				);
-				MARKETING_VERSION = 0.1.13;
+				MARKETING_VERSION = 0.1.38;
 				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.WebRTCSDK;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -1064,7 +1064,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.13;
+				MARKETING_VERSION = 0.1.38;
 				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.WebRTCSDK;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -1121,7 +1121,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = TelnyxWebRTCDemo/TelnyxWebRTCDemo.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = YKUVNPU9FS;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = TelnyxWebRTCDemo/Info.plist;
@@ -1130,7 +1130,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.19;
+				MARKETING_VERSION = 0.1.20;
 				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.webrtcapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -1146,7 +1146,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = TelnyxWebRTCDemo/TelnyxWebRTCDemo.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 32;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = YKUVNPU9FS;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = TelnyxWebRTCDemo/Info.plist;
@@ -1155,7 +1155,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.19;
+				MARKETING_VERSION = 0.1.20;
 				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.webrtcapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/TelnyxRTC.xcodeproj/project.pbxproj
+++ b/TelnyxRTC.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		995BF7132CE7E8F100454076 /* WebRTCEnvironmentExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995BF7122CE7E8EB00454076 /* WebRTCEnvironmentExtension.swift */; };
 		995BF7162CE7EB2600454076 /* SipUserCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995BF7152CE7EB2200454076 /* SipUserCredential.swift */; };
 		995BF71C2CE7EC0600454076 /* SipCredentialsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995BF71A2CE7EBF800454076 /* SipCredentialsManager.swift */; };
+		995BF7202CE8175B00454076 /* SipCredentialsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995BF71F2CE8175200454076 /* SipCredentialsViewController.swift */; };
+		995BF7222CE818A400454076 /* SipCredentialsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 995BF7212CE818A400454076 /* SipCredentialsViewController.xib */; };
 		B309D13D25EF119E00A2AADF /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B309D11125EF107F00A2AADF /* Starscream.framework */; };
 		B309D1D625F020B300A2AADF /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D1D525F020B300A2AADF /* Message.swift */; };
 		B309D1DB25F020D400A2AADF /* Method.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D1DA25F020D400A2AADF /* Method.swift */; };
@@ -140,6 +142,8 @@
 		995BF7122CE7E8EB00454076 /* WebRTCEnvironmentExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRTCEnvironmentExtension.swift; sourceTree = "<group>"; };
 		995BF7152CE7EB2200454076 /* SipUserCredential.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SipUserCredential.swift; sourceTree = "<group>"; };
 		995BF71A2CE7EBF800454076 /* SipCredentialsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SipCredentialsManager.swift; sourceTree = "<group>"; };
+		995BF71F2CE8175200454076 /* SipCredentialsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SipCredentialsViewController.swift; sourceTree = "<group>"; };
+		995BF7212CE818A400454076 /* SipCredentialsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SipCredentialsViewController.xib; sourceTree = "<group>"; };
 		A7CE9BEFEDE503E7BC7BE3C8 /* Pods_TelnyxWebRTCDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxWebRTCDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B309D11125EF107F00A2AADF /* Starscream.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Starscream.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B309D1D525F020B300A2AADF /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
@@ -267,6 +271,15 @@
 			path = Managers;
 			sourceTree = "<group>";
 		};
+		995BF71E2CE8174B00454076 /* ViewControllers */ = {
+			isa = PBXGroup;
+			children = (
+				995BF71F2CE8175200454076 /* SipCredentialsViewController.swift */,
+				995BF7212CE818A400454076 /* SipCredentialsViewController.xib */,
+			);
+			path = ViewControllers;
+			sourceTree = "<group>";
+		};
 		B309D1D425F020A300A2AADF /* Verto */ = {
 			isa = PBXGroup;
 			children = (
@@ -391,6 +404,7 @@
 				995BF7142CE7EB0B00454076 /* Models */,
 				B3E1032F25F7F93000227DCE /* Resources */,
 				B309D1FB25F028F100A2AADF /* Views */,
+				995BF71E2CE8174B00454076 /* ViewControllers */,
 				B3AF24A825EE84410062EDA9 /* Extensions */,
 				B368BEEA25EDDD060032AE52 /* AppDelegate.swift */,
 				B368BEEE25EDDD060032AE52 /* ViewController.swift */,
@@ -643,6 +657,7 @@
 				B368BEF425EDDD070032AE52 /* Assets.xcassets in Resources */,
 				B3E1033325F7F94900227DCE /* ringback_tone.mp3 in Resources */,
 				B368BEF225EDDD060032AE52 /* Main.storyboard in Resources */,
+				995BF7222CE818A400454076 /* SipCredentialsViewController.xib in Resources */,
 				B309D24E25F0717B00A2AADF /* UICallScreen.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -813,6 +828,7 @@
 				B3B1D9A426545807008D28C9 /* UserDefaultExtension.swift in Sources */,
 				B32AE8BB26D6952500C7C6F4 /* AppDelegateCallKitExtension.swift in Sources */,
 				B3AF24AA25EE84570062EDA9 /* UIViewControllerExtension.swift in Sources */,
+				995BF7202CE8175B00454076 /* SipCredentialsViewController.swift in Sources */,
 				B309D25325F071DD00A2AADF /* UICallScreen.swift in Sources */,
 				B3B8F53726E7D4EF0007B583 /* AppDelegateTelnyxVoIPExtension.swift in Sources */,
 				B309D27B25F17C1700A2AADF /* UIIncomingCallView.swift in Sources */,

--- a/TelnyxRTC.xcodeproj/project.pbxproj
+++ b/TelnyxRTC.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		995BF71C2CE7EC0600454076 /* SipCredentialsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995BF71A2CE7EBF800454076 /* SipCredentialsManager.swift */; };
 		995BF7202CE8175B00454076 /* SipCredentialsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995BF71F2CE8175200454076 /* SipCredentialsViewController.swift */; };
 		995BF7222CE818A400454076 /* SipCredentialsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 995BF7212CE818A400454076 /* SipCredentialsViewController.xib */; };
+		995BF7242CE8474A00454076 /* UISipCredentialHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995BF7232CE8471B00454076 /* UISipCredentialHeaderView.swift */; };
 		B309D13D25EF119E00A2AADF /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B309D11125EF107F00A2AADF /* Starscream.framework */; };
 		B309D1D625F020B300A2AADF /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D1D525F020B300A2AADF /* Message.swift */; };
 		B309D1DB25F020D400A2AADF /* Method.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D1DA25F020D400A2AADF /* Method.swift */; };
@@ -144,6 +145,7 @@
 		995BF71A2CE7EBF800454076 /* SipCredentialsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SipCredentialsManager.swift; sourceTree = "<group>"; };
 		995BF71F2CE8175200454076 /* SipCredentialsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SipCredentialsViewController.swift; sourceTree = "<group>"; };
 		995BF7212CE818A400454076 /* SipCredentialsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SipCredentialsViewController.xib; sourceTree = "<group>"; };
+		995BF7232CE8471B00454076 /* UISipCredentialHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UISipCredentialHeaderView.swift; sourceTree = "<group>"; };
 		A7CE9BEFEDE503E7BC7BE3C8 /* Pods_TelnyxWebRTCDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxWebRTCDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B309D11125EF107F00A2AADF /* Starscream.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Starscream.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B309D1D525F020B300A2AADF /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
@@ -317,6 +319,7 @@
 		B309D1FB25F028F100A2AADF /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				995BF7232CE8471B00454076 /* UISipCredentialHeaderView.swift */,
 				B309D27A25F17C1700A2AADF /* UIIncomingCallView.xib */,
 				B309D27925F17C1700A2AADF /* UIIncomingCallView.swift */,
 				B309D1FC25F0291100A2AADF /* UISettingsView.xib */,
@@ -827,6 +830,7 @@
 				995BF7132CE7E8F100454076 /* WebRTCEnvironmentExtension.swift in Sources */,
 				B3B1D9A426545807008D28C9 /* UserDefaultExtension.swift in Sources */,
 				B32AE8BB26D6952500C7C6F4 /* AppDelegateCallKitExtension.swift in Sources */,
+				995BF7242CE8474A00454076 /* UISipCredentialHeaderView.swift in Sources */,
 				B3AF24AA25EE84570062EDA9 /* UIViewControllerExtension.swift in Sources */,
 				995BF7202CE8175B00454076 /* SipCredentialsViewController.swift in Sources */,
 				B309D25325F071DD00A2AADF /* UICallScreen.swift in Sources */,

--- a/TelnyxRTC.xcodeproj/project.pbxproj
+++ b/TelnyxRTC.xcodeproj/project.pbxproj
@@ -21,6 +21,9 @@
 		3BC03B592CC2653700FD2B29 /* TelnyxRTC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B368BEC025EDDB610032AE52 /* TelnyxRTC.framework */; };
 		3BC03B5E2CC2659500FD2B29 /* Pods_TelnyxRTC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A11DAA0171B02D67683620E /* Pods_TelnyxRTC.framework */; };
 		3BF1D5842BEB7B8F0097453F /* TelnyxRTC.podspec in Resources */ = {isa = PBXBuildFile; fileRef = 3BF1D5832BEB7B8F0097453F /* TelnyxRTC.podspec */; };
+		995BF7132CE7E8F100454076 /* WebRTCEnvironmentExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995BF7122CE7E8EB00454076 /* WebRTCEnvironmentExtension.swift */; };
+		995BF7162CE7EB2600454076 /* SipUserCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995BF7152CE7EB2200454076 /* SipUserCredential.swift */; };
+		995BF71C2CE7EC0600454076 /* SipCredentialsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995BF71A2CE7EBF800454076 /* SipCredentialsManager.swift */; };
 		B309D13D25EF119E00A2AADF /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B309D11125EF107F00A2AADF /* Starscream.framework */; };
 		B309D1D625F020B300A2AADF /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D1D525F020B300A2AADF /* Message.swift */; };
 		B309D1DB25F020D400A2AADF /* Method.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D1DA25F020D400A2AADF /* Method.swift */; };
@@ -134,6 +137,9 @@
 		65B0B19B5206EECCAE2E29CA /* Pods_TelnyxRTC_TelnyxRTCTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxRTC_TelnyxRTCTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		711958501DD45FDFBD112FC6 /* Pods-TelnyxRTC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC.debug.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC/Pods-TelnyxRTC.debug.xcconfig"; sourceTree = "<group>"; };
 		8A11DAA0171B02D67683620E /* Pods_TelnyxRTC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxRTC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		995BF7122CE7E8EB00454076 /* WebRTCEnvironmentExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRTCEnvironmentExtension.swift; sourceTree = "<group>"; };
+		995BF7152CE7EB2200454076 /* SipUserCredential.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SipUserCredential.swift; sourceTree = "<group>"; };
+		995BF71A2CE7EBF800454076 /* SipCredentialsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SipCredentialsManager.swift; sourceTree = "<group>"; };
 		A7CE9BEFEDE503E7BC7BE3C8 /* Pods_TelnyxWebRTCDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxWebRTCDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B309D11125EF107F00A2AADF /* Starscream.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Starscream.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B309D1D525F020B300A2AADF /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
@@ -243,6 +249,22 @@
 				4DE56344987C90A16F102652 /* Pods-TelnyxWebRTCDemo.release.xcconfig */,
 			);
 			path = Pods;
+			sourceTree = "<group>";
+		};
+		995BF7142CE7EB0B00454076 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				995BF7152CE7EB2200454076 /* SipUserCredential.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		995BF71D2CE7EC5000454076 /* Managers */ = {
+			isa = PBXGroup;
+			children = (
+				995BF71A2CE7EBF800454076 /* SipCredentialsManager.swift */,
+			);
+			path = Managers;
 			sourceTree = "<group>";
 		};
 		B309D1D425F020A300A2AADF /* Verto */ = {
@@ -365,6 +387,8 @@
 			isa = PBXGroup;
 			children = (
 				B3B1D9A22654546E008D28C9 /* TelnyxWebRTCDemo.entitlements */,
+				995BF71D2CE7EC5000454076 /* Managers */,
+				995BF7142CE7EB0B00454076 /* Models */,
 				B3E1032F25F7F93000227DCE /* Resources */,
 				B309D1FB25F028F100A2AADF /* Views */,
 				B3AF24A825EE84410062EDA9 /* Extensions */,
@@ -440,6 +464,7 @@
 		B3AF24A825EE84410062EDA9 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				995BF7122CE7E8EB00454076 /* WebRTCEnvironmentExtension.swift */,
 				B3AF24A925EE84570062EDA9 /* UIViewControllerExtension.swift */,
 				B3B1D9A326545807008D28C9 /* UserDefaultExtension.swift */,
 				B32AE8BE26D6D69E00C7C6F4 /* ViewControllerVoIPExtension.swift */,
@@ -784,6 +809,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				995BF7132CE7E8F100454076 /* WebRTCEnvironmentExtension.swift in Sources */,
 				B3B1D9A426545807008D28C9 /* UserDefaultExtension.swift in Sources */,
 				B32AE8BB26D6952500C7C6F4 /* AppDelegateCallKitExtension.swift in Sources */,
 				B3AF24AA25EE84570062EDA9 /* UIViewControllerExtension.swift in Sources */,
@@ -791,6 +817,8 @@
 				B3B8F53726E7D4EF0007B583 /* AppDelegateTelnyxVoIPExtension.swift in Sources */,
 				B309D27B25F17C1700A2AADF /* UIIncomingCallView.swift in Sources */,
 				B368BEEF25EDDD060032AE52 /* ViewController.swift in Sources */,
+				995BF7162CE7EB2600454076 /* SipUserCredential.swift in Sources */,
+				995BF71C2CE7EC0600454076 /* SipCredentialsManager.swift in Sources */,
 				B368BEEB25EDDD060032AE52 /* AppDelegate.swift in Sources */,
 				B309D20225F0291B00A2AADF /* UISettingsView.swift in Sources */,
 				B32AE8BF26D6D69E00C7C6F4 /* ViewControllerVoIPExtension.swift in Sources */,

--- a/TelnyxWebRTCDemo/AppDelegate.swift
+++ b/TelnyxWebRTCDemo/AppDelegate.swift
@@ -106,7 +106,7 @@ extension AppDelegate: PKPushRegistryDelegate {
             // Store incoming token in user defaults
             let userDefaults = UserDefaults.standard
             let deviceToken = credentials.token.reduce("", {$0 + String(format: "%02X", $1) })
-            userDefaults.savePushToken(pushToken: deviceToken)
+            userDefaults.savePushToken(deviceToken)
             print("Device push token: \(deviceToken)")
         }
     }

--- a/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
@@ -228,8 +228,9 @@ extension AppDelegate : CXProviderDelegate {
             serverConfig = TxServerConfiguration(environment: .production)
         }
         
-        let sipUser = userDefaults.getSipUser()
-        let password = userDefaults.getSipUserPassword()
+        let selectedCredentials = SipCredentialsManager.shared.getSelectedCredential()
+        let sipUser = selectedCredentials?.username ?? ""
+        let password = selectedCredentials?.password ?? ""
         let deviceToken = userDefaults.getPushToken()
         //Sets the login credentials and the ringtone/ringback configurations if required.
         //Ringtone / ringback tone files are not mandatory.

--- a/TelnyxWebRTCDemo/Extensions/UserDefaultExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/UserDefaultExtension.swift
@@ -8,63 +8,60 @@
 import Foundation
 import TelnyxRTC
 
-fileprivate let PUSH_DEVICE_TOKEN = ""
-
-fileprivate let SIP_USER = "SIP_USER"
-fileprivate let SIP_USER_PASSWORD = "SIP_USER_PASSWORD"
-fileprivate let CALL_DESTINATION = "CALL_DESTINATION"
-fileprivate let WEBRTC_ENVIRONMENT = "WEBRTC_ENVIRONMENT"
+enum UserDefaultsKey: String {
+    case pushDeviceToken = "PUSH_DEVICE_TOKEN"
+    case sipUser = "SIP_USER"
+    case sipUserPassword = "SIP_USER_PASSWORD"
+    case callDestination = "CALL_DESTINATION"
+    case webrtcEnvironment = "WEBRTC_ENVIRONMENT"
+}
 
 extension UserDefaults {
-
-    func savePushToken(pushToken: String) {
-        let userDefaults = UserDefaults.standard
-        userDefaults.set(pushToken, forKey: PUSH_DEVICE_TOKEN)
-        userDefaults.synchronize()
+    
+    // MARK: - Push Token
+    func savePushToken(_ pushToken: String) {
+        set(pushToken, forKey: UserDefaultsKey.pushDeviceToken.rawValue)
     }
-
+    
     func deletePushToken() {
-        let userDefaults = UserDefaults.standard
-        userDefaults.removeObject(forKey: PUSH_DEVICE_TOKEN)
-        userDefaults.synchronize()
+        removeObject(forKey: UserDefaultsKey.pushDeviceToken.rawValue)
     }
-
+    
     func getPushToken() -> String {
-        let userDefaults = UserDefaults.standard
-        return userDefaults.string(forKey: PUSH_DEVICE_TOKEN) ?? ""
+        return string(forKey: UserDefaultsKey.pushDeviceToken.rawValue) ?? ""
     }
-
+    
+    // MARK: - SIP User
     func saveUser(sipUser: String, password: String) {
-        let userDefaults = UserDefaults.standard
-        userDefaults.set(sipUser, forKey: SIP_USER)
-        userDefaults.set(password, forKey: SIP_USER_PASSWORD)
-        userDefaults.synchronize()
+        set(sipUser, forKey: UserDefaultsKey.sipUser.rawValue)
+        set(password, forKey: UserDefaultsKey.sipUserPassword.rawValue)
     }
-
-    func saveCallDestination(callDestination: String) {
-        let userDefaults = UserDefaults.standard
-        userDefaults.set(callDestination, forKey: CALL_DESTINATION)
-        userDefaults.synchronize()
-    }
-
+    
     func getSipUser() -> String {
-        let userDefaults = UserDefaults.standard
-        return userDefaults.string(forKey: SIP_USER) ?? ""
+        return string(forKey: UserDefaultsKey.sipUser.rawValue) ?? ""
     }
-
+    
     func getSipUserPassword() -> String {
-        let userDefaults = UserDefaults.standard
-        return userDefaults.string(forKey: SIP_USER_PASSWORD) ?? ""
+        return string(forKey: UserDefaultsKey.sipUserPassword.rawValue) ?? ""
     }
-
-    func saveEnvironment(environment: WebRTCEnvironment) {
-        let userDefaults = UserDefaults.standard
-        userDefaults.set((environment == .development) ? "development" : "production", forKey: WEBRTC_ENVIRONMENT)
-        userDefaults.synchronize()
+    
+    // MARK: - Call Destination
+    func saveCallDestination(_ callDestination: String) {
+        set(callDestination, forKey: UserDefaultsKey.callDestination.rawValue)
     }
-
+    
+    func getCallDestination() -> String {
+        return string(forKey: UserDefaultsKey.callDestination.rawValue) ?? ""
+    }
+    
     func getEnvironment() -> WebRTCEnvironment {
-        let userDefaults = UserDefaults.standard
-        return (userDefaults.string(forKey: WEBRTC_ENVIRONMENT) == "development") ? .development : .production
+        let value = string(forKey: UserDefaultsKey.webrtcEnvironment.rawValue) ?? ""
+        return WebRTCEnvironment.fromString(value)
+    }
+    
+    func saveEnvironment(_ environment: WebRTCEnvironment) {
+        let value = environment.toString()
+        set(value, forKey: UserDefaultsKey.webrtcEnvironment.rawValue)
     }
 }
+

--- a/TelnyxWebRTCDemo/Extensions/UserDefaultExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/UserDefaultExtension.swift
@@ -9,9 +9,9 @@ import Foundation
 import TelnyxRTC
 
 enum UserDefaultsKey: String {
+    case selectedSipCredential = "SELECTED_SIP_CREDENTIAL"
+    case sipCredentials = "SIP_CREDENTIALS"
     case pushDeviceToken = "PUSH_DEVICE_TOKEN"
-    case sipUser = "SIP_USER"
-    case sipUserPassword = "SIP_USER_PASSWORD"
     case callDestination = "CALL_DESTINATION"
     case webrtcEnvironment = "WEBRTC_ENVIRONMENT"
 }
@@ -31,21 +31,6 @@ extension UserDefaults {
         return string(forKey: UserDefaultsKey.pushDeviceToken.rawValue) ?? ""
     }
     
-    // MARK: - SIP User
-    func saveUser(sipUser: String, password: String) {
-        set(sipUser, forKey: UserDefaultsKey.sipUser.rawValue)
-        set(password, forKey: UserDefaultsKey.sipUserPassword.rawValue)
-    }
-    
-    func getSipUser() -> String {
-        return string(forKey: UserDefaultsKey.sipUser.rawValue) ?? ""
-    }
-    
-    func getSipUserPassword() -> String {
-        return string(forKey: UserDefaultsKey.sipUserPassword.rawValue) ?? ""
-    }
-    
-    // MARK: - Call Destination
     func saveCallDestination(_ callDestination: String) {
         set(callDestination, forKey: UserDefaultsKey.callDestination.rawValue)
     }

--- a/TelnyxWebRTCDemo/Extensions/ViewControllerVoIPExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/ViewControllerVoIPExtension.swift
@@ -61,7 +61,7 @@ extension ViewController : VoIPDelegate {
         print("ViewController:: TxClientDelegate onClientError() error: \(error)")
         let noActiveCalls = self.telnyxClient?.calls.filter { $0.value.callState == .ACTIVE || $0.value.callState == .HELD }.isEmpty
         
-        if(noActiveCalls != true){
+        if noActiveCalls != true {
             return
         }
         
@@ -70,13 +70,14 @@ extension ViewController : VoIPDelegate {
             self.incomingCallView.isHidden = true
             self.appDelegate.executeEndCallAction(uuid: UUID());
             
-            if(error.self is NWError){
+            if error.self is NWError {
                 print("ERROR: socket connectiontion error \(error)")
             } else {
                 print("ERROR: client error \(error)")
             }
-           
         }
+        
+        self.telnyxClient?.disconnect()
     }
     
     func onClientReady() {
@@ -86,7 +87,7 @@ extension ViewController : VoIPDelegate {
             self.socketStateLabel.text = "Client ready"
             self.settingsView.isHidden = true
             self.callView.isHidden = false
-            if(!self.incomingCall){
+            if !self.incomingCall {
                 self.incomingCallView.isHidden = true
             }
         }

--- a/TelnyxWebRTCDemo/Extensions/WebRTCEnvironmentExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/WebRTCEnvironmentExtension.swift
@@ -1,0 +1,24 @@
+import TelnyxRTC
+
+extension WebRTCEnvironment {
+
+    func toString() -> String {
+        switch self {
+            case .development:
+                return "development"
+            case .production:
+                return "production"
+        }
+    }
+
+    static func fromString(_ value: String) -> WebRTCEnvironment {
+        switch value {
+            case "development":
+                return .development
+            case "production":
+                return .production
+            default:
+                return .production
+        }
+    }
+}

--- a/TelnyxWebRTCDemo/Managers/SipCredentialsManager.swift
+++ b/TelnyxWebRTCDemo/Managers/SipCredentialsManager.swift
@@ -1,0 +1,71 @@
+import Foundation
+import TelnyxRTC
+
+class SipCredentialsManager {
+    
+    // Get the current environment
+    private static func currentEnvironment() -> WebRTCEnvironment {
+        return UserDefaults.standard.getEnvironment()
+    }
+    
+    // Generate the key for credentials based on the environment
+    private static func credentialsKey(for environment: WebRTCEnvironment) -> String {
+        return "\(UserDefaultsKey.sipUser.rawValue)_\(environment.toString())"
+    }
+    
+    // Get credentials for the current environment
+    static func getCredentials() -> [SipCredential] {
+        let environment = currentEnvironment()
+        let key = credentialsKey(for: environment)
+        guard let data = UserDefaults.standard.data(forKey: key),
+              let credentials = try? JSONDecoder().decode([SipCredential].self, from: data) else {
+            return []
+        }
+        return credentials
+    }
+    
+    // Save credentials for the current environment
+    static func saveCredentials(_ credentials: [SipCredential]) {
+        let environment = currentEnvironment()
+        let key = credentialsKey(for: environment)
+        if let encoded = try? JSONEncoder().encode(credentials) {
+            UserDefaults.standard.set(encoded, forKey: key)
+        }
+    }
+    
+    // Add a new credential
+    static func addCredential(_ credential: SipCredential) {
+        var credentials = getCredentials()
+        
+        // Check if the username already exists
+        if credentials.contains(where: { $0.username == credential.username }) {
+            print("User already exists. Cannot add.")
+            return
+        }
+        
+        credentials.append(credential)
+        saveCredentials(credentials)
+    }
+    
+    // Update an existing credential
+    static func updateCredential(_ credential: SipCredential) {
+        var credentials = getCredentials()
+        
+        // Find the index of the existing credential by username
+        if let index = credentials.firstIndex(where: { $0.username == credential.username }) {
+            credentials[index] = credential
+            saveCredentials(credentials)
+        } else {
+            print("User not found. Cannot update.")
+        }
+    }
+    
+    // Remove a credential by username
+    static func removeCredential(username: String) {
+        var credentials = getCredentials()
+        
+        // Remove the credential with the matching username
+        credentials.removeAll { $0.username == username }
+        saveCredentials(credentials)
+    }
+}

--- a/TelnyxWebRTCDemo/Managers/SipCredentialsManager.swift
+++ b/TelnyxWebRTCDemo/Managers/SipCredentialsManager.swift
@@ -70,6 +70,12 @@ class SipCredentialsManager {
         
         // Remove the credential with the matching username
         credentials.removeAll { $0.username == username }
+        
+        if let selectedCredential = getSelectedCredential(),
+           selectedCredential.username == username {
+            // If it matches, remove the selected credential
+            removeSelectedCredential()
+        }
         saveCredentials(credentials)
     }
     
@@ -110,5 +116,9 @@ extension SipCredentialsManager {
             credentials.append(credential)
             saveCredentials(credentials)
         }
+    }
+    
+    func removeSelectedCredential() {
+        UserDefaults.standard.removeObject(forKey: SipCredentialsManager.selectedCredentialKey(for: SipCredentialsManager.currentEnvironment()))
     }
 }

--- a/TelnyxWebRTCDemo/Managers/SipCredentialsManager.swift
+++ b/TelnyxWebRTCDemo/Managers/SipCredentialsManager.swift
@@ -37,31 +37,22 @@ class SipCredentialsManager {
         }
     }
     
-    // Add a new credential
-    func addCredential(_ credential: SipCredential) {
+    func addOrUpdateCredential(_ credential: SipCredential) {
         var credentials = getCredentials()
         
-        // Check if the username already exists
-        if credentials.contains(where: { $0.username == credential.username }) {
-            print("User already exists. Cannot add.")
-            return
-        }
-        
-        credentials.append(credential)
-        saveCredentials(credentials)
-    }
-    
-    // Update an existing credential
-    func updateCredential(_ credential: SipCredential) {
-        var credentials = getCredentials()
-        
-        // Find the index of the existing credential by username
+        // Verificar si ya existe una credencial con el mismo username
         if let index = credentials.firstIndex(where: { $0.username == credential.username }) {
+            // Actualizar la credencial existente con el nuevo password
             credentials[index] = credential
-            saveCredentials(credentials)
+            print("User already exists. Updating the password.")
         } else {
-            print("User not found. Cannot update.")
+            // Agregar la nueva credencial si no existe
+            credentials.append(credential)
+            print("Adding new user credential.")
         }
+        
+        // Guardar las credenciales actualizadas
+        saveCredentials(credentials)
     }
     
     // Remove a credential by username

--- a/TelnyxWebRTCDemo/Models/SipUserCredential.swift
+++ b/TelnyxWebRTCDemo/Models/SipUserCredential.swift
@@ -1,0 +1,5 @@
+
+struct SipCredential: Codable, Equatable {
+    let username: String
+    let password: String
+}

--- a/TelnyxWebRTCDemo/ViewController.swift
+++ b/TelnyxWebRTCDemo/ViewController.swift
@@ -93,10 +93,6 @@ class ViewController: UIViewController {
         self.settingsView.isHidden = false
         self.settingsView.delegate = self
         
-        let selectedCredentials = SipCredentialsManager.shared.getSelectedCredential()
-        self.settingsView.sipUsernameLabel.text = selectedCredentials?.username ?? ""
-        self.settingsView.passwordUserNameLabel.text = selectedCredentials?.password ?? ""
-
         // Environment Selector
         let longPressRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(self.handleLongPress))
         self.logo.addGestureRecognizer(longPressRecognizer)
@@ -113,6 +109,14 @@ class ViewController: UIViewController {
                  print("Reachable via Cellular")
              }
          }
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        let selectedCredentials = SipCredentialsManager.shared.getSelectedCredential()
+        self.settingsView.sipUsernameLabel.text = selectedCredentials?.username ?? ""
+        self.settingsView.passwordUserNameLabel.text = selectedCredentials?.password ?? ""
     }
     
     @objc func handleLongPress(gesture: UILongPressGestureRecognizer) {
@@ -311,9 +315,19 @@ extension ViewController : UICallScreenDelegate {
 }
 
 // MARK: - UISettingsViewProtocol
-extension ViewController: UISettingsViewProtocol {
+extension ViewController: UISettingsViewDelegate {
     func onOpenSipSelector() {
         let sipCredentialsVC = SipCredentialsViewController()
+        sipCredentialsVC.delegate = self
         self.present(sipCredentialsVC, animated: true, completion: nil)
+    }
+}
+
+// MARK: - SipCredentialsViewControllerDelegate
+extension ViewController: SipCredentialsViewControllerDelegate {
+
+    func onSipCredentialSelected(credential: SipCredential) {
+        self.settingsView.sipUsernameLabel.text = credential.username
+        self.settingsView.passwordUserNameLabel.text = credential.password
     }
 }

--- a/TelnyxWebRTCDemo/ViewController.swift
+++ b/TelnyxWebRTCDemo/ViewController.swift
@@ -159,10 +159,15 @@ class ViewController: UIViewController {
 
     func updateEnvironment() {
         DispatchQueue.main.async {
-            let plistInfo = Bundle(for: TxClient.self).infoDictionary?["CFBundleShortVersionString"] as? String
-            
-            self.environment.text = (self.serverConfig?.environment == .development) ? "Development" : "Production " +
-            (plistInfo ?? "")
+            // Update selected credentials in UI after switching environment
+            let credentials = SipCredentialsManager.shared.getSelectedCredential()
+            self.onSipCredentialSelected(credential: credentials)
+
+            let sdkVersion = Bundle(for: TxClient.self).infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+            let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+
+            let env = self.serverConfig?.environment == .development ? "Development" : "Production "
+            self.environment.text = "\(env) TelnyxSDK [v\(sdkVersion)] - App [v\(appVersion)]"
         }
     }
 

--- a/TelnyxWebRTCDemo/ViewController.swift
+++ b/TelnyxWebRTCDemo/ViewController.swift
@@ -222,7 +222,7 @@ class ViewController: UIViewController {
 
                 //store user / password in user defaults
                 let selectedCredential = SipCredential(username: sipUser, password: password)
-                SipCredentialsManager.shared.addCredential(selectedCredential)
+                SipCredentialsManager.shared.addOrUpdateCredential(selectedCredential)
                 SipCredentialsManager.shared.saveSelectedCredential(selectedCredential)
                 self.settingsView.selectCredentialButton.isHidden = false
             }

--- a/TelnyxWebRTCDemo/ViewController.swift
+++ b/TelnyxWebRTCDemo/ViewController.swift
@@ -92,8 +92,10 @@ class ViewController: UIViewController {
         // Restore last user credentials
         self.settingsView.isHidden = false
         self.settingsView.delegate = self
-        self.settingsView.sipUsernameLabel.text = userDefaults.getSipUser()
-        self.settingsView.passwordUserNameLabel.text = userDefaults.getSipUserPassword()
+        
+        let selectedCredentials = SipCredentialsManager.shared.getSelectedCredential()
+        self.settingsView.sipUsernameLabel.text = selectedCredentials?.username ?? ""
+        self.settingsView.passwordUserNameLabel.text = selectedCredentials?.password ?? ""
 
         // Environment Selector
         let longPressRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(self.handleLongPress))
@@ -209,7 +211,9 @@ class ViewController: UIViewController {
                 )
 
                 //store user / password in user defaults
-                userDefaults.saveUser(sipUser: sipUser, password: password)
+                let selectedCredential = SipCredential(username: sipUser, password: password)
+                SipCredentialsManager.shared.addCredential(selectedCredential)
+                SipCredentialsManager.shared.saveSelectedCredential(selectedCredential)
             }
 
             do {

--- a/TelnyxWebRTCDemo/ViewController.swift
+++ b/TelnyxWebRTCDemo/ViewController.swift
@@ -123,13 +123,13 @@ class ViewController: UIViewController {
         let alert = UIAlertController(title: "Options", message: "", preferredStyle: .actionSheet)
         alert.addAction(UIAlertAction(title: "Development Environment", style: .default , handler:{ (UIAlertAction)in
             self.serverConfig = TxServerConfiguration(environment: .development)
-            self.userDefaults.saveEnvironment(environment: .development)
+            self.userDefaults.saveEnvironment(.development)
             self.updateEnvironment()
         }))
         
         alert.addAction(UIAlertAction(title: "Production Environment", style: .default , handler:{ (UIAlertAction)in
             self.serverConfig = nil
-            self.userDefaults.saveEnvironment(environment: .production)
+            self.userDefaults.saveEnvironment(.production)
             self.updateEnvironment()
         }))
 

--- a/TelnyxWebRTCDemo/ViewController.swift
+++ b/TelnyxWebRTCDemo/ViewController.swift
@@ -91,6 +91,7 @@ class ViewController: UIViewController {
 
         // Restore last user credentials
         self.settingsView.isHidden = false
+        self.settingsView.delegate = self
         self.settingsView.sipUsernameLabel.text = userDefaults.getSipUser()
         self.settingsView.passwordUserNameLabel.text = userDefaults.getSipUserPassword()
 
@@ -302,5 +303,13 @@ extension ViewController : UICallScreenDelegate {
         } else {
             self.telnyxClient?.setEarpiece()
         }
+    }
+}
+
+// MARK: - UISettingsViewProtocol
+extension ViewController: UISettingsViewProtocol {
+    func onOpenSipSelector() {
+        let sipCredentialsVC = SipCredentialsViewController()
+        self.present(sipCredentialsVC, animated: true, completion: nil)
     }
 }

--- a/TelnyxWebRTCDemo/ViewController.swift
+++ b/TelnyxWebRTCDemo/ViewController.swift
@@ -326,8 +326,8 @@ extension ViewController: UISettingsViewDelegate {
 // MARK: - SipCredentialsViewControllerDelegate
 extension ViewController: SipCredentialsViewControllerDelegate {
 
-    func onSipCredentialSelected(credential: SipCredential) {
-        self.settingsView.sipUsernameLabel.text = credential.username
-        self.settingsView.passwordUserNameLabel.text = credential.password
+    func onSipCredentialSelected(credential: SipCredential?) {
+        self.settingsView.sipUsernameLabel.text = credential?.username ?? ""
+        self.settingsView.passwordUserNameLabel.text = credential?.password ?? ""
     }
 }

--- a/TelnyxWebRTCDemo/ViewController.swift
+++ b/TelnyxWebRTCDemo/ViewController.swift
@@ -117,6 +117,12 @@ class ViewController: UIViewController {
         let selectedCredentials = SipCredentialsManager.shared.getSelectedCredential()
         self.settingsView.sipUsernameLabel.text = selectedCredentials?.username ?? ""
         self.settingsView.passwordUserNameLabel.text = selectedCredentials?.password ?? ""
+        
+        if SipCredentialsManager.shared.getCredentials().isEmpty {
+            self.settingsView.selectCredentialButton.isHidden = true
+        } else {
+            self.settingsView.selectCredentialButton.isHidden = false
+        }
     }
     
     @objc func handleLongPress(gesture: UILongPressGestureRecognizer) {
@@ -218,6 +224,7 @@ class ViewController: UIViewController {
                 let selectedCredential = SipCredential(username: sipUser, password: password)
                 SipCredentialsManager.shared.addCredential(selectedCredential)
                 SipCredentialsManager.shared.saveSelectedCredential(selectedCredential)
+                self.settingsView.selectCredentialButton.isHidden = false
             }
 
             do {
@@ -329,5 +336,12 @@ extension ViewController: SipCredentialsViewControllerDelegate {
     func onSipCredentialSelected(credential: SipCredential?) {
         self.settingsView.sipUsernameLabel.text = credential?.username ?? ""
         self.settingsView.passwordUserNameLabel.text = credential?.password ?? ""
+        
+        
+        if SipCredentialsManager.shared.getCredentials().isEmpty {
+            self.settingsView.selectCredentialButton.isHidden = true
+        } else {
+            self.settingsView.selectCredentialButton.isHidden = false
+        }
     }
 }

--- a/TelnyxWebRTCDemo/ViewControllers/SipCredentialsViewController.swift
+++ b/TelnyxWebRTCDemo/ViewControllers/SipCredentialsViewController.swift
@@ -1,8 +1,10 @@
 import UIKit
 
 class SipCredentialsViewController: UIViewController {
-        
+    
     @IBOutlet weak var tableView: UITableView!
+    
+    private var credentialsList: [SipCredential] = []
     
     init() {
         super.init(nibName: "SipCredentialsViewController", bundle: nil)
@@ -11,21 +13,50 @@ class SipCredentialsViewController: UIViewController {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
-        
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Additional setup if needed
+        setupTableView()
+        loadCredentials()
+    }
+    
+    private func setupTableView() {
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "SipCredentialCell")
+    }
+    
+    private func loadCredentials() {
+        // Fetch credentials for the current environment
+        credentialsList = SipCredentialsManager.shared.getCredentials()
+        tableView.reloadData()
     }
 }
 
-extension SipCredentialsViewController: UITableViewDataSource, UITableViewDelegate {
+// MARK: - UITableViewDataSource
+extension SipCredentialsViewController: UITableViewDataSource {
+    
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 0
+        return credentialsList.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        return UITableViewCell()
+        let cell = tableView.dequeueReusableCell(withIdentifier: "SipCredentialCell", for: indexPath)
+        let credential = credentialsList[indexPath.row]
+        
+        // Configure the cell
+        cell.textLabel?.text = "User: \(credential.username)"
+        cell.detailTextLabel?.text = "Password: \(credential.password)"
+        cell.selectionStyle = .none
+        
+        return cell
     }
-    
-    
+}
+
+// MARK: - UITableViewDelegate
+extension SipCredentialsViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let selectedCredential = credentialsList[indexPath.row]
+        print("Selected User: \(selectedCredential.username)")
+    }
 }

--- a/TelnyxWebRTCDemo/ViewControllers/SipCredentialsViewController.swift
+++ b/TelnyxWebRTCDemo/ViewControllers/SipCredentialsViewController.swift
@@ -86,7 +86,7 @@ extension SipCredentialsViewController: UITableViewDataSource {
         let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: "UISipCredentialHeaderView") as! UISipCredentialHeaderView
         let environment = UserDefaults.standard.getEnvironment().toString()
         headerView.configure(title: "SIP Credentials", subtitle: "\(environment)")
-
+        
         return headerView
     }
     
@@ -134,18 +134,32 @@ extension SipCredentialsViewController: UITableViewDelegate {
 
 // MARK: - Extension for UITableView Empty Message
 extension UITableView {
+
     func setEmptyMessage(_ message: String) {
         let messageLabel = UILabel()
         messageLabel.text = message
-        messageLabel.textAlignment = .center
-        messageLabel.font = UIFont.systemFont(ofSize: 17, weight: .medium)
-        messageLabel.textColor = .lightGray
+        messageLabel.textColor = .gray
         messageLabel.numberOfLines = 0
+        messageLabel.textAlignment = .center
+        messageLabel.font = UIFont.systemFont(ofSize: 16, weight: .regular)
+        
+        let containerView = UIView()
+        containerView.addSubview(messageLabel)
+        
         messageLabel.translatesAutoresizingMaskIntoConstraints = false
-        backgroundView = messageLabel
+        NSLayoutConstraint.activate([
+            messageLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 30),
+            messageLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -30),
+            messageLabel.topAnchor.constraint(equalTo: containerView.topAnchor),
+            messageLabel.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
+        ])
+        
+        self.backgroundView = containerView
+        self.layoutIfNeeded()
+
     }
     
     func restore() {
-        backgroundView = nil
+        self.backgroundView = nil
     }
 }

--- a/TelnyxWebRTCDemo/ViewControllers/SipCredentialsViewController.swift
+++ b/TelnyxWebRTCDemo/ViewControllers/SipCredentialsViewController.swift
@@ -1,0 +1,31 @@
+import UIKit
+
+class SipCredentialsViewController: UIViewController {
+        
+    @IBOutlet weak var tableView: UITableView!
+    
+    init() {
+        super.init(nibName: "SipCredentialsViewController", bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+        
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Additional setup if needed
+    }
+}
+
+extension SipCredentialsViewController: UITableViewDataSource, UITableViewDelegate {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 0
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        return UITableViewCell()
+    }
+    
+    
+}

--- a/TelnyxWebRTCDemo/ViewControllers/SipCredentialsViewController.swift
+++ b/TelnyxWebRTCDemo/ViewControllers/SipCredentialsViewController.swift
@@ -1,11 +1,17 @@
 import UIKit
 
+protocol SipCredentialsViewControllerDelegate: AnyObject {
+    func onSipCredentialSelected(credential: SipCredential)
+}
+
 class SipCredentialsViewController: UIViewController {
     
     @IBOutlet weak var tableView: UITableView!
     
     private var credentialsList: [SipCredential] = []
     private var selectedCredential: SipCredential?
+    weak var delegate: SipCredentialsViewControllerDelegate?
+
     
     init() {
         super.init(nibName: "SipCredentialsViewController", bundle: nil)
@@ -98,8 +104,16 @@ extension SipCredentialsViewController: UITableViewDataSource {
 // MARK: - UITableViewDelegate
 extension SipCredentialsViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        
+        guard indexPath.row < credentialsList.count else {
+            print("Invalid index")
+            return
+        }
         let selectedCredential = credentialsList[indexPath.row]
         print("Selected User: \(selectedCredential.username)")
+        SipCredentialsManager.shared.saveSelectedCredential(selectedCredential)
+        self.delegate?.onSipCredentialSelected(credential: selectedCredential)
+        self.dismiss(animated: true, completion: nil)
     }
     
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {

--- a/TelnyxWebRTCDemo/ViewControllers/SipCredentialsViewController.xib
+++ b/TelnyxWebRTCDemo/ViewControllers/SipCredentialsViewController.xib
@@ -11,6 +11,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SipCredentialsViewController" customModule="TelnyxWebRTCDemo" customModuleProvider="target">
             <connections>
+                <outlet property="tableView" destination="JmI-K4-yht" id="Phq-CY-oGh"/>
                 <outlet property="view" destination="iN0-l3-epB" id="rQh-9x-aLj"/>
             </connections>
         </placeholder>

--- a/TelnyxWebRTCDemo/ViewControllers/SipCredentialsViewController.xib
+++ b/TelnyxWebRTCDemo/ViewControllers/SipCredentialsViewController.xib
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SipCredentialsViewController" customModule="TelnyxWebRTCDemo" customModuleProvider="target">
+            <connections>
+                <outlet property="view" destination="iN0-l3-epB" id="rQh-9x-aLj"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="JmI-K4-yht">
+                    <rect key="frame" x="0.0" y="59" width="393" height="759"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <connections>
+                        <outlet property="dataSource" destination="-1" id="9Co-nJ-Shu"/>
+                        <outlet property="delegate" destination="-1" id="MPh-Ik-p0d"/>
+                    </connections>
+                </tableView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="JmI-K4-yht" secondAttribute="trailing" id="6gM-V1-0Lh"/>
+                <constraint firstItem="JmI-K4-yht" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="PDM-2P-3DH"/>
+                <constraint firstItem="JmI-K4-yht" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="QyA-fA-Wvu"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="JmI-K4-yht" secondAttribute="bottom" id="Wn1-7P-GgO"/>
+            </constraints>
+            <point key="canvasLocation" x="138" y="21"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/TelnyxWebRTCDemo/Views/UISettingsView.swift
+++ b/TelnyxWebRTCDemo/Views/UISettingsView.swift
@@ -37,7 +37,8 @@ class UISettingsView: UIView {
     @IBOutlet weak var passwordUserNameLabel: UITextField!
     @IBOutlet weak var tokenLabel: UITextField!
     @IBOutlet weak var loginSelector: UISwitch!
-
+    @IBOutlet weak var selectCredentialButton: UIButton!
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         commonInit()

--- a/TelnyxWebRTCDemo/Views/UISettingsView.swift
+++ b/TelnyxWebRTCDemo/Views/UISettingsView.swift
@@ -8,12 +8,17 @@
 
 import UIKit
 
+protocol UISettingsViewProtocol {
+    func onOpenSipSelector()
+}
+
 @IBDesignable
 class UISettingsView: UIView {
     
     let kCONTENT_XIB_NAME = "UISettingsView"
     
-    private var textFields:[UITextField] = [UITextField]()
+    public var delegate: UISettingsViewProtocol?
+    private var textFields = [UITextField]()
     private var activeField: UITextField?
 
     public var isTokenSelected: Bool {
@@ -100,6 +105,10 @@ class UISettingsView: UIView {
             self.credentialsLoginViewHeightConstraint.constant = 85
             self.tokenLoginView.isHidden = true
         }
+    }
+
+    @IBAction func onOpenSipSelector(_ sender: Any) {
+        delegate?.onOpenSipSelector()
     }
 }
 

--- a/TelnyxWebRTCDemo/Views/UISettingsView.swift
+++ b/TelnyxWebRTCDemo/Views/UISettingsView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol UISettingsViewProtocol {
+protocol UISettingsViewDelegate: AnyObject {
     func onOpenSipSelector()
 }
 
@@ -17,7 +17,7 @@ class UISettingsView: UIView {
     
     let kCONTENT_XIB_NAME = "UISettingsView"
     
-    public var delegate: UISettingsViewProtocol?
+    public weak var delegate: UISettingsViewDelegate?
     private var textFields = [UITextField]()
     private var activeField: UITextField?
 

--- a/TelnyxWebRTCDemo/Views/UISettingsView.xib
+++ b/TelnyxWebRTCDemo/Views/UISettingsView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -127,17 +127,40 @@
                         <constraint firstAttribute="bottom" secondItem="It9-Aq-D11" secondAttribute="bottom" id="nvK-2i-h2W"/>
                     </constraints>
                 </view>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8jg-WG-JqZ">
+                    <rect key="frame" x="25" y="254" width="364" height="30"/>
+                    <color key="backgroundColor" red="0.0" green="0.75294117650000003" blue="0.5450980392" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="30" id="ETV-7j-v4D"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                    <state key="normal" title="Select SIP Credential">
+                        <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </state>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                            <integer key="value" value="5"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <action selector="onOpenSipSelector:" destination="-1" eventType="touchUpInside" id="jOr-KY-nJf"/>
+                    </connections>
+                </button>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="Yvd-Fr-v9A" firstAttribute="top" secondItem="v42-cu-6zj" secondAttribute="bottom" constant="5" id="32h-0S-WlT"/>
+                <constraint firstItem="8jg-WG-JqZ" firstAttribute="top" secondItem="6jO-g3-ZzP" secondAttribute="bottom" constant="29" id="3pb-w5-H9q"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="uN3-ie-ge1" secondAttribute="trailing" constant="20" id="CuC-XP-hN0"/>
                 <constraint firstItem="v42-cu-6zj" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="5" id="EY9-zS-Lb0"/>
                 <constraint firstItem="uN3-ie-ge1" firstAttribute="top" secondItem="Yvd-Fr-v9A" secondAttribute="bottom" constant="5" id="EbR-iY-bb7"/>
                 <constraint firstItem="uN3-ie-ge1" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="20" id="HKN-ln-1Oi"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="8jg-WG-JqZ" secondAttribute="trailing" constant="25" id="JZu-jM-Ahb"/>
                 <constraint firstItem="Yvd-Fr-v9A" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="KC9-j9-O8Y"/>
                 <constraint firstItem="BZx-gd-B7S" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="PZi-Cv-Kw1"/>
+                <constraint firstItem="8jg-WG-JqZ" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="25" id="WSr-aM-0bJ"/>
                 <constraint firstItem="BZx-gd-B7S" firstAttribute="top" secondItem="v42-cu-6zj" secondAttribute="bottom" id="Wxt-97-RtV"/>
                 <constraint firstItem="Yvd-Fr-v9A" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="bz3-Q2-ZJj"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="6jO-g3-ZzP" secondAttribute="trailing" constant="20" id="dFE-ZC-km9"/>

--- a/TelnyxWebRTCDemo/Views/UISettingsView.xib
+++ b/TelnyxWebRTCDemo/Views/UISettingsView.xib
@@ -18,6 +18,7 @@
                 <outlet property="credentialsLoginViewHeightConstraint" destination="dTg-cC-rBC" id="aDR-oz-8Ch"/>
                 <outlet property="loginSelector" destination="qgF-Gg-7So" id="LaQ-jf-Oij"/>
                 <outlet property="passwordUserNameLabel" destination="XgO-ys-zI4" id="E26-JL-OKP"/>
+                <outlet property="selectCredentialButton" destination="8jg-WG-JqZ" id="QDt-gD-oHw"/>
                 <outlet property="sipUsernameLabel" destination="gPv-K3-sHg" id="VAN-KN-U8x"/>
                 <outlet property="tokenLabel" destination="HNl-BA-gMe" id="ilR-u0-qud"/>
                 <outlet property="tokenLoginView" destination="BZx-gd-B7S" id="BhD-61-ENv"/>

--- a/TelnyxWebRTCDemo/Views/UISipCredentialHeaderView.swift
+++ b/TelnyxWebRTCDemo/Views/UISipCredentialHeaderView.swift
@@ -1,0 +1,54 @@
+import UIKit
+
+class UISipCredentialHeaderView: UITableViewHeaderFooterView {
+    
+    
+    // Create title and subtitle labels
+    let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.boldSystemFont(ofSize: 16)
+        label.textColor = .black
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    let subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 12)
+        label.textColor = .gray
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        
+        contentView.addSubview(titleLabel)
+        contentView.addSubview(subtitleLabel)
+        
+        // Set constraints for titleLabel
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8),
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 15),
+            titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -15)
+        ])
+        
+        // Set constraints for subtitleLabel
+        NSLayoutConstraint.activate([
+            subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 4),
+            subtitleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 15),
+            subtitleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -15),
+            subtitleLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -8)
+        ])
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    // Configure the header with title and subtitle
+    func configure(title: String, subtitle: String) {
+        titleLabel.text = title
+        subtitleLabel.text = subtitle
+    }
+}


### PR DESCRIPTION
[[WEBRTC-2351] [Feat] Support Multiple credentials in demo app](https://telnyx.atlassian.net/browse/WEBRTC-2351)
---
This PR introduces enhanced SIP credential management with support for handling multiple environments and improved user interaction for credential manipulation.

## Features Added (Demo App):
### Environment-based Credential Storage:

- SIP credentials are now stored based on the current environment (e.g., Development, Production). This ensures that credentials are isolated per environment, providing better organization and reducing potential mix-ups between different configurations.

- New credentials are added automatically after completing a successful connection sequence.

- The password for existing credentials is updated upon a successful connection process.

- Swipe to Delete SIP Credentials: Users can now easily delete SIP credentials using a swipe gesture (right to left) on any credential in the list.
This feature enhances the user experience by providing a quick way to remove outdated or incorrect credentials.
Selection and Persistence of Selected Credential:

- When a user selects a credential from the list, it is automatically saved as the current active credential for the chosen environment.The selected credential is used for subsequent SIP connections, providing a streamlined experience when switching environments.


## Add new credentials and switch between them
https://github.com/user-attachments/assets/f14b560d-df26-4ffe-973a-aa0a1041ab80


### Delete credentials
https://github.com/user-attachments/assets/c941af21-7ab1-4296-9deb-9b255592346e




[WEBRTC-2351]: https://telnyx.atlassian.net/browse/WEBRTC-2351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ