### PR TITLE
WEBRTC-2685: [iOS][Sample App] Fix Profile Name Overflow Affecting Switch Profile Button Layout

### DIFF
--- a/TelnyxWebRTCDemo/Views/ProfileView.swift
+++ b/TelnyxWebRTCDemo/Views/ProfileView.swift
@@ -31,8 +31,8 @@ struct ProfileView: View {
                         Text(viewModel.selectedProfile?.username ?? "")
                             .font(.system(size: 18, weight: .regular))
                             .foregroundColor(Color(hex: "1D1D1D"))
-                            .lineLimit(1)  
-                            .layoutPriority(1)
+                            .frame(maxWidth: 150, alignment: .leading)
+                            .lineLimit(1)
                         
                         Button(action: onSwitchProfile) {
                             Text("Switch Profile")


### PR DESCRIPTION
## WEBRTC-2685: Fix Profile Name Overflow Affecting Switch Profile Button Layout

### Changes Made
- Added a maxWidth constraint of 150 points to the profile name Text component in ProfileView.swift
- Maintained left alignment (.leading) for the username text
- Kept the existing lineLimit(1) to ensure text truncation with ellipsis

### Acceptance Criteria Met
- The profile name text will never overlap or push the button out of view
- Long usernames will be truncated gracefully with an ellipsis
- The 'Switch Profile' button will always be fully visible and aligned to the right of the profile name
- Layout remains responsive and visually consistent across different device sizes

### Testing
- Tested with various profile name lengths to ensure proper truncation and layout
- Verified that the 'Switch Profile' button remains visible at all times

### Related Jira Ticket
[WEBRTC-2685](https://telnyx.atlassian.net/browse/WEBRTC-2685)

[WEBRTC-2685]: https://telnyx.atlassian.net/browse/WEBRTC-2685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ