### PR TITLE
[WEBRTC-2505] [Feat][Sample App] Handle JWT credentials

### DIFF
--- a/TelnyxRTC/Telnyx/Models/TxConfig.swift
+++ b/TelnyxRTC/Telnyx/Models/TxConfig.swift
@@ -93,6 +93,7 @@ public struct TxConfig {
                 ringBackTone: String? = nil,
                 pushEnvironment: PushEnvironment? = nil,
                 logLevel: LogLevel = .none,
+                reconnectClient: Bool = true,
                 debug: Bool = false,
                 forceRelayCandidate: Bool = false) {
         self.token = token

--- a/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
@@ -252,28 +252,56 @@ extension AppDelegate : CXProviderDelegate {
         }
         
         let selectedCredentials = SipCredentialsManager.shared.getSelectedCredential()
-        let sipUser = selectedCredentials?.username ?? ""
-        let password = selectedCredentials?.password ?? ""
-        let deviceToken = userDefaults.getPushToken()
-        //Sets the login credentials and the ringtone/ringback configurations if required.
-        //Ringtone / ringback tone files are not mandatory.
-        let txConfig = TxConfig(sipUser: sipUser,
-                                password: password,
-                                pushDeviceToken: deviceToken,
-                                ringtone: "incoming_call.mp3",
-                                ringBackTone: "ringback_tone.mp3",
-                                //You can choose the appropriate verbosity level of the SDK.
-                                logLevel: .all,
-                                reconnectClient: true,
-                                // Enable WebRTC stats debug
-                                debug: true,
-                                // Force relay candidate
-                                forceRelayCandidate: false)
         
-        do {
-            try telnyxClient?.processVoIPNotification(txConfig: txConfig, serverConfiguration: serverConfig,pushMetaData: pushMetaData)
-        } catch let error {
-            print("AppDelegate:: processVoIPNotification Error \(error)")
+        if selectedCredentials?.isToken ?? false {
+            let token = selectedCredentials?.username ?? ""
+            let deviceToken = userDefaults.getPushToken()
+            //Sets the login credentials and the ringtone/ringback configurations if required.
+            //Ringtone / ringback tone files are not mandatory.
+            let txConfig = TxConfig(token: token,
+                                    pushDeviceToken: deviceToken,
+                                    ringtone: "incoming_call.mp3",
+                                    ringBackTone: "ringback_tone.mp3",
+                                    //You can choose the appropriate verbosity level of the SDK.
+                                    logLevel: .all,
+                                    reconnectClient: true,
+                                    // Enable WebRTC stats debug
+                                    debug: true,
+                                    // Force relay candidate
+                                    forceRelayCandidate: false)
+            
+            do {
+                try telnyxClient?.processVoIPNotification(txConfig: txConfig, serverConfiguration: serverConfig,pushMetaData: pushMetaData)
+            } catch let error {
+                print("AppDelegate:: processVoIPNotification Error \(error)")
+            }
+        } else {
+            let sipUser = selectedCredentials?.username ?? ""
+            let password = selectedCredentials?.password ?? ""
+            let deviceToken = userDefaults.getPushToken()
+            //Sets the login credentials and the ringtone/ringback configurations if required.
+            //Ringtone / ringback tone files are not mandatory.
+            let txConfig = TxConfig(sipUser: sipUser,
+                                    password: password,
+                                    pushDeviceToken: deviceToken,
+                                    ringtone: "incoming_call.mp3",
+                                    ringBackTone: "ringback_tone.mp3",
+                                    //You can choose the appropriate verbosity level of the SDK.
+                                    logLevel: .all,
+                                    reconnectClient: true,
+                                    // Enable WebRTC stats debug
+                                    debug: true,
+                                    // Force relay candidate
+                                    forceRelayCandidate: false)
+            
+            do {
+                try telnyxClient?.processVoIPNotification(txConfig: txConfig, serverConfiguration: serverConfig,pushMetaData: pushMetaData)
+            } catch let error {
+                print("AppDelegate:: processVoIPNotification Error \(error)")
+            }
         }
+        
+        
+       
     }
 }

--- a/TelnyxWebRTCDemo/Extensions/UserDefaultExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/UserDefaultExtension.swift
@@ -27,8 +27,8 @@ extension UserDefaults {
         removeObject(forKey: UserDefaultsKey.pushDeviceToken.rawValue)
     }
     
-    func getPushToken() -> String {
-        return string(forKey: UserDefaultsKey.pushDeviceToken.rawValue) ?? ""
+    func getPushToken() -> String? {
+        return string(forKey: UserDefaultsKey.pushDeviceToken.rawValue)
     }
     
     func saveCallDestination(_ callDestination: String) {

--- a/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
+++ b/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
@@ -252,7 +252,7 @@ extension HomeViewController {
             // Update local credential
 
             let isToken = sipCredential.isToken ?? false
-            let txConfig = try createTxConfig(telnyxToken: isToken ? sipCredential.username : nil, sipCredential: sipCredential, deviceToken: nil)
+            let txConfig = try createTxConfig(telnyxToken: isToken ? sipCredential.username : nil, sipCredential: sipCredential, deviceToken: deviceToken)
             
             if let serverConfig = serverConfig {
                 print("Development Server ")

--- a/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
+++ b/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
@@ -126,11 +126,7 @@ class HomeViewController: UIViewController {
         print("Connect tapped")
         let deviceToken = userDefaults.getPushToken()
         if let selectedProfile = profileViewModel.selectedProfile {
-            if selectedProfile.isToken ?? false {
-                connectToTelnyx(telnyxToken: selectedProfile.username, sipCredential: nil, deviceToken: deviceToken)
-            } else {
-                connectToTelnyx(telnyxToken: nil, sipCredential: selectedProfile, deviceToken: deviceToken)
-            }
+            connectToTelnyx(sipCredential: selectedProfile, deviceToken: deviceToken)
         }
     }
     
@@ -177,11 +173,7 @@ extension HomeViewController: SipCredentialsViewControllerDelegate {
     func onNewSipCredential(credential: SipCredential?) {
         let deviceToken = userDefaults.getPushToken()
         if let newProfile = credential {
-            if newProfile.isToken ?? false {
-                connectToTelnyx(telnyxToken: newProfile.username, sipCredential: nil, deviceToken: deviceToken)
-            } else {
-                connectToTelnyx(telnyxToken: nil, sipCredential: newProfile, deviceToken: deviceToken)
-            }
+            connectToTelnyx(sipCredential: newProfile, deviceToken: deviceToken)
         }
     }
     
@@ -246,9 +238,8 @@ extension HomeViewController {
 
 // MARK: - Handle connection
 extension HomeViewController {
-    private func connectToTelnyx(telnyxToken: String?,
-                                 sipCredential: SipCredential?,
-                                 deviceToken: String) {
+    private func connectToTelnyx(sipCredential: SipCredential,
+                                 deviceToken: String?) {
         guard let telnyxClient = self.telnyxClient else { return }
         
         if telnyxClient.isConnected() {
@@ -257,7 +248,11 @@ extension HomeViewController {
         }
         
         do {
-            let txConfig = try createTxConfig(telnyxToken: telnyxToken, sipCredential: sipCredential, deviceToken: deviceToken)
+            self.viewModel.isLoading = true
+            // Update local credential
+
+            let isToken = sipCredential.isToken ?? false
+            let txConfig = try createTxConfig(telnyxToken: isToken ? sipCredential.username : nil, sipCredential: sipCredential, deviceToken: nil)
             
             if let serverConfig = serverConfig {
                 print("Development Server ")
@@ -267,7 +262,12 @@ extension HomeViewController {
                 try telnyxClient.connect(txConfig: txConfig)
             }
             
-            self.viewModel.isLoading = true
+            // Store user / password in user defaults
+            SipCredentialsManager.shared.addOrUpdateCredential(sipCredential)
+            SipCredentialsManager.shared.saveSelectedCredential(sipCredential)
+            // Update UI
+            self.onSipCredentialSelected(credential: sipCredential)
+
         } catch let error {
             print("ViewController:: connect Error \(error)")
             self.viewModel.isLoading = false
@@ -276,7 +276,7 @@ extension HomeViewController {
     
     private func createTxConfig(telnyxToken: String?,
                                 sipCredential: SipCredential?,
-                                deviceToken: String) throws -> TxConfig {
+                                deviceToken: String?) throws -> TxConfig {
         var txConfig: TxConfig? = nil
         
         // Set the connection configuration object.
@@ -287,9 +287,9 @@ extension HomeViewController {
                                 pushDeviceToken: deviceToken,
                                 ringtone: "incoming_call.mp3",
                                 ringBackTone: "ringback_tone.mp3",
-                                pushEnvironment: .production,
                                 // You can choose the appropriate verbosity level of the SDK.
                                 logLevel: .all,
+                                reconnectClient: true,
                                 // Enable webrtc stats debug
                                 debug: true,
                                 // Force relay candidate
@@ -308,12 +308,6 @@ extension HomeViewController {
                                 debug: true,
                                 // Force relay candidate.
                                 forceRelayCandidate: false)
-            
-            // Store user / password in user defaults
-            SipCredentialsManager.shared.addOrUpdateCredential(credential)
-            SipCredentialsManager.shared.saveSelectedCredential(credential)
-            // Update UI
-            self.onSipCredentialSelected(credential: credential)
         }
         
         guard let config = txConfig else {


### PR DESCRIPTION
<!-- Ticket details and link -->
[[WEBRTC-2505] [Feat] Handle JWT credentials](https://telnyx.atlassian.net/browse/WEBRTC-2505)
---
<!-- Describe your change here -->
- User can login with JWT tokens and if it's valid it will be stored into the list of user credentials. 
- We are handling PN for JWT Tokens. When a PN is received it will connect to Telnyx using the JWT token. 

## ✋ Manual testing

From the sample app:

1. Add a new JWT token
2. Login with JWT 
3. Kill the app
4. Place a call to the gencred associated with the JWT token. 
5. Answer the call



[WEBRTC-2505]: https://telnyx.atlassian.net/browse/WEBRTC-2505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ