### PR TITLE
[WEBRTC-2465][feat] Implement DTMF keyboard on Demo App

### DIFF
--- a/TelnyxRTC.xcodeproj/project.pbxproj
+++ b/TelnyxRTC.xcodeproj/project.pbxproj
@@ -62,6 +62,8 @@
 		99B6E0012CF547680010CA96 /* DebugReportDataMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B6E0002CF547680010CA96 /* DebugReportDataMessage.swift */; };
 		99CC5BAC2CF804A500EF43DC /* WebRTCStatsReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99CC5BAB2CF804A200EF43DC /* WebRTCStatsReporter.swift */; };
 		99CC5BAE2CF80D3A00EF43DC /* WebRTCEventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99CC5BAD2CF80D3400EF43DC /* WebRTCEventHandler.swift */; };
+		99FF7B102D4BC4F700DB1408 /* DTMFKeyboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99FF7B0F2D4BC4F700DB1408 /* DTMFKeyboardView.swift */; };
+		99FF7B122D4BC71800DB1408 /* DTMFKeyboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99FF7B112D4BC71800DB1408 /* DTMFKeyboardViewModel.swift */; };
 		B309D13D25EF119E00A2AADF /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B309D11125EF107F00A2AADF /* Starscream.framework */; };
 		B309D1D625F020B300A2AADF /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D1D525F020B300A2AADF /* Message.swift */; };
 		B309D1DB25F020D400A2AADF /* Method.swift in Sources */ = {isa = PBXBuildFile; fileRef = B309D1DA25F020D400A2AADF /* Method.swift */; };
@@ -201,6 +203,8 @@
 		99B6E0002CF547680010CA96 /* DebugReportDataMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugReportDataMessage.swift; sourceTree = "<group>"; };
 		99CC5BAB2CF804A200EF43DC /* WebRTCStatsReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRTCStatsReporter.swift; sourceTree = "<group>"; };
 		99CC5BAD2CF80D3400EF43DC /* WebRTCEventHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRTCEventHandler.swift; sourceTree = "<group>"; };
+		99FF7B0F2D4BC4F700DB1408 /* DTMFKeyboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DTMFKeyboardView.swift; sourceTree = "<group>"; };
+		99FF7B112D4BC71800DB1408 /* DTMFKeyboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DTMFKeyboardViewModel.swift; sourceTree = "<group>"; };
 		B309D11125EF107F00A2AADF /* Starscream.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Starscream.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B309D1D525F020B300A2AADF /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		B309D1DA25F020D400A2AADF /* Method.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Method.swift; sourceTree = "<group>"; };
@@ -372,6 +376,7 @@
 		99ADA94D2D47C9B6000C956A /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
+				99FF7B112D4BC71800DB1408 /* DTMFKeyboardViewModel.swift */,
 				99ADA9AF2D4886E3000C956A /* CallViewModel.swift */,
 				99ADA9AD2D487DE1000C956A /* ProfileViewModel.swift */,
 				99ADA94C2D47C9B6000C956A /* HomeViewModel.swift */,
@@ -427,6 +432,7 @@
 		B309D1FB25F028F100A2AADF /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				99FF7B0F2D4BC4F700DB1408 /* DTMFKeyboardView.swift */,
 				99ADA9A92D487AC4000C956A /* CallView.swift */,
 				99ADA9A72D4878ED000C956A /* ProfileView.swift */,
 				998670412D4096A7001E1D01 /* HomeView.swift */,
@@ -966,6 +972,7 @@
 				B3B8F53726E7D4EF0007B583 /* AppDelegateTelnyxVoIPExtension.swift in Sources */,
 				9986703E2D3EC7A3001E1D01 /* View+Extensions.swift in Sources */,
 				9986703A2D3E9DCE001E1D01 /* SipInputCredentialsView.swift in Sources */,
+				99FF7B102D4BC4F700DB1408 /* DTMFKeyboardView.swift in Sources */,
 				991A6D442D3A96C100B29785 /* SplashScreen.swift in Sources */,
 				99ADA9A82D4878FA000C956A /* ProfileView.swift in Sources */,
 				998670402D40849C001E1D01 /* HomeViewController.swift in Sources */,
@@ -979,6 +986,7 @@
 				998670382D3E9506001E1D01 /* Color+Extensions.swift in Sources */,
 				B368BEEB25EDDD060032AE52 /* AppDelegate.swift in Sources */,
 				99ADA9B22D488D98000C956A /* HomeViewController+VoIPExtension.swift in Sources */,
+				99FF7B122D4BC71800DB1408 /* DTMFKeyboardViewModel.swift in Sources */,
 				99ADA94E2D47C9B6000C956A /* HomeViewModel.swift in Sources */,
 				9986703C2D3EAF64001E1D01 /* ErrorView.swift in Sources */,
 			);

--- a/TelnyxWebRTCDemo/ViewControllers/HomeViewController+VoIPExtension.swift
+++ b/TelnyxWebRTCDemo/ViewControllers/HomeViewController+VoIPExtension.swift
@@ -82,6 +82,7 @@ extension HomeViewController : VoIPDelegate {
         self.incomingCall = true
         DispatchQueue.main.async {
             self.callViewModel.callState = call.callState
+            self.viewModel.callState = call.callState
             //Hide the keyboard
             self.view.endEditing(true)
         }
@@ -94,6 +95,7 @@ extension HomeViewController : VoIPDelegate {
     func onCallStateUpdated(callState: CallState, callId: UUID) {
         DispatchQueue.main.async {
             self.callViewModel.callState = callState
+            self.viewModel.callState = callState
 
             switch (callState) {
                 case .CONNECTING:

--- a/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
+++ b/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
@@ -52,6 +52,9 @@ class HomeViewController: UIViewController {
             },
             onToggleSpeaker: { [weak self] in
                 self?.onToggleSpeaker()
+            },
+            onHold: { [weak self] hold in
+                self?.onHoldUnholdSwitch(isOnHold: hold)
             })
         
         let homeView = HomeView(

--- a/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
+++ b/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
@@ -160,6 +160,7 @@ extension HomeViewController {
             self.viewModel.socketState = !sessionId.isEmpty && isConnected ? .clientReady : isConnected ? .connected : .disconnected
             self.viewModel.isLoading = false
             self.viewModel.sessionId = sessionId.isEmpty ? "-" : sessionId
+            self.viewModel.callState = self.appDelegate.currentCall?.callState ?? .DONE
             self.callViewModel.callState = self.appDelegate.currentCall?.callState ?? .DONE
             self.callViewModel.isMuted = self.appDelegate.currentCall?.isMuted ?? false
             self.callViewModel.isSpeakerOn = self.telnyxClient?.isSpeakerEnabled ?? false

--- a/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
+++ b/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
@@ -55,7 +55,11 @@ class HomeViewController: UIViewController {
             },
             onHold: { [weak self] hold in
                 self?.onHoldUnholdSwitch(isOnHold: hold)
-            })
+            },
+            onDTMF: { [weak self] key in
+                self?.appDelegate.currentCall?.dtmf(dtmf: key)
+            }
+        )
         
         let homeView = HomeView(
             viewModel: viewModel,

--- a/TelnyxWebRTCDemo/ViewModels/CallViewModel.swift
+++ b/TelnyxWebRTCDemo/ViewModels/CallViewModel.swift
@@ -6,4 +6,5 @@ class CallViewModel: ObservableObject {
     @Published var isMuted: Bool = false
     @Published var isSpeakerOn: Bool = false
     @Published var callState: CallState = .DONE
+    @Published var isOnHold: Bool = false
 }

--- a/TelnyxWebRTCDemo/ViewModels/CallViewModel.swift
+++ b/TelnyxWebRTCDemo/ViewModels/CallViewModel.swift
@@ -7,4 +7,11 @@ class CallViewModel: ObservableObject {
     @Published var isSpeakerOn: Bool = false
     @Published var callState: CallState = .DONE
     @Published var isOnHold: Bool = false
+    @Published var showDTMFKeyboard: Bool = false
+    
+    var currentCall: Call?
+    
+    func setCurrentCall(_ call: Call?) {
+        currentCall = call
+    }
 }

--- a/TelnyxWebRTCDemo/ViewModels/CallViewModel.swift
+++ b/TelnyxWebRTCDemo/ViewModels/CallViewModel.swift
@@ -7,11 +7,5 @@ class CallViewModel: ObservableObject {
     @Published var isSpeakerOn: Bool = false
     @Published var callState: CallState = .DONE
     @Published var isOnHold: Bool = false
-    @Published var showDTMFKeyboard: Bool = false
-    
-    var currentCall: Call?
-    
-    func setCurrentCall(_ call: Call?) {
-        currentCall = call
-    }
+    @Published var showDTMFKeyboard: Bool = false    
 }

--- a/TelnyxWebRTCDemo/ViewModels/DTMFKeyboardViewModel.swift
+++ b/TelnyxWebRTCDemo/ViewModels/DTMFKeyboardViewModel.swift
@@ -3,17 +3,6 @@ import TelnyxRTC
 
 class DTMFKeyboardViewModel: ObservableObject {
     @Published var displayText: String = ""
-    let currentCall: Call?
-    
-    init(currentCall: Call? = nil) {
-        self.currentCall = currentCall
-    }
-    
-    func sendDTMF(_ value: String) {
-        currentCall?.dtmf(value)
-        displayText += value
-    }
-    
     func clearDisplay() {
         displayText = ""
     }

--- a/TelnyxWebRTCDemo/ViewModels/DTMFKeyboardViewModel.swift
+++ b/TelnyxWebRTCDemo/ViewModels/DTMFKeyboardViewModel.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+import TelnyxRTC
+
+class DTMFKeyboardViewModel: ObservableObject {
+    @Published var displayText: String = ""
+    let currentCall: Call?
+    
+    init(currentCall: Call? = nil) {
+        self.currentCall = currentCall
+    }
+    
+    func sendDTMF(_ value: String) {
+        currentCall?.dtmf(value)
+        displayText += value
+    }
+    
+    func clearDisplay() {
+        displayText = ""
+    }
+}

--- a/TelnyxWebRTCDemo/ViewModels/HomeViewModel.swift
+++ b/TelnyxWebRTCDemo/ViewModels/HomeViewModel.swift
@@ -1,8 +1,10 @@
 import SwiftUI
+import TelnyxRTC
 
 class HomeViewModel: ObservableObject {
     @Published var socketState: SocketState = .disconnected
     @Published var sessionId: String = "-"
     @Published var environment: String = "-"
     @Published var isLoading: Bool = false
+    @Published var callState: CallState = .DONE
 }

--- a/TelnyxWebRTCDemo/Views/CallView.swift
+++ b/TelnyxWebRTCDemo/Views/CallView.swift
@@ -59,9 +59,7 @@ struct CallView: View {
                 .padding()
                 .disabled(true)
                 .opacity(0.5)
-            
-            Spacer()
-            
+                        
             HStack {
                 Button(action: {
                     viewModel.isMuted.toggle()
@@ -72,24 +70,9 @@ struct CallView: View {
                         .frame(width: 60, height: 60)
                         .background(Color(hex: "#F5F3E4"))
                         .clipShape(Circle())
-                }
-                .padding()
-                
-                Spacer()
-                
-                Button(action: {
-                    onEndCall()
-                }) {
-                    Image(systemName: "phone.down.fill")
-                        .foregroundColor(Color(hex: "#1D1D1D"))
-                        .frame(width: 60, height: 60)
-                        .background(Color(hex: "#EB0000"))
-                        .clipShape(Circle())
-                }
-                .padding()
-                
-                Spacer()
-                
+                }.padding(.horizontal, 2)
+                                
+                                
                 Button(action: {
                     viewModel.isSpeakerOn.toggle()
                     onToggleSpeaker()
@@ -99,13 +82,8 @@ struct CallView: View {
                         .frame(width: 60, height: 60)
                         .background(Color(hex: "#F5F3E4"))
                         .clipShape(Circle())
-                }
-                .padding()
-            }
-            
-            Spacer()
-            
-            HStack {
+                }.padding(.horizontal, 2)
+
                 Button(action: {
                     viewModel.isOnHold.toggle()
                     onHold(viewModel.isOnHold)
@@ -115,10 +93,7 @@ struct CallView: View {
                         .frame(width: 60, height: 60)
                         .background(Color(hex: "#F5F3E4"))
                         .clipShape(Circle())
-                }
-                .padding()
-                
-                Spacer()
+                }.padding(.horizontal, 2)
 
                 Button(action: {
                     viewModel.showDTMFKeyboard.toggle()
@@ -137,11 +112,19 @@ struct CallView: View {
                             onDTMF(key)
                         }
                     )
-                }
-                
+                }.padding(.horizontal, 2)
             }
             
-            Spacer()
+            Button(action: {
+                onEndCall()
+            }) {
+                Image(systemName: "phone.down.fill")
+                    .foregroundColor(Color(hex: "#1D1D1D"))
+                    .frame(width: 60, height: 60)
+                    .background(Color(hex: "#EB0000"))
+                    .clipShape(Circle())
+            }
+            .padding()
         }
     }
     

--- a/TelnyxWebRTCDemo/Views/CallView.swift
+++ b/TelnyxWebRTCDemo/Views/CallView.swift
@@ -10,7 +10,8 @@ struct CallView: View {
     let onAnswerCall: () -> Void
     let onMuteUnmuteSwitch: (Bool) -> Void
     let onToggleSpeaker: () -> Void
-    
+    let onHold: (Bool) -> Void
+
     var body: some View {
         VStack {
             switch viewModel.callState {
@@ -71,18 +72,8 @@ struct CallView: View {
                         .background(Color(hex: "#F5F3E4"))
                         .clipShape(Circle())
                 }
-                .padding()
-                
-                Button(action: {
-                    onEndCall()
-                }) {
-                    Image(systemName: "phone.down.fill")
-                        .foregroundColor(Color(hex: "#1D1D1D"))
-                        .frame(width: 60, height: 60)
-                        .background(Color(hex: "#EB0000"))
-                        .clipShape(Circle())
-                }
-                .padding()
+                .padding() 
+               
                 
                 Button(action: {
                     onToggleSpeaker()
@@ -94,7 +85,30 @@ struct CallView: View {
                         .clipShape(Circle())
                 }
                 .padding()
+
+                Button(action: {
+                    viewModel.isOnHold.toggle()
+                    onHold(viewModel.isOnHold)
+                }) {
+                    Image(systemName: viewModel.isOnHold ? "play.fill" : "pause")
+                        .foregroundColor(Color(hex: "#1D1D1D"))
+                        .frame(width: 60, height: 60)
+                        .background(Color(hex: "#F5F3E4"))
+                        .clipShape(Circle())
+                }
+                .padding()
             }
+
+             Button(action: {
+                    onEndCall()
+                }) {
+                    Image(systemName: "phone.down.fill")
+                        .foregroundColor(Color(hex: "#1D1D1D"))
+                        .frame(width: 60, height: 60)
+                        .background(Color(hex: "#EB0000"))
+                        .clipShape(Circle())
+                }
+                .padding()
             
             Spacer()
         }
@@ -143,6 +157,7 @@ struct CallView_Previews: PreviewProvider {
             onRejectCall: {},
             onAnswerCall: {},
             onMuteUnmuteSwitch: { _ in },
-            onToggleSpeaker: {})
+            onToggleSpeaker: {},
+            onHold: { _ in })
     }
 }

--- a/TelnyxWebRTCDemo/Views/CallView.swift
+++ b/TelnyxWebRTCDemo/Views/CallView.swift
@@ -25,6 +25,19 @@ struct CallView: View {
             }
         }
         .padding()
+        .sheet(isPresented: $viewModel.showDTMFKeyboard) {
+            VStack {
+                DTMFKeyboardView(
+                    viewModel: DTMFKeyboardViewModel(),
+                    onClose: { viewModel.showDTMFKeyboard = false },
+                    onDTMF: { key in
+                        onDTMF(key)
+                    }
+                )
+                .background(Color.white)
+            }
+            .ignoresSafeArea(edges: .bottom)
+        }
     }
     
     @ViewBuilder
@@ -104,15 +117,7 @@ struct CallView: View {
                         .background(Color(hex: "#F5F3E4"))
                         .clipShape(Circle())
                 }
-                .sheet(isPresented: $viewModel.showDTMFKeyboard) {
-                    DTMFKeyboardView(
-                        viewModel: DTMFKeyboardViewModel(),
-                        onClose: { viewModel.showDTMFKeyboard = false },
-                        onDTMF: { key in
-                            onDTMF(key)
-                        }
-                    )
-                }.padding(.horizontal, 2)
+
             }
             
             Button(action: {
@@ -126,6 +131,7 @@ struct CallView: View {
             }
             .padding()
         }
+        Spacer()
     }
     
     @ViewBuilder

--- a/TelnyxWebRTCDemo/Views/CallView.swift
+++ b/TelnyxWebRTCDemo/Views/CallView.swift
@@ -11,6 +11,7 @@ struct CallView: View {
     let onMuteUnmuteSwitch: (Bool) -> Void
     let onToggleSpeaker: () -> Void
     let onHold: (Bool) -> Void
+    let onDTMF: (String) -> Void
 
     var body: some View {
         VStack {
@@ -72,10 +73,25 @@ struct CallView: View {
                         .background(Color(hex: "#F5F3E4"))
                         .clipShape(Circle())
                 }
-                .padding() 
-               
+                .padding()
+                
+                Spacer()
                 
                 Button(action: {
+                    onEndCall()
+                }) {
+                    Image(systemName: "phone.down.fill")
+                        .foregroundColor(Color(hex: "#1D1D1D"))
+                        .frame(width: 60, height: 60)
+                        .background(Color(hex: "#EB0000"))
+                        .clipShape(Circle())
+                }
+                .padding()
+                
+                Spacer()
+                
+                Button(action: {
+                    viewModel.isSpeakerOn.toggle()
                     onToggleSpeaker()
                 }) {
                     Image(systemName: viewModel.isSpeakerOn ? "speaker.wave.3.fill" : "speaker.slash.fill")
@@ -85,25 +101,11 @@ struct CallView: View {
                         .clipShape(Circle())
                 }
                 .padding()
-                
-                Button(action: {
-                    viewModel.showDTMFKeyboard.toggle()
-                }) {
-                    Image(systemName: "circle.grid.3x3.fill")
-                        .foregroundColor(Color(hex: "#1D1D1D"))
-                        .frame(width: 60, height: 60)
-                        .background(Color(hex: "#F5F3E4"))
-                        .clipShape(Circle())
-                }
-                .padding()
-                .sheet(isPresented: $viewModel.showDTMFKeyboard) {
-                    DTMFKeyboardView(
-                        viewModel: DTMFKeyboardViewModel(currentCall: viewModel.currentCall),
-                        onClose: { viewModel.showDTMFKeyboard = false }
-                    )
-                    .presentationDetents([.height(400)])
-                }
-
+            }
+            
+            Spacer()
+            
+            HStack {
                 Button(action: {
                     viewModel.isOnHold.toggle()
                     onHold(viewModel.isOnHold)
@@ -115,18 +117,29 @@ struct CallView: View {
                         .clipShape(Circle())
                 }
                 .padding()
-            }
+                
+                Spacer()
 
-             Button(action: {
-                    onEndCall()
+                Button(action: {
+                    viewModel.showDTMFKeyboard.toggle()
                 }) {
-                    Image(systemName: "phone.down.fill")
+                    Image(systemName: "circle.grid.3x3.fill")
                         .foregroundColor(Color(hex: "#1D1D1D"))
                         .frame(width: 60, height: 60)
-                        .background(Color(hex: "#EB0000"))
+                        .background(Color(hex: "#F5F3E4"))
                         .clipShape(Circle())
                 }
-                .padding()
+                .sheet(isPresented: $viewModel.showDTMFKeyboard) {
+                    DTMFKeyboardView(
+                        viewModel: DTMFKeyboardViewModel(),
+                        onClose: { viewModel.showDTMFKeyboard = false },
+                        onDTMF: { key in
+                            onDTMF(key)
+                        }
+                    )
+                }
+                
+            }
             
             Spacer()
         }
@@ -176,6 +189,8 @@ struct CallView_Previews: PreviewProvider {
             onAnswerCall: {},
             onMuteUnmuteSwitch: { _ in },
             onToggleSpeaker: {},
-            onHold: { _ in })
+            onHold: { _ in },
+            onDTMF: { _ in }
+        )
     }
 }

--- a/TelnyxWebRTCDemo/Views/CallView.swift
+++ b/TelnyxWebRTCDemo/Views/CallView.swift
@@ -85,6 +85,24 @@ struct CallView: View {
                         .clipShape(Circle())
                 }
                 .padding()
+                
+                Button(action: {
+                    viewModel.showDTMFKeyboard.toggle()
+                }) {
+                    Image(systemName: "circle.grid.3x3.fill")
+                        .foregroundColor(Color(hex: "#1D1D1D"))
+                        .frame(width: 60, height: 60)
+                        .background(Color(hex: "#F5F3E4"))
+                        .clipShape(Circle())
+                }
+                .padding()
+                .sheet(isPresented: $viewModel.showDTMFKeyboard) {
+                    DTMFKeyboardView(
+                        viewModel: DTMFKeyboardViewModel(currentCall: viewModel.currentCall),
+                        onClose: { viewModel.showDTMFKeyboard = false }
+                    )
+                    .presentationDetents([.height(400)])
+                }
 
                 Button(action: {
                     viewModel.isOnHold.toggle()

--- a/TelnyxWebRTCDemo/Views/DTMFKeyboardView.swift
+++ b/TelnyxWebRTCDemo/Views/DTMFKeyboardView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct DTMFKeyboardView: View {
     @ObservedObject var viewModel: DTMFKeyboardViewModel
     let onClose: () -> Void
+    let onDTMF: (String) -> Void
     
     private let keypadButtons = [
         ["1", "2", "3"],
@@ -35,7 +36,7 @@ struct DTMFKeyboardView: View {
                     HStack(spacing: 12) {
                         ForEach(row, id: \.self) { key in
                             Button(action: {
-                                viewModel.sendDTMF(key)
+                                onDTMF(key)
                             }) {
                                 Text(key)
                                     .font(.title)
@@ -58,7 +59,10 @@ struct DTMFKeyboardView: View {
 
 struct DTMFKeyboardView_Previews: PreviewProvider {
     static var previews: some View {
-        DTMFKeyboardView(viewModel: DTMFKeyboardViewModel(), onClose: {})
+        DTMFKeyboardView(
+            viewModel: DTMFKeyboardViewModel(),
+            onClose: {},
+            onDTMF: { _ in })
             .padding()
     }
 }

--- a/TelnyxWebRTCDemo/Views/DTMFKeyboardView.swift
+++ b/TelnyxWebRTCDemo/Views/DTMFKeyboardView.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+struct DTMFKeyboardView: View {
+    @ObservedObject var viewModel: DTMFKeyboardViewModel
+    let onClose: () -> Void
+    
+    private let keypadButtons = [
+        ["1", "2", "3"],
+        ["4", "5", "6"],
+        ["7", "8", "9"],
+        ["*", "0", "#"]
+    ]
+    
+    var body: some View {
+        VStack(spacing: 16) {
+            HStack {
+                Text("DTMF Dialpad")
+                    .font(.headline)
+                Spacer()
+                Button(action: onClose) {
+                    Image(systemName: "xmark")
+                        .foregroundColor(Color(hex: "#1D1D1D"))
+                }
+            }
+            .padding(.horizontal)
+            .padding(.top)
+            
+            TextField("", text: .constant(viewModel.displayText))
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .disabled(true)
+                .padding(.horizontal)
+            
+            VStack(spacing: 12) {
+                ForEach(keypadButtons, id: \.self) { row in
+                    HStack(spacing: 12) {
+                        ForEach(row, id: \.self) { key in
+                            Button(action: {
+                                viewModel.sendDTMF(key)
+                            }) {
+                                Text(key)
+                                    .font(.title)
+                                    .foregroundColor(Color(hex: "#1D1D1D"))
+                                    .frame(width: 70, height: 70)
+                                    .background(Color(hex: "#F5F3E4"))
+                                    .clipShape(Circle())
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(.bottom)
+        }
+        .background(Color.white)
+        .cornerRadius(16)
+        .shadow(radius: 10)
+    }
+}
+
+struct DTMFKeyboardView_Previews: PreviewProvider {
+    static var previews: some View {
+        DTMFKeyboardView(viewModel: DTMFKeyboardViewModel(), onClose: {})
+            .padding()
+    }
+}

--- a/TelnyxWebRTCDemo/Views/DTMFKeyboardView.swift
+++ b/TelnyxWebRTCDemo/Views/DTMFKeyboardView.swift
@@ -37,6 +37,7 @@ struct DTMFKeyboardView: View {
                         ForEach(row, id: \.self) { key in
                             Button(action: {
                                 onDTMF(key)
+                                viewModel.displayText += key
                             }) {
                                 Text(key)
                                     .font(.title)
@@ -49,11 +50,9 @@ struct DTMFKeyboardView: View {
                     }
                 }
             }
-            .padding(.bottom)
         }
         .background(Color.white)
-        .cornerRadius(16)
-        .shadow(radius: 10)
+        Spacer()
     }
 }
 

--- a/TelnyxWebRTCDemo/Views/HomeView.swift
+++ b/TelnyxWebRTCDemo/Views/HomeView.swift
@@ -200,7 +200,10 @@ struct HomeView_Previews: PreviewProvider {
                     onAnswerCall: {},
                     onMuteUnmuteSwitch: { _ in },
                     onToggleSpeaker: {},
-                    onHold: { _ in }))
+                    onHold: { _ in },
+                    onDTMF: { _ in }
+                )
+            )
         )
     }
 }

--- a/TelnyxWebRTCDemo/Views/HomeView.swift
+++ b/TelnyxWebRTCDemo/Views/HomeView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import TelnyxRTC
 
 enum SocketState {
     case clientReady
@@ -91,39 +92,42 @@ struct HomeView: View {
                                 profileOrCallView(for: viewModel.socketState)
                                 
                                 Spacer()
-                                
-                                if viewModel.socketState == .disconnected {
-                                    Button(action: onConnect) {
-                                        Text("Connect")
-                                            .font(.system(size: 16).bold())
-                                            .foregroundColor(.white)
-                                            .frame(maxWidth: 300)
-                                            .padding(.vertical, 12)
-                                            .background(Color(hex: "#1D1D1D"))
-                                            .cornerRadius(20)
+                                if viewModel.callState == .NEW ||
+                                   viewModel.callState == .DONE
+                                {
+                                    if viewModel.socketState == .disconnected {
+                                        Button(action: onConnect) {
+                                            Text("Connect")
+                                                .font(.system(size: 16).bold())
+                                                .foregroundColor(.white)
+                                                .frame(maxWidth: 300)
+                                                .padding(.vertical, 12)
+                                                .background(Color(hex: "#1D1D1D"))
+                                                .cornerRadius(20)
+                                        }
+                                        .padding(.horizontal, 60)
+                                        .padding(.bottom, 20)
+                                    } else {
+                                        Button(action: onDisconnect) {
+                                            Text("Disconnect")
+                                                .font(.system(size: 16).bold())
+                                                .foregroundColor(.white)
+                                                .frame(maxWidth: 300)
+                                                .padding(.vertical, 12)
+                                                .background(Color(hex: "#1D1D1D"))
+                                                .cornerRadius(20)
+                                        }
+                                        .padding(.horizontal, 60)
+                                        .padding(.bottom, 10)
                                     }
-                                    .padding(.horizontal, 60)
-                                    .padding(.bottom, 20)
-                                } else {
-                                    Button(action: onDisconnect) {
-                                        Text("Disconnect")
-                                            .font(.system(size: 16).bold())
-                                            .foregroundColor(.white)
-                                            .frame(maxWidth: 300)
-                                            .padding(.vertical, 12)
-                                            .background(Color(hex: "#1D1D1D"))
-                                            .cornerRadius(20)
-                                    }
-                                    .padding(.horizontal, 60)
-                                    .padding(.bottom, 10)
+                                    
+                                    
+                                    // Environment Text
+                                    Text(viewModel.environment)
+                                        .font(.system(size: 14, weight: .regular))
+                                        .foregroundColor(Color(hex: "1D1D1D"))
+                                        .padding(.bottom, 5)
                                 }
-                                
-                                
-                                // Environment Text
-                                Text(viewModel.environment)
-                                    .font(.system(size: 14, weight: .regular))
-                                    .foregroundColor(Color(hex: "1D1D1D"))
-                                    .padding(.bottom, 5)
                             }
                             .opacity(textOpacity)
                             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/TelnyxWebRTCDemo/Views/HomeView.swift
+++ b/TelnyxWebRTCDemo/Views/HomeView.swift
@@ -199,7 +199,8 @@ struct HomeView_Previews: PreviewProvider {
                     onRejectCall: {},
                     onAnswerCall: {},
                     onMuteUnmuteSwitch: { _ in },
-                    onToggleSpeaker: {}))
+                    onToggleSpeaker: {},
+                    onHold: { _ in }))
         )
     }
 }


### PR DESCRIPTION
## Description
Implements a DTMF keyboard feature in the iOS Demo App as requested in WEBRTC-2465.

### Changes
- Added DTMFKeyboardViewModel for handling DTMF functionality
- Created DTMFKeyboardView with a phone-like keypad layout
- Added DTMF button after speaker control in CallView
- Implemented bottom sheet presentation for the DTMF keyboard

### Implementation Details
- The DTMF button uses the `circle.grid.3x3.fill` SF Symbol icon
- Keyboard buttons use the specified colors:
  - Background: #F5F3E4
  - Foreground: #1D1D1D
- Bottom sheet presentation with fixed height of 400 points
- Text input field only accepts input from keypad buttons


https://github.com/user-attachments/assets/9f472638-6a90-4556-a97d-bc4e42b25e45



Jira Ticket: [WEBRTC-2465](https://telnyx.atlassian.net/browse/WEBRTC-2465)

[WEBRTC-2465]: https://telnyx.atlassian.net/browse/WEBRTC-2465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ