### PR TITLE
WEBRTC-2558: [iOS] Voice SDK - Release 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [1.2.2](https://github.com/team-telnyx/telnyx-webrtc-ios/releases/tag/1.2.2) (2025-03-20)
+
+### Enhancements
+- Improved call reconnection process for better reliability during network changes
+- Added configurable reconnection timeout for more control over network recovery
+
 ## [1.2.1](https://github.com/team-telnyx/telnyx-webrtc-ios/releases/tag/1.2.1) (2025-03-11)
 
 ### Bug Fixes


### PR DESCRIPTION
## Description
This PR updates the CHANGELOG.md for the 1.2.2 release of the iOS Voice SDK.

### Changes
- Updated CHANGELOG.md with version 1.2.2 information
- Highlighted improvements to the call reconnection process
- Added information about the new configurable reconnection timeout

## Jira Ticket
[WEBRTC-2558](https://telnyx.atlassian.net/browse/WEBRTC-2558)