### PR TITLE
WEBRTC-2589: [IOS] - UUID problem for PSTN Inbound Call

### DIFF
--- a/TelnyxRTC/Telnyx/Models/TxCallInfo.swift
+++ b/TelnyxRTC/Telnyx/Models/TxCallInfo.swift
@@ -11,16 +11,38 @@ import Foundation
 
 /// `TxCallInfo` contains the required information of the current Call
 public struct TxCallInfo {
-    /// The UUID of the call
+    /// The UUID of the call - Used by SDK consumers and required for CallKit integration
     public internal(set) var callId: UUID
+    /// The string representation of the call ID - Used internally for communication with the server
+    /// This can be either a UUID string or a non-UUID format like "420009675_133898086@206.147.68.154"
+    internal var callIdString: String
     /// The caller name of the call
     public internal(set) var callerName:String?
     /// The caller number of the call
     public internal(set) var callerNumber: String?
+    
+    /// Initialize with a UUID
+    init(callId: UUID) {
+        self.callId = callId
+        self.callIdString = callId.uuidString.lowercased()
+    }
+    
+    /// Initialize with a string callId
+    /// If the string is a valid UUID, both callId and callIdString will use it
+    /// If not, a new UUID will be generated for callId, and the original string will be kept in callIdString
+    init(callIdString: String) {
+        if let uuid = UUID(uuidString: callIdString) {
+            self.callId = uuid
+            self.callIdString = callIdString.lowercased()
+        } else {
+            self.callId = UUID()
+            self.callIdString = callIdString
+        }
+    }
 
     func encode() -> [String : Any] {
         var dictionary = [String : Any]()
-        dictionary["callID"] = callId.uuidString.lowercased()
+        dictionary["callID"] = callIdString
         dictionary["caller_id_name"] = callerName ?? ""
         dictionary["caller_id_number"] = callerNumber ?? ""
         return dictionary

--- a/TelnyxRTC/Telnyx/WebRTC/Call.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call.swift
@@ -231,7 +231,8 @@ public class Call {
 
     // MARK: - Initializers
     /// Constructor for incoming calls
-    init(callId: UUID,
+    init(callId: UUID, callIdString: String,
+         callIdString: String,
          remoteSdp: String,
          sessionId: String,
          socket: Socket,
@@ -259,7 +260,7 @@ public class Call {
         self.telnyxLegId = telnyxLegId
 
         self.remoteSdp = remoteSdp
-        self.callInfo = TxCallInfo(callId: callId)
+        self.callInfo = TxCallInfo(callIdString: callIdString)
         self.delegate = delegate
 
         // Configure iceServers
@@ -282,7 +283,7 @@ public class Call {
     }
     
     //Contructor for attachCalls
-    init(callId: UUID,
+    init(callId: UUID, callIdString: String,
          remoteSdp: String,
          sessionId: String,
          socket: Socket,
@@ -302,7 +303,7 @@ public class Call {
         self.telnyxLegId = telnyxLegId
 
         self.remoteSdp = remoteSdp
-        self.callInfo = TxCallInfo(callId: callId)
+        self.callInfo = TxCallInfo(callIdString: callIdString)
         self.delegate = delegate
 
         // Configure iceServers
@@ -313,7 +314,7 @@ public class Call {
     }
 
     /// Constructor for outgoing calls
-    init(callId: UUID,
+    init(callId: UUID, callIdString: String,
          sessionId: String,
          socket: Socket,
          delegate: CallProtocol,
@@ -326,7 +327,7 @@ public class Call {
         self.sessionId = sessionId
         //this is the signaling server socket
         self.socket = socket
-        self.callInfo = TxCallInfo(callId: callId)
+        self.callInfo = TxCallInfo(callIdString: callIdString)
         self.delegate = delegate
 
         // Configure iceServers
@@ -470,7 +471,7 @@ extension Call {
     public func hangup() {
         Logger.log.i(message: "Call:: hangup()")
         guard let sessionId = self.sessionId, let callId = self.callInfo?.callId else { return }
-        let byeMessage = ByeMessage(sessionId: sessionId, callId: callId.uuidString, causeCode: .USER_BUSY)
+        let byeMessage = ByeMessage(sessionId: sessionId, callId: callInfo?.callIdString ?? callId.uuidString, causeCode: .USER_BUSY)
         let message = byeMessage.encode() ?? ""
         self.socket?.sendMessage(message: message)
         self.endCall()
@@ -632,7 +633,7 @@ extension Call {
         Logger.log.i(message: "Call:: hold()")
         guard let callId = self.callInfo?.callId,
               let sessionId = self.sessionId else { return }
-        let hold = ModifyMessage(sessionId: sessionId, callId: callId.uuidString, action: .HOLD)
+        let hold = ModifyMessage(sessionId: sessionId, callId: callInfo?.callIdString ?? callId.uuidString, action: .HOLD)
         let message = hold.encode() ?? ""
         self.socket?.sendMessage(message: message)
         self.updateCallState(callState: .HELD)
@@ -647,7 +648,7 @@ extension Call {
         Logger.log.i(message: "Call:: unhold()")
         guard let callId = self.callInfo?.callId,
               let sessionId = self.sessionId else { return }
-        let unhold = ModifyMessage(sessionId: sessionId, callId: callId.uuidString, action: .UNHOLD)
+        let unhold = ModifyMessage(sessionId: sessionId, callId: callInfo?.callIdString ?? callId.uuidString, action: .UNHOLD)
         let message = unhold.encode() ?? ""
         self.socket?.sendMessage(message: message)
         self.updateCallState(callState: .ACTIVE)
@@ -661,7 +662,7 @@ extension Call {
         Logger.log.i(message: "Call:: toggleHold()")
         guard let callId = self.callInfo?.callId,
               let sessionId = self.sessionId else { return }
-        let toggleHold = ModifyMessage(sessionId: sessionId, callId: callId.uuidString, action: .TOGGLE_HOLD)
+        let toggleHold = ModifyMessage(sessionId: sessionId, callId: callInfo?.callIdString ?? callId.uuidString, action: .TOGGLE_HOLD)
         let message = toggleHold.encode() ?? ""
         self.socket?.sendMessage(message: message)
 

--- a/TelnyxRTCTests/Verto/VertoMessagesTests.swift
+++ b/TelnyxRTCTests/Verto/VertoMessagesTests.swift
@@ -120,9 +120,9 @@ class VertoMessagesTests: XCTestCase {
         let callId = UUID.init()
         let callerName = "<callerName>"
         let callerNumber = "<callerNumber>"
-        let callInfo: TxCallInfo = TxCallInfo(callId: callId,
-                                              callerName: callerName,
-                                              callerNumber: callerNumber)
+        let callInfo: TxCallInfo = TxCallInfo(callIdString: callId.uuidString); callInfo.callerName = 
+                                              callerName; callInfo.callerNumber = 
+                                              callerNumber
         // Setup callOptions
         let destinationNumber = "<destinationNumber>"
         let remoteCallerName = "<remoteCallerName>"
@@ -217,9 +217,9 @@ class VertoMessagesTests: XCTestCase {
         let callId = UUID.init()
         let callerName = "<callerName>"
         let callerNumber = "<callerNumber>"
-        let callInfo: TxCallInfo = TxCallInfo(callId: callId,
-                                              callerName: callerName,
-                                              callerNumber: callerNumber)
+        let callInfo: TxCallInfo = TxCallInfo(callIdString: callId.uuidString); callInfo.callerName = 
+                                              callerName; callInfo.callerNumber = 
+                                              callerNumber
         // Setup callOptions
         let destinationNumber = "<destinationNumber>"
         let remoteCallerName = "<remoteCallerName>"
@@ -304,7 +304,7 @@ class VertoMessagesTests: XCTestCase {
         let callId = UUID.init()
         let dtmf = "1"
 
-        let callInfo = TxCallInfo(callId: callId, callerName: "<caller_name>", callerNumber: "<caller_number>")
+        let callInfo = TxCallInfo(callIdString: callId.uuidString); callInfo.callerName = "<caller_name>"; callInfo.callerNumber = "<caller_number>"
         let callOptions = TxCallOptions(destinationNumber: "<destination_number>", audio: true)
         let infoMessage = InfoMessage(sessionId: sessionId, dtmf: dtmf, callInfo: callInfo, callOptions: callOptions)
 


### PR DESCRIPTION
## Description

This PR addresses the issue with PSTN inbound calls where the callID is not a valid UUID format. The current SDK expects callIDs to be valid UUIDs, but PSTN calls provide callIDs in a different format like '420009675_133898086@206.147.68.154'.

## Changes

- Added callIdString property to TxCallInfo to store the original callID string
- Modified Call initializers to accept string callIDs
- Updated message handling to work with both UUID and non-UUID formats
- Updated tests to work with the new implementation

## Implementation Details

Each call now has two callIDs:
1. UUID callID – Used by the SDK consumers and required for CallKit integration
2. String callID – Used internally within the SDK for communication with the server

For incoming calls:
- If the server-provided callID is a valid UUID, we use it for both the UUID and String callIDs
- If the callID is not a valid UUID, we generate a new UUID internally for TxCallInfo, while keeping the original string callID for internal SDK-server communication

This ensures backward compatibility while allowing the SDK to handle PSTN call IDs in non-UUID formats.

## Jira Ticket
[WEBRTC-2589](https://telnyx.atlassian.net/browse/WEBRTC-2589)

[WEBRTC-2589]: https://telnyx.atlassian.net/browse/WEBRTC-2589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ