### PR TITLE
[WEBRTC-2557] [Feature] [Sample App] Implement connection timeout logic in sample app

### DIFF
--- a/TelnyxWebRTCDemo/ViewControllers/HomeViewController+VoIPExtension.swift
+++ b/TelnyxWebRTCDemo/ViewControllers/HomeViewController+VoIPExtension.swift
@@ -14,10 +14,14 @@ extension HomeViewController : VoIPDelegate {
             self.viewModel.socketState = .connected
             self.sipCredentialsVC.dismiss(animated: false)
         }
+        // Don't stop the timer here, wait for onClientReady
     }
     
     func onSocketDisconnected() {
         print("ViewController:: TxClientDelegate onSocketDisconnected()")
+        
+        // Stop the connection timer if it's running
+        stopConnectionTimer()
         
         DispatchQueue.main.async {
             self.viewModel.isLoading = false
@@ -28,6 +32,9 @@ extension HomeViewController : VoIPDelegate {
     func onClientError(error: Error) {
         print("ViewController:: TxClientDelegate onClientError() error: \(error)")
         let noActiveCalls = self.telnyxClient?.calls.filter { $0.value.callState == .ACTIVE || $0.value.callState == .HELD }.isEmpty
+        
+        // Stop the connection timer if it's running
+        stopConnectionTimer()
         
         if noActiveCalls != true {
             return
@@ -77,6 +84,10 @@ extension HomeViewController : VoIPDelegate {
     
     func onClientReady() {
         print("ViewController:: TxClientDelegate onClientReady()")
+        
+        // Stop the connection timer as the connection is now established
+        stopConnectionTimer()
+        
         DispatchQueue.main.async {
             self.viewModel.isLoading = false
             self.viewModel.socketState = .clientReady

--- a/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
+++ b/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
@@ -288,7 +288,7 @@ extension HomeViewController {
     }
     
     // Start the connection timeout timer
-    private func startConnectionTimer() {
+    internal func startConnectionTimer() {
         // Invalidate any existing timer first
         stopConnectionTimer()
         
@@ -304,7 +304,7 @@ extension HomeViewController {
     }
     
     // Stop the connection timeout timer
-    private func stopConnectionTimer() {
+    internal func stopConnectionTimer() {
         connectionTimer?.invalidate()
         connectionTimer = nil
         print("Connection timer stopped")

--- a/TelnyxWebRTCDemo/ViewModels/HomeViewModel.swift
+++ b/TelnyxWebRTCDemo/ViewModels/HomeViewModel.swift
@@ -7,4 +7,7 @@ class HomeViewModel: ObservableObject {
     @Published var environment: String = "-"
     @Published var isLoading: Bool = false
     @Published var callState: CallState = .DONE
+    
+    // Connection timeout in seconds
+    let connectionTimeout: TimeInterval = 30.0
 }


### PR DESCRIPTION
## Description
This PR implements a timeout mechanism in the iOS sample app to prevent it from getting stuck when connecting to rtc.telnyx.com when there is no internet connection or the server is unresponsive.

## Changes
- Added a connection timeout property to `HomeViewModel` (30 seconds)
- Added a timer property to `HomeViewController` to track the connection timeout
- Implemented timer start/stop methods and timeout handling
- Added timer management in the connection flow:
  - Start timer when connection is initiated
  - Stop timer when connection is successful (onClientReady)
  - Stop timer when connection fails (onClientError)
  - Stop timer when user manually disconnects

## Behavior
When a timeout occurs, the app will:
1. Stop the loading indicator
2. Disconnect the socket
3. Show an alert to the user



https://github.com/user-attachments/assets/17c003fe-756d-4ca0-a9ae-120c18e82eb0


## Jira Ticket
[WEBRTC-2557](https://telnyx.atlassian.net/browse/WEBRTC-2557)

[WEBRTC-2557]: https://telnyx.atlassian.net/browse/WEBRTC-2557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ