### PR TITLE
WEBRTC-2521: Add changelog entry for version 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [1.2.1](https://github.com/team-telnyx/telnyx-webrtc-ios/releases/tag/1.2.1) (2025-03-11)
+
+### Bug Fixes
+- Disabled WebRTC stats during socket reconnection process to improve call reconnection speed.
+
 ## [1.2.0](https://github.com/team-telnyx/telnyx-webrtc-ios/releases/tag/1.2.0) (2025-03-01)
 
 ### Enhacement


### PR DESCRIPTION
## Description

This PR adds a changelog entry for version 1.2.1, which includes the fix to disable WebRTC stats during socket reconnection process. This change improves call reconnection speed.

## Changes

- Added changelog entry for version 1.2.1 in the CHANGELOG.md file
- Followed the same format as previous versions
- Provided a minimal description of the change

## Jira Ticket
[WEBRTC-2521](https://telnyx.atlassian.net/browse/WEBRTC-2521)

[WEBRTC-2521]: https://telnyx.atlassian.net/browse/WEBRTC-2521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ