### PR TITLE
WEBRTC-2521: Disabling Webrtc Stats while socket connection is recovering

### DIFF
--- a/TelnyxRTC/Telnyx/WebRTC/Call.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call.swift
@@ -438,6 +438,12 @@ public class Call {
     internal func updateCallState(callState: CallState) {
         Logger.log.i(message: "Call state updated: \(callState)")
         self.callState = callState
+        
+        // Notify the stats reporter about the call state change
+        if let statsReporter = self.statsReporter, debug {
+            statsReporter.handleCallStateChange(callState: callState)
+        }
+        
         self.delegate?.callStateUpdated(call: self)
     }
 } // End Call class


### PR DESCRIPTION
## Description

This PR addresses the issue where reconnection takes a long time (around 40 seconds) when WebRTC stats are enabled. The problem occurs because the SDK continues to send WebRTC stats over the socket while it is disconnected or when the internet connection is lost.

## Changes

1. Added an  flag to the  class to track when stats reporting should be paused
2. Added logic to check socket connection state and call state before sending stats
3. Added a  method to pause/resume stats based on call state
4. Updated the  class to notify the stats reporter when call state changes

## Expected Outcome

- WebRTC stats will not be sent when the socket is disconnected or when the call is in RECONNECTING or DROPPED state
- Reconnection time should be significantly reduced (from ~40 seconds to a reasonable duration)
- Once reconnected, stats reporting will resume automatically if the call is still active

## Jira Ticket
[WEBRTC-2521](https://telnyx.atlassian.net/browse/WEBRTC-2521)