### PR TITLE
WEBRTC-2559: UI Implementation for handling multiple calls on Demo App

### DIFF
--- a/TelnyxRTC.xcodeproj/project.pbxproj
+++ b/TelnyxRTC.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0625B70BEAC00D5C1EB97BE1 /* Pods_TelnyxRTC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 08F9EC11D802BAB887557386 /* Pods_TelnyxRTC.framework */; };
 		3B0F56CB2C7F15830011A48A /* StatsMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0F56CA2C7F15830011A48A /* StatsMessage.swift */; };
 		3B1BE6F72AA9A467000B7962 /* TxPushIPConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1BE6F62AA9A467000B7962 /* TxPushIPConfig.swift */; };
 		3B1F43EF2AE0B01E00A610BA /* Params.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1F43EE2AE0B01E00A610BA /* Params.swift */; };
@@ -21,7 +20,7 @@
 		3BABEA392D5F595A00B7C79C /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BABEA382D5F595A00B7C79C /* NetworkMonitor.swift */; };
 		3BC03B4E2CC25F5F00FD2B29 /* Reachability.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B0F56CC2C7F1CCA0011A48A /* Reachability.framework */; };
 		3BF1D5842BEB7B8F0097453F /* TelnyxRTC.podspec in Resources */ = {isa = PBXBuildFile; fileRef = 3BF1D5832BEB7B8F0097453F /* TelnyxRTC.podspec */; };
-		72360FFF38E07DA9FBD52311 /* Pods_TelnyxRTC_TelnyxRTCTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C6477303A77FD516F4AF935 /* Pods_TelnyxRTC_TelnyxRTCTests.framework */; };
+		7EB2E65F89305CF57BD63F27 /* Pods_TelnyxRTC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B853B231995808B2BEBC3F23 /* Pods_TelnyxRTC.framework */; };
 		9911247E2CF50092000C23BA /* Dictionary+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9911247D2CF50088000C23BA /* Dictionary+Extensions.swift */; };
 		991A6D442D3A96C100B29785 /* SplashScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991A6D432D3A96C100B29785 /* SplashScreen.swift */; };
 		991A6D492D3AB36E00B29785 /* SipCredentialsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991A6D482D3AB36E00B29785 /* SipCredentialsView.swift */; };
@@ -120,8 +119,9 @@
 		B3E1029A25F2C16500227DCE /* ModifyMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E1029925F2C16500227DCE /* ModifyMessage.swift */; };
 		B3E1033225F7F94900227DCE /* incoming_call.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = B3E1033025F7F94900227DCE /* incoming_call.mp3 */; };
 		B3E1033325F7F94900227DCE /* ringback_tone.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = B3E1033125F7F94900227DCE /* ringback_tone.mp3 */; };
-		B84E50517AD67FE44AC37952 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
-		EB9B6A26518AD94606426627 /* Pods_TelnyxWebRTCDemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 784A5AF30CB86852E72E8B4E /* Pods_TelnyxWebRTCDemo.framework */; };
+		B84E50517AD67FE44AC37952 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
+		BB6E0EDBF9F6547C650386AE /* Pods_TelnyxRTC_TelnyxRTCTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5251CC82192867F4903DEEC1 /* Pods_TelnyxRTC_TelnyxRTCTests.framework */; };
+		E42501713E0451C76A71AFBC /* Pods_TelnyxWebRTCDemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F3E4D1DFD4A46822F44C510F /* Pods_TelnyxWebRTCDemo.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -173,9 +173,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		08F9EC11D802BAB887557386 /* Pods_TelnyxRTC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxRTC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		16BE4A701775FFFB83AA3D77 /* Pods-TelnyxRTC.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC.release.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC/Pods-TelnyxRTC.release.xcconfig"; sourceTree = "<group>"; };
-		1C6477303A77FD516F4AF935 /* Pods_TelnyxRTC_TelnyxRTCTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxRTC_TelnyxRTCTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0E521DA9EE89948D68FFFA39 /* Pods-TelnyxRTC.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC.release.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC/Pods-TelnyxRTC.release.xcconfig"; sourceTree = "<group>"; };
+		30902ED4B5EC816A535331BD /* Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig"; sourceTree = "<group>"; };
 		3B0F56CA2C7F15830011A48A /* StatsMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsMessage.swift; sourceTree = "<group>"; };
 		3B0F56CC2C7F1CCA0011A48A /* Reachability.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Reachability.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B1BE6F62AA9A467000B7962 /* TxPushIPConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxPushIPConfig.swift; sourceTree = "<group>"; };
@@ -187,9 +186,9 @@
 		3B91C0F42BE3A44600A03067 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		3BABEA382D5F595A00B7C79C /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
 		3BF1D5832BEB7B8F0097453F /* TelnyxRTC.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = TelnyxRTC.podspec; sourceTree = "<group>"; };
-		6398D465D32B69C5DD343742 /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig"; sourceTree = "<group>"; };
-		77A12850421EF9E7C6CAF8A6 /* Pods-TelnyxWebRTCDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxWebRTCDemo.debug.xcconfig"; path = "Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo.debug.xcconfig"; sourceTree = "<group>"; };
-		784A5AF30CB86852E72E8B4E /* Pods_TelnyxWebRTCDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxWebRTCDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5251CC82192867F4903DEEC1 /* Pods_TelnyxRTC_TelnyxRTCTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxRTC_TelnyxRTCTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		527925E79DE26CD3E26AC188 /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig"; sourceTree = "<group>"; };
+		5FC9450D1C6A5C27F50EA72B /* Pods-TelnyxWebRTCDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxWebRTCDemo.debug.xcconfig"; path = "Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo.debug.xcconfig"; sourceTree = "<group>"; };
 		9911247D2CF50088000C23BA /* Dictionary+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extensions.swift"; sourceTree = "<group>"; };
 		991A6D432D3A96C100B29785 /* SplashScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashScreen.swift; sourceTree = "<group>"; };
 		991A6D462D3AB36E00B29785 /* SipCredentialHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SipCredentialHeader.swift; sourceTree = "<group>"; };
@@ -242,7 +241,6 @@
 		99D717752D6E229000471D44 /* TelnyxRTCLoggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelnyxRTCLoggerTests.swift; sourceTree = "<group>"; };
 		99FF7B0F2D4BC4F700DB1408 /* DTMFKeyboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DTMFKeyboardView.swift; sourceTree = "<group>"; };
 		99FF7B112D4BC71800DB1408 /* DTMFKeyboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DTMFKeyboardViewModel.swift; sourceTree = "<group>"; };
-		9E87A28BE544F7FDB409B32C /* Pods-TelnyxWebRTCDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxWebRTCDemo.release.xcconfig"; path = "Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo.release.xcconfig"; sourceTree = "<group>"; };
 		B309D11125EF107F00A2AADF /* Starscream.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Starscream.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B309D1D525F020B300A2AADF /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		B309D1DA25F020D400A2AADF /* Method.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Method.swift; sourceTree = "<group>"; };
@@ -295,8 +293,10 @@
 		B3E1029925F2C16500227DCE /* ModifyMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyMessage.swift; sourceTree = "<group>"; };
 		B3E1033025F7F94900227DCE /* incoming_call.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = incoming_call.mp3; sourceTree = "<group>"; };
 		B3E1033125F7F94900227DCE /* ringback_tone.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = ringback_tone.mp3; sourceTree = "<group>"; };
-		CC468BC444BE3E4261450CFC /* Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig"; sourceTree = "<group>"; };
-		DD202DB325F6C231624793BF /* Pods-TelnyxRTC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC.debug.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC/Pods-TelnyxRTC.debug.xcconfig"; sourceTree = "<group>"; };
+		B4ECC0DD58D74A9E74DD62A7 /* Pods-TelnyxWebRTCDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxWebRTCDemo.release.xcconfig"; path = "Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo.release.xcconfig"; sourceTree = "<group>"; };
+		B853B231995808B2BEBC3F23 /* Pods_TelnyxRTC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxRTC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E78E903E5E2745ADF926EF38 /* Pods-TelnyxRTC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC.debug.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC/Pods-TelnyxRTC.debug.xcconfig"; sourceTree = "<group>"; };
+		F3E4D1DFD4A46822F44C510F /* Pods_TelnyxWebRTCDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxWebRTCDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -312,7 +312,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B309D13D25EF119E00A2AADF /* Starscream.framework in Frameworks */,
-				0625B70BEAC00D5C1EB97BE1 /* Pods_TelnyxRTC.framework in Frameworks */,
+				7EB2E65F89305CF57BD63F27 /* Pods_TelnyxRTC.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -321,8 +321,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				B368BED625EDDBC90032AE52 /* TelnyxRTC.framework in Frameworks */,
-				B84E50517AD67FE44AC37952 /* (null) in Frameworks */,
-				72360FFF38E07DA9FBD52311 /* Pods_TelnyxRTC_TelnyxRTCTests.framework in Frameworks */,
+				B84E50517AD67FE44AC37952 /* BuildFile in Frameworks */,
+				BB6E0EDBF9F6547C650386AE /* Pods_TelnyxRTC_TelnyxRTCTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -332,7 +332,7 @@
 			files = (
 				3B5CD8D92D833677006D3734 /* TelnyxRTC.framework in Frameworks */,
 				3BC03B4E2CC25F5F00FD2B29 /* Reachability.framework in Frameworks */,
-				EB9B6A26518AD94606426627 /* Pods_TelnyxWebRTCDemo.framework in Frameworks */,
+				E42501713E0451C76A71AFBC /* Pods_TelnyxWebRTCDemo.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -342,12 +342,12 @@
 		8AB3A6A2ADA6A9FAC6C77491 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				DD202DB325F6C231624793BF /* Pods-TelnyxRTC.debug.xcconfig */,
-				16BE4A701775FFFB83AA3D77 /* Pods-TelnyxRTC.release.xcconfig */,
-				6398D465D32B69C5DD343742 /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */,
-				CC468BC444BE3E4261450CFC /* Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig */,
-				77A12850421EF9E7C6CAF8A6 /* Pods-TelnyxWebRTCDemo.debug.xcconfig */,
-				9E87A28BE544F7FDB409B32C /* Pods-TelnyxWebRTCDemo.release.xcconfig */,
+				E78E903E5E2745ADF926EF38 /* Pods-TelnyxRTC.debug.xcconfig */,
+				0E521DA9EE89948D68FFFA39 /* Pods-TelnyxRTC.release.xcconfig */,
+				527925E79DE26CD3E26AC188 /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */,
+				30902ED4B5EC816A535331BD /* Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig */,
+				5FC9450D1C6A5C27F50EA72B /* Pods-TelnyxWebRTCDemo.debug.xcconfig */,
+				B4ECC0DD58D74A9E74DD62A7 /* Pods-TelnyxWebRTCDemo.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -694,9 +694,9 @@
 			children = (
 				3B0F56CC2C7F1CCA0011A48A /* Reachability.framework */,
 				B309D11125EF107F00A2AADF /* Starscream.framework */,
-				08F9EC11D802BAB887557386 /* Pods_TelnyxRTC.framework */,
-				1C6477303A77FD516F4AF935 /* Pods_TelnyxRTC_TelnyxRTCTests.framework */,
-				784A5AF30CB86852E72E8B4E /* Pods_TelnyxWebRTCDemo.framework */,
+				B853B231995808B2BEBC3F23 /* Pods_TelnyxRTC.framework */,
+				5251CC82192867F4903DEEC1 /* Pods_TelnyxRTC_TelnyxRTCTests.framework */,
+				F3E4D1DFD4A46822F44C510F /* Pods_TelnyxWebRTCDemo.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -737,7 +737,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = B368BEC825EDDB610032AE52 /* Build configuration list for PBXNativeTarget "TelnyxRTC" */;
 			buildPhases = (
-				1F7E6B31CC438CE8C4CF753B /* [CP] Check Pods Manifest.lock */,
+				AD5CD1607F2DC9535061D55B /* [CP] Check Pods Manifest.lock */,
 				B368BEBB25EDDB610032AE52 /* Headers */,
 				B368BEBC25EDDB610032AE52 /* Sources */,
 				B368BEBD25EDDB610032AE52 /* Frameworks */,
@@ -757,11 +757,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = B368BEDB25EDDBC90032AE52 /* Build configuration list for PBXNativeTarget "TelnyxRTCTests" */;
 			buildPhases = (
-				B343C2141FEACA1D426C9896 /* [CP] Check Pods Manifest.lock */,
+				E4EFEB8650027D10B8B6BB9A /* [CP] Check Pods Manifest.lock */,
 				B368BECD25EDDBC90032AE52 /* Sources */,
 				B368BECE25EDDBC90032AE52 /* Frameworks */,
 				B368BECF25EDDBC90032AE52 /* Resources */,
-				37EC15B89443A429B820E3C8 /* [CP] Embed Pods Frameworks */,
+				6BE8BE3061F659FE222A4186 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -777,12 +777,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = B368BEF925EDDD070032AE52 /* Build configuration list for PBXNativeTarget "TelnyxWebRTCDemo" */;
 			buildPhases = (
-				54A38B104A11670269B33136 /* [CP] Check Pods Manifest.lock */,
+				4BF52D52152337894691A19C /* [CP] Check Pods Manifest.lock */,
 				B368BEE425EDDD060032AE52 /* Sources */,
 				B368BEE525EDDD060032AE52 /* Frameworks */,
 				B368BEE625EDDD060032AE52 /* Resources */,
-				E16C81FE28CFF517F8139D40 /* [CP] Embed Pods Frameworks */,
 				3B5CD8DB2D833677006D3734 /* Embed Frameworks */,
+				7E8D75304D7750B0CFB2E8E3 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -882,46 +882,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		1F7E6B31CC438CE8C4CF753B /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-TelnyxRTC-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		37EC15B89443A429B820E3C8 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		54A38B104A11670269B33136 /* [CP] Check Pods Manifest.lock */ = {
+		4BF52D52152337894691A19C /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -943,7 +904,63 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		B343C2141FEACA1D426C9896 /* [CP] Check Pods Manifest.lock */ = {
+		6BE8BE3061F659FE222A4186 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		7E8D75304D7750B0CFB2E8E3 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		AD5CD1607F2DC9535061D55B /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-TelnyxRTC-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E4EFEB8650027D10B8B6BB9A /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -963,23 +980,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		E16C81FE28CFF517F8139D40 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -1321,7 +1321,7 @@
 		};
 		B368BEC925EDDB610032AE52 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DD202DB325F6C231624793BF /* Pods-TelnyxRTC.debug.xcconfig */;
+			baseConfigurationReference = E78E903E5E2745ADF926EF38 /* Pods-TelnyxRTC.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -1361,7 +1361,7 @@
 		};
 		B368BECA25EDDB610032AE52 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 16BE4A701775FFFB83AA3D77 /* Pods-TelnyxRTC.release.xcconfig */;
+			baseConfigurationReference = 0E521DA9EE89948D68FFFA39 /* Pods-TelnyxRTC.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -1395,7 +1395,7 @@
 		};
 		B368BED925EDDBC90032AE52 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6398D465D32B69C5DD343742 /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */;
+			baseConfigurationReference = 527925E79DE26CD3E26AC188 /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
@@ -1416,7 +1416,7 @@
 		};
 		B368BEDA25EDDBC90032AE52 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CC468BC444BE3E4261450CFC /* Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig */;
+			baseConfigurationReference = 30902ED4B5EC816A535331BD /* Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
@@ -1437,7 +1437,7 @@
 		};
 		B368BEFA25EDDD070032AE52 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 77A12850421EF9E7C6CAF8A6 /* Pods-TelnyxWebRTCDemo.debug.xcconfig */;
+			baseConfigurationReference = 5FC9450D1C6A5C27F50EA72B /* Pods-TelnyxWebRTCDemo.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -1464,7 +1464,7 @@
 		};
 		B368BEFB25EDDD070032AE52 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9E87A28BE544F7FDB409B32C /* Pods-TelnyxWebRTCDemo.release.xcconfig */;
+			baseConfigurationReference = B4ECC0DD58D74A9E74DD62A7 /* Pods-TelnyxWebRTCDemo.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
@@ -48,6 +48,19 @@ extension AppDelegate : CXProviderDelegate {
         }
     }
     
+    func excuteCallOnHoldAction(uuid: UUID, isOnHold: Bool) {
+        let setHeldAction = CXSetHeldCallAction(call: UUID(uuidString: uuid.uuidString)!, onHold: isOnHold)
+        let transaction = CXTransaction()
+        transaction.addAction(setHeldAction)
+        callKitCallController.request(transaction) { error in
+            if let error = error {
+                print("AppDelegate:: HoldCallAction transaction request failed: \(error.localizedDescription).")
+            } else {
+                print("AppDelegate:: HoldCallAction transaction request successful")
+            }
+        }
+    }
+    
     func executeOutGoingCall() {
         if let provider = self.callKitProvider,
            let callKitUUID = self.callKitUUID {
@@ -175,7 +188,7 @@ extension AppDelegate : CXProviderDelegate {
     }
 
     func provider(_ provider: CXProvider, perform action: CXEndCallAction) {
-        print("AppDelegate:: END call action: callKitUUID [\(String(describing: self.callKitUUID))] action [\(action.callUUID)]")
+        print("AppDelegate:: CXEndCallAction: callKitUUID [\(String(describing: self.callKitUUID))] action [\(action.callUUID)]")
         
         if(previousCall?.callState == .HELD){
             print("AppDelegate:: call held.. unholding call")

--- a/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
+++ b/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
@@ -450,6 +450,8 @@ extension HomeViewController {
     func onHoldUnholdSwitch(isOnHold: Bool) {
         if isOnHold {
             self.appDelegate.currentCall?.hold()
+            let currentCall =  self.appDelegate.currentCall
+            self.appDelegate.excuteCallOnHoldAction(uuid: currentCall?.callInfo?.callId ?? UUID(), isOnHold: isOnHold)
         } else {
             self.appDelegate.currentCall?.unhold()
         }

--- a/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
+++ b/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
@@ -62,6 +62,9 @@ class HomeViewController: UIViewController {
             },
             onDTMF: { [weak self] key in
                 self?.appDelegate.currentCall?.dtmf(dtmf: key)
+            },
+            onStartNewCall: { [weak self] in
+                self?.onStartNewCall()
             }
         )
         
@@ -400,6 +403,21 @@ extension HomeViewController {
         let uuid = UUID()
         let handle = "Telnyx"
         
+        appDelegate.executeStartCallAction(uuid: uuid, handle: handle)
+    }
+    
+    func onStartNewCall() {
+        // Store the current call as the previous call
+        self.appDelegate.previousCall = self.appDelegate.currentCall
+        
+        // Use the current sipAddress for the new call
+        let destinationNumber = self.callViewModel.sipAddress
+        
+        // Create a new UUID for the call
+        let uuid = UUID()
+        let handle = "Telnyx"
+        
+        // Execute the start call action
         appDelegate.executeStartCallAction(uuid: uuid, handle: handle)
     }
     

--- a/TelnyxWebRTCDemo/ViewModels/CallViewModel.swift
+++ b/TelnyxWebRTCDemo/ViewModels/CallViewModel.swift
@@ -7,5 +7,7 @@ class CallViewModel: ObservableObject {
     @Published var isSpeakerOn: Bool = false
     @Published var callState: CallState = .DONE
     @Published var isOnHold: Bool = false
-    @Published var showDTMFKeyboard: Bool = false    
+    @Published var showDTMFKeyboard: Bool = false
+    @Published var isMultiCallActive: Bool = false
+    @Published var newCallNumber: String = "+15551234567" // Default number for new call
 }

--- a/TelnyxWebRTCDemo/ViewModels/CallViewModel.swift
+++ b/TelnyxWebRTCDemo/ViewModels/CallViewModel.swift
@@ -9,5 +9,4 @@ class CallViewModel: ObservableObject {
     @Published var isOnHold: Bool = false
     @Published var showDTMFKeyboard: Bool = false
     @Published var isMultiCallActive: Bool = false
-    @Published var newCallNumber: String = "+15551234567" // Default number for new call
 }

--- a/TelnyxWebRTCDemo/Views/CallView.swift
+++ b/TelnyxWebRTCDemo/Views/CallView.swift
@@ -12,6 +12,7 @@ struct CallView: View {
     let onToggleSpeaker: () -> Void
     let onHold: (Bool) -> Void
     let onDTMF: (String) -> Void
+    let onStartNewCall: () -> Void
 
     var body: some View {
         VStack {
@@ -72,8 +73,8 @@ struct CallView: View {
             TextField("Enter sip address or phone number", text: $viewModel.sipAddress)
                 .textFieldStyle(RoundedBorderTextFieldStyle())
                 .padding()
-                .disabled(true)
-                .opacity(0.5)
+                .disabled(false) // Enable the text field during active calls
+                .opacity(1.0)
                         
             HStack {
                 Button(action: {
@@ -126,20 +127,48 @@ struct CallView: View {
                         .clipShape(Circle())
                 }
                 .accessibilityIdentifier(AccessibilityIdentifiers.dtmfButton)
-
             }
             
-            Button(action: {
-                onEndCall()
-            }) {
-                Image(systemName: "phone.down.fill")
-                    .foregroundColor(Color(hex: "#1D1D1D"))
-                    .frame(width: 60, height: 60)
-                    .background(Color(hex: "#EB0000"))
-                    .clipShape(Circle())
+            HStack {
+                // New Call Button
+                Button(action: {
+                    // Put current call on hold
+                    if !viewModel.isOnHold {
+                        viewModel.isOnHold = true
+                        onHold(true)
+                    }
+                    // Start a new call
+                    onStartNewCall()
+                }) {
+                    HStack {
+                        Image(systemName: "phone.fill.badge.plus")
+                            .foregroundColor(Color(hex: "#1D1D1D"))
+                        Text("New Call")
+                            .foregroundColor(Color(hex: "#1D1D1D"))
+                            .font(.system(size: 14, weight: .medium))
+                    }
+                    .frame(height: 40)
+                    .padding(.horizontal, 16)
+                    .background(Color(hex: "#00E3AA"))
+                    .cornerRadius(20)
+                }
+                .accessibilityIdentifier("newCallButton")
+                .padding(.horizontal, 8)
+                
+                // End Call Button
+                Button(action: {
+                    onEndCall()
+                }) {
+                    Image(systemName: "phone.down.fill")
+                        .foregroundColor(Color(hex: "#1D1D1D"))
+                        .frame(width: 60, height: 60)
+                        .background(Color(hex: "#EB0000"))
+                        .clipShape(Circle())
+                }
+                .accessibilityIdentifier(AccessibilityIdentifiers.hangupButton)
+                .padding(.horizontal, 8)
             }
-            .accessibilityIdentifier(AccessibilityIdentifiers.hangupButton)
-            .padding()
+            .padding(.vertical, 8)
         }
         Spacer()
     }
@@ -191,7 +220,8 @@ struct CallView_Previews: PreviewProvider {
             onMuteUnmuteSwitch: { _ in },
             onToggleSpeaker: {},
             onHold: { _ in },
-            onDTMF: { _ in }
+            onDTMF: { _ in },
+            onStartNewCall: {}
         )
     }
 }

--- a/TelnyxWebRTCDemo/Views/HomeView.swift
+++ b/TelnyxWebRTCDemo/Views/HomeView.swift
@@ -220,7 +220,7 @@ struct HomeView_Previews: PreviewProvider {
                     onMuteUnmuteSwitch: { _ in },
                     onToggleSpeaker: {},
                     onHold: { _ in },
-                    onDTMF: { _ in }
+                    onDTMF: { _ in }, onStartNewCall: {}
                 )
             )
         )

--- a/TelnyxWebRTCDemo/Views/HomeView.swift
+++ b/TelnyxWebRTCDemo/Views/HomeView.swift
@@ -220,7 +220,8 @@ struct HomeView_Previews: PreviewProvider {
                     onMuteUnmuteSwitch: { _ in },
                     onToggleSpeaker: {},
                     onHold: { _ in },
-                    onDTMF: { _ in }, onStartNewCall: {}
+                    onDTMF: { _ in },
+                    onStartNewCall: {}
                 )
             )
         )


### PR DESCRIPTION
## Description
This PR implements the UI changes needed to handle multiple calls in the Demo App.

### Changes
- Modified CallViewModel to add support for multiple calls
- Updated CallView to enable the text field during active calls
- Added a "New Call" button that puts the current call on hold and initiates a new call
- Implemented the onStartNewCall method in HomeViewController

### How to Test
1. Make a call to any number
2. While on the call, enter a new number in the text field
3. Press the "New Call" button
4. The first call should be put on hold and a new call should be initiated

Fixes: [WEBRTC-2559](https://telnyx.atlassian.net/browse/WEBRTC-2559)

[WEBRTC-2559]: https://telnyx.atlassian.net/browse/WEBRTC-2559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ