### PR TITLE
[WEBRTC-2325] [FIX] Handle CallKit Mute / Unmute buttons

### DIFF
--- a/TelnyxRTC/Telnyx/WebRTC/Call.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call.swift
@@ -120,9 +120,16 @@ public class Call {
     public var callInfo: TxCallInfo?
     /// `CallState` The actual state of the Call.
     public var callState: CallState = .NEW
+    
+    /// `isMuted` Indicates if the call audio is muted based on the peer's audio track state.
+    public var isMuted: Bool {
+        return !(peer?.isAudioTrackEnabled ?? false)
+    }
 
     private var ringTonePlayer: AVAudioPlayer?
     private var ringbackPlayer: AVAudioPlayer?
+    
+    
 
     // MARK: - Initializers
     /// Constructor for incoming calls

--- a/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
@@ -139,7 +139,21 @@ extension AppDelegate : CXProviderDelegate {
             self.callKitUUID = nil
         }
     }
-    // MARK: - CXProviderDelegate - 
+    
+    func executeMuteUnmuteAction(uuid: UUID, mute: Bool) {
+        let muteAction = CXSetMutedCallAction(call: uuid, muted: mute)
+        let transaction = CXTransaction(action: muteAction)
+        
+        callKitCallController.request(transaction) { error in
+            if let error = error {
+                print("Error executing mute/unmute action: \(error.localizedDescription)")
+            } else {
+                print("Successfully executed mute/unmute action. Mute: \(mute)")
+            }
+        }
+    }
+    
+    // MARK: - CXProviderDelegate -
     func provider(_ provider: CXProvider, perform action: CXStartCallAction) {
         print("AppDelegate:: START call action: callKitUUID [\(String(describing: self.callKitUUID))] action [\(action.callUUID)]")
         self.callKitUUID = action.callUUID

--- a/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
@@ -214,7 +214,18 @@ extension AppDelegate : CXProviderDelegate {
     }
     
     func provider(_ provider: CXProvider, perform action: CXSetMutedCallAction) {
-        print("provider:performSetMutedAction:")
+        print("provider:performSetMutedAction: \(action.isMuted)")
+        if let call = currentCall {
+            if action.isMuted {
+                print("provider:performSetMutedAction: incoming action to mute call")
+                call.muteAudio()
+            } else {
+                print("provider:performSetMutedAction: incoming action to unmute call")
+                call.unmuteAudio()
+            }
+            print("provider:performSetMutedAction: call.isMuted \(call.isMuted)")
+        }
+        action.fulfill()
     }
     
     func processVoIPNotification(callUUID: UUID,pushMetaData:[String: Any]) {

--- a/TelnyxWebRTCDemo/ViewController.swift
+++ b/TelnyxWebRTCDemo/ViewController.swift
@@ -81,6 +81,7 @@ class ViewController: UIViewController {
     func initViews() {
         print("ViewController:: initViews()")
         self.callView.isHidden = true
+        self.callView.isMuted = self.appDelegate.currentCall?.isMuted ?? false
         self.callView.delegate = self
         self.callView.hideEndButton(hide: true)
 
@@ -251,8 +252,8 @@ class ViewController: UIViewController {
         self.incomingCall = false
         self.incomingCallView.isHidden = true
         self.callView.isHidden = false
-        self.callView.resetMuteUnmuteState()
         self.callView.resetHoldUnholdState()
+        self.callView.isMuted = self.appDelegate.currentCall?.isMuted ?? false
         self.callView.resetSpeakerState()
     }
     
@@ -300,12 +301,11 @@ extension ViewController : UICallScreenDelegate {
         appDelegate.executeEndCallAction(uuid: uuid)
     }
     
-    func onMuteUnmuteSwitch(isMuted: Bool) {
-        if (isMuted) {
-            self.appDelegate.currentCall?.muteAudio()
-        } else {
-            self.appDelegate.currentCall?.unmuteAudio()
+    func onMuteUnmuteSwitch(mute: Bool) {
+        guard let callId = self.appDelegate.currentCall?.callInfo?.callId else {
+            return
         }
+        self.appDelegate.executeMuteUnmuteAction(uuid: callId, mute: mute)
     }
     
     func onHoldUnholdSwitch(isOnHold: Bool) {

--- a/TelnyxWebRTCDemo/ViewController.swift
+++ b/TelnyxWebRTCDemo/ViewController.swift
@@ -76,6 +76,15 @@ class ViewController: UIViewController {
         self.telnyxClient = appDelegate.telnyxClient
         self.initViews()
         
+        // Register notifications
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(appWillEnterForeground),
+                                               name: UIApplication.willEnterForegroundNotification,
+                                               object: nil)
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 
     func initViews() {
@@ -131,6 +140,11 @@ class ViewController: UIViewController {
             // Internal use only
             self.showHiddenOptions()
         }
+    }
+    
+    @objc func appWillEnterForeground() {
+        print("ViewController:: App is about to enter the foreground")
+        self.callView.isMuted = self.appDelegate.currentCall?.isMuted ?? false
     }
 
     func showHiddenOptions() {

--- a/TelnyxWebRTCDemo/Views/UICallScreen.swift
+++ b/TelnyxWebRTCDemo/Views/UICallScreen.swift
@@ -12,7 +12,7 @@ import TelnyxRTC
 protocol UICallScreenDelegate: AnyObject {
     func onCallButton()
     func onEndCallButton()
-    func onMuteUnmuteSwitch(isMuted: Bool)
+    func onMuteUnmuteSwitch(mute: Bool)
     func onHoldUnholdSwitch(isOnHold: Bool)
     func onToggleSpeaker(isSpeakerActive: Bool)
 }
@@ -36,6 +36,13 @@ class UICallScreen: UIView {
     @IBOutlet weak var holdUnholdSwitch: UISwitch!
     @IBOutlet weak var holdUnholdLabel: UILabel!
     @IBOutlet weak var speakerOnOffSwitch: UISwitch!
+    
+    var isMuted: Bool = false {
+        didSet {
+            muteUnmuteSwitch.isOn = isMuted
+            muteUnmuteLabel.text = isMuted ? "Unmute" : "Mute"
+        }
+    }
     
     
     override init(frame: CGRect) {
@@ -123,11 +130,6 @@ class UICallScreen: UIView {
         self.holdUnholdLabel.text = "Hold"
     }
 
-    func resetMuteUnmuteState() {
-        self.muteUnmuteSwitch.setOn(false, animated: false)
-        self.muteUnmuteLabel.text = "Mute"
-    }
-
     @IBAction func callButtonTapped(_ sender: Any) {
         self.delegate?.onCallButton()
     }
@@ -137,12 +139,8 @@ class UICallScreen: UIView {
     }
 
     @IBAction func muteUnmuteTapped(_ sender: Any) {
-        if (muteUnmuteSwitch.isOn) {
-            self.muteUnmuteLabel.text = "Unmute"
-        } else {
-            self.muteUnmuteLabel.text = "Mute"
-        }
-        self.delegate?.onMuteUnmuteSwitch(isMuted: muteUnmuteSwitch.isOn)
+        let shouldMute = muteUnmuteSwitch.isOn
+        self.delegate?.onMuteUnmuteSwitch(mute: shouldMute)
     }
 
     @IBAction func holdUnholdTapped(_ sender: Any) {


### PR DESCRIPTION
<!-- Ticket details and link -->
[WEBRTC-2325 [FIX] Handle CallKit Mute / Unmute buttons](https://telnyx.atlassian.net/browse/WEBRTC-2325)
---
## Features and Improvements:

### Add isAudioTrackEnabled property to Peer class

- Introduces a computed property isAudioTrackEnabled in the Peer class to check if the first audio track is enabled.
- Supports both PlanB and Unified Plan SDP configurations.
- Defaults to false if no audio track is available.


### Add isMuted property to Call class
- Adds a new property isMuted to determine the mute state of a call.

### Handle mute/unmute actions via CXSetMutedCallAction (Demo App)

- Implements provider(_:perform:) to handle mute/unmute actions through CallKit's CXSetMutedCallAction.
- Updates the Call class by integrating muteAudio() and unmuteAudio() methods to manage audio state.
- Ensures actions are fulfilled after processing for CallKit compliance.

### Synchronize mute state across components
Updates the Call mute/unmute state by:
- Accessing the call’s mute status.
- Propagating updates to CallKit by executing the corresponding mute/unmute action.

### Sync mute button state in CallView on foreground entry
- Ensures the mute button in the CallView reflects the call's mute state when the app enters the foreground.
