### PR TITLE
[WEBRTC-2464] [feat] [Demo App] Add Hold/Resume call button to demo app

### DIFF
--- a/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
+++ b/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
@@ -52,6 +52,9 @@ class HomeViewController: UIViewController {
             },
             onToggleSpeaker: { [weak self] in
                 self?.onToggleSpeaker()
+            },
+            onHold: { [weak self] hold in
+                self?.onHoldUnholdSwitch(isOnHold: hold)
             })
         
         let homeView = HomeView(

--- a/TelnyxWebRTCDemo/ViewModels/CallViewModel.swift
+++ b/TelnyxWebRTCDemo/ViewModels/CallViewModel.swift
@@ -6,4 +6,5 @@ class CallViewModel: ObservableObject {
     @Published var isMuted: Bool = false
     @Published var isSpeakerOn: Bool = false
     @Published var callState: CallState = .DONE
+    @Published var isOnHold: Bool = false
 }

--- a/TelnyxWebRTCDemo/Views/CallView.swift
+++ b/TelnyxWebRTCDemo/Views/CallView.swift
@@ -10,7 +10,8 @@ struct CallView: View {
     let onAnswerCall: () -> Void
     let onMuteUnmuteSwitch: (Bool) -> Void
     let onToggleSpeaker: () -> Void
-    
+    let onHold: (Bool) -> Void
+
     var body: some View {
         VStack {
             switch viewModel.callState {
@@ -71,18 +72,8 @@ struct CallView: View {
                         .background(Color(hex: "#F5F3E4"))
                         .clipShape(Circle())
                 }
-                .padding()
-                
-                Button(action: {
-                    onEndCall()
-                }) {
-                    Image(systemName: "phone.down.fill")
-                        .foregroundColor(Color(hex: "#1D1D1D"))
-                        .frame(width: 60, height: 60)
-                        .background(Color(hex: "#EB0000"))
-                        .clipShape(Circle())
-                }
-                .padding()
+                .padding() 
+               
                 
                 Button(action: {
                     onToggleSpeaker()
@@ -94,7 +85,30 @@ struct CallView: View {
                         .clipShape(Circle())
                 }
                 .padding()
+
+                Button(action: {
+                    viewModel.isOnHold.toggle()
+                    onHold(viewModel.isOnHold)
+                }) {
+                    Image(systemName: viewModel.isOnHold ? "play.fill" : "pause")
+                        .foregroundColor(Color(hex: "#1D1D1D"))
+                        .frame(width: 60, height: 60)
+                        .background(Color(hex: "#F5F3E4"))
+                        .clipShape(Circle())
+                }
+                .padding()
             }
+
+             Button(action: {
+                    onEndCall()
+                }) {
+                    Image(systemName: "phone.down.fill")
+                        .foregroundColor(Color(hex: "#1D1D1D"))
+                        .frame(width: 60, height: 60)
+                        .background(Color(hex: "#EB0000"))
+                        .clipShape(Circle())
+                }
+                .padding()
             
             Spacer()
         }
@@ -143,6 +157,7 @@ struct CallView_Previews: PreviewProvider {
             onRejectCall: {},
             onAnswerCall: {},
             onMuteUnmuteSwitch: { _ in },
-            onToggleSpeaker: {})
+            onToggleSpeaker: {},
+            onHold: { _ in })
     }
 }

--- a/TelnyxWebRTCDemo/Views/HomeView.swift
+++ b/TelnyxWebRTCDemo/Views/HomeView.swift
@@ -199,7 +199,8 @@ struct HomeView_Previews: PreviewProvider {
                     onRejectCall: {},
                     onAnswerCall: {},
                     onMuteUnmuteSwitch: { _ in },
-                    onToggleSpeaker: {}))
+                    onToggleSpeaker: {},
+                    onHold: { _ in }))
         )
     }
 }


### PR DESCRIPTION
[[WEBRTC-2464] [feat] [Demo App] Add Hold/Resume call button to demo app](https://telnyx.atlassian.net/browse/WEBRTC-2464)
---
This PR adds a Hold/Resume call button to the CallView in the demo app. The button allows users to put an ongoing call on hold or resume it. The button dynamically changes its icon:

- Play icon (▶️): Indicates that the call is on hold and can be resumed.
- Pause icon (⏸️): Indicates that the call is active and can be put on hold.

## :older_man: :baby: Behaviors
### Before changes
- There was no option to hold or resume an ongoing call in the demo app.


### After changes
- A new button is added to `CallView` that allows users to toggle between Hold and Resume states.
- The button icon updates dynamically based on the call state.


https://github.com/user-attachments/assets/690f7068-b3d0-4c2e-b59f-898bb568ebda


