### PR TITLE
WEBRTC-2742: Add Call History Data for Incoming and Outgoing Calls

### DIFF
--- a/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
@@ -64,6 +64,14 @@ extension AppDelegate : CXProviderDelegate {
     ///   - uuid: uuid of the incoming call
     func newIncomingCall(from: String, uuid: UUID) {
         print("AppDelegate:: report NEW incoming call from [\(from)] uuid [\(uuid)]")
+        
+        // Track incoming call in call history
+        CallHistoryManager.shared.handleIncomingCall(
+            callId: uuid,
+            phoneNumber: from,
+            callerName: nil
+        )
+        
         #if targetEnvironment(simulator)
         //Do not execute this function when debugging on the simulator.
         //By reporting a call through CallKit from the simulator, it automatically cancels the call.
@@ -83,6 +91,8 @@ extension AppDelegate : CXProviderDelegate {
         provider.reportNewIncomingCall(with: uuid, update: callUpdate) { error in
             if let error = error {
                 print("AppDelegate:: Failed to report incoming call: \(error.localizedDescription).")
+                // Track failed incoming call
+                CallHistoryManager.shared.handleCallFailed(callId: uuid)
             } else {
                 print("AppDelegate:: Incoming call successfully reported.")
             }
@@ -159,11 +169,22 @@ extension AppDelegate : CXProviderDelegate {
         self.callKitUUID = action.callUUID
         self.voipDelegate?.executeCall(callUUID: action.callUUID) { call in
             self.currentCall = call
-            if call != nil {
+            if let call = call {
                 print("AppDelegate:: performVoiceCall() successful")
                 self.isCallOutGoing = true
+                
+                // Track outgoing call in call history
+                if let destinationNumber = call.callOptions?.destinationNumber {
+                    CallHistoryManager.shared.handleStartCallAction(
+                        action: action,
+                        phoneNumber: destinationNumber,
+                        callerName: call.callInfo?.callerName
+                    )
+                }
             } else {
                 print("AppDelegate:: performVoiceCall() failed")
+                // Track failed call
+                CallHistoryManager.shared.handleCallFailed(callId: action.callUUID)
             }
         }
         action.fulfill()
@@ -171,11 +192,38 @@ extension AppDelegate : CXProviderDelegate {
 
     func provider(_ provider: CXProvider, perform action: CXAnswerCallAction) {
         print("AppDelegate:: ANSWER call action: callKitUUID [\(String(describing: self.callKitUUID))] action [\(action.callUUID)]")
+        
+        // Track incoming call answer in call history
+        if let call = self.telnyxClient?.calls[action.callUUID] {
+            let phoneNumber = call.callInfo?.callerNumber ?? "Unknown"
+            let callerName = call.callInfo?.callerName
+            CallHistoryManager.shared.handleAnswerCallAction(
+                action: action,
+                phoneNumber: phoneNumber,
+                callerName: callerName
+            )
+        }
+        
         self.telnyxClient?.answerFromCallkit(answerAction: action, customHeaders:  ["X-test-answer":"ios-test"],debug: true)
     }
 
     func provider(_ provider: CXProvider, perform action: CXEndCallAction) {
         print("AppDelegate:: END call action: callKitUUID [\(String(describing: self.callKitUUID))] action [\(action.callUUID)]")
+        
+        // Track call end in call history
+        if let call = self.telnyxClient?.calls[action.callUUID] {
+            // Determine if this was a rejection or normal end
+            let status: CallStatus
+            switch call.callState {
+            case .RINGING:
+                status = .rejected
+            case .CONNECTING, .NEW:
+                status = .cancelled
+            default:
+                status = .answered
+            }
+            CallHistoryManager.shared.trackCallEnd(callId: action.callUUID, status: status)
+        }
         
         if previousCall?.callState == .HELD {
             print("AppDelegate:: call held.. unholding call")

--- a/TelnyxWebRTCDemo/Extensions/AppDelegateTelnyxVoIPExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/AppDelegateTelnyxVoIPExtension.swift
@@ -44,6 +44,17 @@ extension AppDelegate: TxClientDelegate {
         self.voipDelegate?.onSessionUpdated(sessionId: sessionId)
     }
     
+    func onCallStateUpdated(callState: CallState, callId: UUID) {
+        print("AppDelegate:: TxClientDelegate onCallStateUpdated() callState: \(callState), callId: \(callId)")
+        
+        // Track call state changes in call history
+        if let call = self.telnyxClient?.calls[callId] {
+            CallHistoryManager.shared.handleCallStateChange(call: call, previousState: nil)
+        }
+        
+        self.voipDelegate?.onCallStateUpdated(callState: callState, callId: callId)
+    }
+    
     func onIncomingCall(call: Call) {
         guard let callId = call.callInfo?.callId else {
             print("AppDelegate:: TxClientDelegate onIncomingCall() Error unknown call UUID")

--- a/TelnyxWebRTCDemo/Managers/CallHistoryManager.swift
+++ b/TelnyxWebRTCDemo/Managers/CallHistoryManager.swift
@@ -1,0 +1,273 @@
+//
+//  CallHistoryManager.swift
+//  TelnyxWebRTCDemo
+//
+//  Created by AI SWE Agent on 02/06/2025.
+//  Copyright © 2025 Telnyx LLC. All rights reserved.
+//
+
+import Foundation
+import TelnyxRTC
+import CallKit
+
+/// Manager class to handle call history tracking and integration
+public class CallHistoryManager: ObservableObject {
+    
+    /// Shared singleton instance
+    public static let shared = CallHistoryManager()
+    
+    /// Database instance
+    private let database = CallHistoryDatabase.shared
+    
+    /// Dictionary to track active calls and their start times
+    private var activeCallsStartTime: [UUID: Date] = [:]
+    
+    /// Dictionary to track call information for history
+    private var callInfoCache: [UUID: CallInfo] = [:]
+    
+    /// Current profile identifier
+    public var currentProfileId: String = "default"
+    
+    private init() {}
+    
+    // MARK: - Call Info Structure
+    
+    struct CallInfo {
+        let phoneNumber: String
+        let callerName: String?
+        let direction: CallDirection
+        let profileId: String
+    }
+    
+    // MARK: - Public Methods
+    
+    /// Track the start of a call
+    /// - Parameters:
+    ///   - callId: Unique call identifier
+    ///   - phoneNumber: Phone number or SIP URI
+    ///   - callerName: Display name (optional)
+    ///   - direction: Call direction
+    ///   - profileId: Profile identifier (optional, uses current if nil)
+    public func trackCallStart(
+        callId: UUID,
+        phoneNumber: String,
+        callerName: String? = nil,
+        direction: CallDirection,
+        profileId: String? = nil
+    ) {
+        let profile = profileId ?? currentProfileId
+        
+        // Cache call information
+        callInfoCache[callId] = CallInfo(
+            phoneNumber: phoneNumber,
+            callerName: callerName,
+            direction: direction,
+            profileId: profile
+        )
+        
+        // Record start time
+        activeCallsStartTime[callId] = Date()
+        
+        print("CallHistoryManager: Tracking call start - \(callId) (\(direction.rawValue))")
+    }
+    
+    /// Track the end of a call
+    /// - Parameters:
+    ///   - callId: Unique call identifier
+    ///   - status: Final call status
+    public func trackCallEnd(callId: UUID, status: CallStatus) {
+        guard let callInfo = callInfoCache[callId] else {
+            print("CallHistoryManager: No cached info for call \(callId)")
+            return
+        }
+        
+        let duration = calculateCallDuration(for: callId)
+        
+        // Add to call history
+        database.addCallHistoryEntry(
+            callId: callId,
+            phoneNumber: callInfo.phoneNumber,
+            callerName: callInfo.callerName,
+            direction: callInfo.direction,
+            duration: Int32(duration),
+            status: status,
+            profileId: callInfo.profileId
+        )
+        
+        // Clean up tracking data
+        activeCallsStartTime.removeValue(forKey: callId)
+        callInfoCache.removeValue(forKey: callId)
+        
+        print("CallHistoryManager: Tracked call end - \(callId) (\(status.rawValue), \(duration)s)")
+    }
+    
+    /// Update call status for an active call
+    /// - Parameters:
+    ///   - callId: Unique call identifier
+    ///   - status: Updated call status
+    public func updateCallStatus(callId: UUID, status: CallStatus) {
+        let duration = calculateCallDuration(for: callId)
+        database.updateCallHistoryEntry(
+            callId: callId,
+            duration: Int32(duration),
+            status: status
+        )
+        
+        print("CallHistoryManager: Updated call status - \(callId) (\(status.rawValue))")
+    }
+    
+    /// Handle CXStartCallAction (outgoing call)
+    /// - Parameters:
+    ///   - action: CXStartCallAction from CallKit
+    ///   - phoneNumber: Destination phone number
+    ///   - callerName: Caller name (optional)
+    public func handleStartCallAction(
+        action: CXStartCallAction,
+        phoneNumber: String,
+        callerName: String? = nil
+    ) {
+        trackCallStart(
+            callId: action.callUUID,
+            phoneNumber: phoneNumber,
+            callerName: callerName,
+            direction: .outgoing
+        )
+    }
+    
+    /// Handle CXAnswerCallAction (incoming call answered)
+    /// - Parameters:
+    ///   - action: CXAnswerCallAction from CallKit
+    ///   - phoneNumber: Caller phone number
+    ///   - callerName: Caller name (optional)
+    public func handleAnswerCallAction(
+        action: CXAnswerCallAction,
+        phoneNumber: String,
+        callerName: String? = nil
+    ) {
+        // Check if we already have this call tracked (from incoming call notification)
+        if callInfoCache[action.callUUID] == nil {
+            trackCallStart(
+                callId: action.callUUID,
+                phoneNumber: phoneNumber,
+                callerName: callerName,
+                direction: .incoming
+            )
+        }
+        
+        // Update status to answered
+        updateCallStatus(callId: action.callUUID, status: .answered)
+    }
+    
+    /// Handle incoming call notification (before answer/reject)
+    /// - Parameters:
+    ///   - callId: Unique call identifier
+    ///   - phoneNumber: Caller phone number
+    ///   - callerName: Caller name (optional)
+    public func handleIncomingCall(
+        callId: UUID,
+        phoneNumber: String,
+        callerName: String? = nil
+    ) {
+        trackCallStart(
+            callId: callId,
+            phoneNumber: phoneNumber,
+            callerName: callerName,
+            direction: .incoming
+        )
+    }
+    
+    /// Handle call rejection
+    /// - Parameter callId: Unique call identifier
+    public func handleCallRejected(callId: UUID) {
+        trackCallEnd(callId: callId, status: .rejected)
+    }
+    
+    /// Handle missed call
+    /// - Parameter callId: Unique call identifier
+    public func handleCallMissed(callId: UUID) {
+        trackCallEnd(callId: callId, status: .missed)
+    }
+    
+    /// Handle call failure
+    /// - Parameter callId: Unique call identifier
+    public func handleCallFailed(callId: UUID) {
+        trackCallEnd(callId: callId, status: .failed)
+    }
+    
+    /// Handle call cancellation
+    /// - Parameter callId: Unique call identifier
+    public func handleCallCancelled(callId: UUID) {
+        trackCallEnd(callId: callId, status: .cancelled)
+    }
+    
+    /// Get call history for current profile
+    /// - Returns: Array of call history entries
+    public func getCallHistory() -> [CallHistoryEntry] {
+        return database.getCallHistory(for: currentProfileId)
+    }
+    
+    /// Clear call history for current profile
+    public func clearCallHistory() {
+        database.clearCallHistory(for: currentProfileId)
+    }
+    
+    /// Set the current profile ID
+    /// - Parameter profileId: Profile identifier
+    public func setCurrentProfile(_ profileId: String) {
+        currentProfileId = profileId
+    }
+    
+    // MARK: - Private Methods
+    
+    /// Calculate call duration for a given call ID
+    /// - Parameter callId: Unique call identifier
+    /// - Returns: Duration in seconds
+    private func calculateCallDuration(for callId: UUID) -> TimeInterval {
+        guard let startTime = activeCallsStartTime[callId] else {
+            return 0
+        }
+        return Date().timeIntervalSince(startTime)
+    }
+}
+
+// MARK: - Integration with TelnyxRTC
+
+extension CallHistoryManager {
+    
+    /// Handle call state changes from TelnyxRTC Call object
+    /// - Parameters:
+    ///   - call: TelnyxRTC Call object
+    ///   - previousState: Previous call state
+    public func handleCallStateChange(call: Call, previousState: CallState?) {
+        guard let callId = call.callInfo?.callId else { return }
+        
+        switch call.callState {
+        case .ACTIVE:
+            // Call became active (answered)
+            if let callInfo = callInfoCache[callId] {
+                updateCallStatus(callId: callId, status: .answered)
+            }
+            
+        case .DONE(let reason):
+            // Call ended
+            let status: CallStatus
+            if let terminationReason = reason?.cause {
+                switch terminationReason {
+                case "CALL_REJECTED":
+                    status = .rejected
+                case "ORIGINATOR_CANCEL":
+                    status = .cancelled
+                default:
+                    status = activeCallsStartTime[callId] != nil ? .answered : .missed
+                }
+            } else {
+                status = activeCallsStartTime[callId] != nil ? .answered : .missed
+            }
+            
+            trackCallEnd(callId: callId, status: status)
+            
+        default:
+            break
+        }
+    }
+}

--- a/TelnyxWebRTCDemo/Models/CallHistory.xcdatamodeld/Contents
+++ b/TelnyxWebRTCDemo/Models/CallHistory.xcdatamodeld/Contents
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22G120" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="CallHistoryEntry" representedClassName="CallHistoryEntry" syncable="YES">
+        <attribute name="callId" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="phoneNumber" attributeType="String"/>
+        <attribute name="callerName" optional="YES" attributeType="String"/>
+        <attribute name="direction" attributeType="String"/>
+        <attribute name="timestamp" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="duration" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="callStatus" attributeType="String"/>
+        <attribute name="profileId" attributeType="String"/>
+        <attribute name="metadata" optional="YES" attributeType="String"/>
+    </entity>
+</model>

--- a/TelnyxWebRTCDemo/Models/CallHistoryDatabase.swift
+++ b/TelnyxWebRTCDemo/Models/CallHistoryDatabase.swift
@@ -1,0 +1,257 @@
+//
+//  CallHistoryDatabase.swift
+//  TelnyxWebRTCDemo
+//
+//  Created by AI SWE Agent on 02/06/2025.
+//  Copyright © 2025 Telnyx LLC. All rights reserved.
+//
+
+import Foundation
+import CoreData
+import Combine
+
+/// Singleton database manager for call history operations
+public class CallHistoryDatabase: ObservableObject {
+    
+    /// Shared singleton instance
+    public static let shared = CallHistoryDatabase()
+    
+    /// Published property to notify UI of changes
+    @Published public var callHistory: [CallHistoryEntry] = []
+    
+    /// Maximum number of call history entries per profile
+    private let maxHistoryCount = 20
+    
+    /// Core Data persistent container
+    private lazy var persistentContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: "CallHistory")
+        container.loadPersistentStores { _, error in
+            if let error = error {
+                print("CallHistoryDatabase: Failed to load Core Data stack: \(error)")
+            }
+        }
+        container.viewContext.automaticallyMergesChangesFromParent = true
+        return container
+    }()
+    
+    /// Main context for UI operations
+    public var viewContext: NSManagedObjectContext {
+        return persistentContainer.viewContext
+    }
+    
+    /// Background context for database operations
+    private var backgroundContext: NSManagedObjectContext {
+        return persistentContainer.newBackgroundContext()
+    }
+    
+    private init() {
+        loadCallHistory()
+    }
+    
+    // MARK: - Public Methods
+    
+    /// Add a new call history entry
+    /// - Parameters:
+    ///   - callId: Unique identifier for the call
+    ///   - phoneNumber: Phone number or SIP URI
+    ///   - callerName: Display name (optional)
+    ///   - direction: Call direction (incoming/outgoing)
+    ///   - duration: Call duration in seconds
+    ///   - status: Final call status
+    ///   - profileId: Profile identifier
+    ///   - metadata: Additional metadata (optional)
+    public func addCallHistoryEntry(
+        callId: UUID,
+        phoneNumber: String,
+        callerName: String? = nil,
+        direction: CallDirection,
+        duration: Int32 = 0,
+        status: CallStatus,
+        profileId: String,
+        metadata: String? = nil
+    ) {
+        backgroundContext.perform { [weak self] in
+            guard let self = self else { return }
+            
+            let entry = CallHistoryEntry(context: self.backgroundContext)
+            entry.callId = callId
+            entry.phoneNumber = phoneNumber
+            entry.callerName = callerName
+            entry.direction = direction.rawValue
+            entry.timestamp = Date()
+            entry.duration = duration
+            entry.callStatus = status.rawValue
+            entry.profileId = profileId
+            entry.metadata = metadata
+            
+            self.saveContext(self.backgroundContext)
+            self.enforceHistoryLimit(for: profileId)
+            
+            DispatchQueue.main.async {
+                self.loadCallHistory()
+            }
+        }
+    }
+    
+    /// Update an existing call history entry
+    /// - Parameters:
+    ///   - callId: Call identifier to update
+    ///   - duration: Updated duration
+    ///   - status: Updated status
+    public func updateCallHistoryEntry(callId: UUID, duration: Int32? = nil, status: CallStatus? = nil) {
+        backgroundContext.perform { [weak self] in
+            guard let self = self else { return }
+            
+            let request: NSFetchRequest<CallHistoryEntry> = CallHistoryEntry.fetchRequest()
+            request.predicate = NSPredicate(format: "callId == %@", callId as CVarArg)
+            
+            do {
+                let entries = try self.backgroundContext.fetch(request)
+                if let entry = entries.first {
+                    if let duration = duration {
+                        entry.duration = duration
+                    }
+                    if let status = status {
+                        entry.callStatus = status.rawValue
+                    }
+                    self.saveContext(self.backgroundContext)
+                    
+                    DispatchQueue.main.async {
+                        self.loadCallHistory()
+                    }
+                }
+            } catch {
+                print("CallHistoryDatabase: Failed to update call history entry: \(error)")
+            }
+        }
+    }
+    
+    /// Get call history for a specific profile
+    /// - Parameter profileId: Profile identifier
+    /// - Returns: Array of call history entries
+    public func getCallHistory(for profileId: String) -> [CallHistoryEntry] {
+        let request: NSFetchRequest<CallHistoryEntry> = CallHistoryEntry.fetchRequest()
+        request.predicate = NSPredicate(format: "profileId == %@", profileId)
+        request.sortDescriptors = [NSSortDescriptor(key: "timestamp", ascending: false)]
+        request.fetchLimit = maxHistoryCount
+        
+        do {
+            return try viewContext.fetch(request)
+        } catch {
+            print("CallHistoryDatabase: Failed to fetch call history: \(error)")
+            return []
+        }
+    }
+    
+    /// Get all call history entries
+    /// - Returns: Array of all call history entries
+    public func getAllCallHistory() -> [CallHistoryEntry] {
+        let request: NSFetchRequest<CallHistoryEntry> = CallHistoryEntry.fetchRequest()
+        request.sortDescriptors = [NSSortDescriptor(key: "timestamp", ascending: false)]
+        
+        do {
+            return try viewContext.fetch(request)
+        } catch {
+            print("CallHistoryDatabase: Failed to fetch all call history: \(error)")
+            return []
+        }
+    }
+    
+    /// Clear call history for a specific profile
+    /// - Parameter profileId: Profile identifier
+    public func clearCallHistory(for profileId: String) {
+        backgroundContext.perform { [weak self] in
+            guard let self = self else { return }
+            
+            let request: NSFetchRequest<CallHistoryEntry> = CallHistoryEntry.fetchRequest()
+            request.predicate = NSPredicate(format: "profileId == %@", profileId)
+            
+            do {
+                let entries = try self.backgroundContext.fetch(request)
+                for entry in entries {
+                    self.backgroundContext.delete(entry)
+                }
+                self.saveContext(self.backgroundContext)
+                
+                DispatchQueue.main.async {
+                    self.loadCallHistory()
+                }
+            } catch {
+                print("CallHistoryDatabase: Failed to clear call history: \(error)")
+            }
+        }
+    }
+    
+    /// Delete a specific call history entry
+    /// - Parameter callId: Call identifier to delete
+    public func deleteCallHistoryEntry(callId: UUID) {
+        backgroundContext.perform { [weak self] in
+            guard let self = self else { return }
+            
+            let request: NSFetchRequest<CallHistoryEntry> = CallHistoryEntry.fetchRequest()
+            request.predicate = NSPredicate(format: "callId == %@", callId as CVarArg)
+            
+            do {
+                let entries = try self.backgroundContext.fetch(request)
+                for entry in entries {
+                    self.backgroundContext.delete(entry)
+                }
+                self.saveContext(self.backgroundContext)
+                
+                DispatchQueue.main.async {
+                    self.loadCallHistory()
+                }
+            } catch {
+                print("CallHistoryDatabase: Failed to delete call history entry: \(error)")
+            }
+        }
+    }
+    
+    // MARK: - Private Methods
+    
+    /// Load call history and update published property
+    private func loadCallHistory() {
+        callHistory = getAllCallHistory()
+    }
+    
+    /// Save the managed object context
+    /// - Parameter context: Context to save
+    private func saveContext(_ context: NSManagedObjectContext) {
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                print("CallHistoryDatabase: Failed to save context: \(error)")
+            }
+        }
+    }
+    
+    /// Enforce the maximum history limit for a profile
+    /// - Parameter profileId: Profile identifier
+    private func enforceHistoryLimit(for profileId: String) {
+        let request: NSFetchRequest<CallHistoryEntry> = CallHistoryEntry.fetchRequest()
+        request.predicate = NSPredicate(format: "profileId == %@", profileId)
+        request.sortDescriptors = [NSSortDescriptor(key: "timestamp", ascending: false)]
+        
+        do {
+            let entries = try backgroundContext.fetch(request)
+            if entries.count > maxHistoryCount {
+                let entriesToDelete = Array(entries.dropFirst(maxHistoryCount))
+                for entry in entriesToDelete {
+                    backgroundContext.delete(entry)
+                }
+                saveContext(backgroundContext)
+            }
+        } catch {
+            print("CallHistoryDatabase: Failed to enforce history limit: \(error)")
+        }
+    }
+}
+
+// MARK: - CallHistoryEntry Extensions
+
+extension CallHistoryEntry {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<CallHistoryEntry> {
+        return NSFetchRequest<CallHistoryEntry>(entityName: "CallHistoryEntry")
+    }
+}

--- a/TelnyxWebRTCDemo/Models/CallHistoryEntry.swift
+++ b/TelnyxWebRTCDemo/Models/CallHistoryEntry.swift
@@ -1,0 +1,81 @@
+//
+//  CallHistoryEntry.swift
+//  TelnyxWebRTCDemo
+//
+//  Created by AI SWE Agent on 02/06/2025.
+//  Copyright © 2025 Telnyx LLC. All rights reserved.
+//
+
+import Foundation
+import CoreData
+
+/// Represents a call history entry with all relevant call information
+public class CallHistoryEntry: NSManagedObject {
+    
+    /// The unique identifier for this call
+    @NSManaged public var callId: UUID
+    
+    /// The phone number or SIP URI that was called or received the call from
+    @NSManaged public var phoneNumber: String
+    
+    /// The display name associated with the call (if available)
+    @NSManaged public var callerName: String?
+    
+    /// The direction of the call (incoming/outgoing)
+    @NSManaged public var direction: String
+    
+    /// The timestamp when the call was initiated
+    @NSManaged public var timestamp: Date
+    
+    /// The duration of the call in seconds (0 if call was not answered)
+    @NSManaged public var duration: Int32
+    
+    /// The final state of the call (answered, missed, rejected, etc.)
+    @NSManaged public var callStatus: String
+    
+    /// The profile/user identifier this call belongs to
+    @NSManaged public var profileId: String
+    
+    /// Additional metadata about the call (JSON string)
+    @NSManaged public var metadata: String?
+    
+    /// Convenience computed property for call direction
+    public var isIncoming: Bool {
+        return direction == "incoming"
+    }
+    
+    /// Convenience computed property for call direction
+    public var isOutgoing: Bool {
+        return direction == "outgoing"
+    }
+    
+    /// Formatted duration string (e.g., "1:23")
+    public var formattedDuration: String {
+        let minutes = duration / 60
+        let seconds = duration % 60
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+    
+    /// Formatted timestamp for display
+    public var formattedTimestamp: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        return formatter.string(from: timestamp)
+    }
+}
+
+/// Call direction enumeration
+public enum CallDirection: String, CaseIterable {
+    case incoming = "incoming"
+    case outgoing = "outgoing"
+}
+
+/// Call status enumeration
+public enum CallStatus: String, CaseIterable {
+    case answered = "answered"
+    case missed = "missed"
+    case rejected = "rejected"
+    case failed = "failed"
+    case cancelled = "cancelled"
+}

--- a/TelnyxWebRTCDemo/ViewControllers/HomeViewController+VoIPExtension.swift
+++ b/TelnyxWebRTCDemo/ViewControllers/HomeViewController+VoIPExtension.swift
@@ -192,6 +192,11 @@ extension HomeViewController : VoIPDelegate {
     }
     
     func onCallStateUpdated(callState: CallState, callId: UUID) {
+        // Track call state changes in call history
+        if let call = self.appDelegate.telnyxClient?.calls[callId] {
+            CallHistoryManager.shared.handleCallStateChange(call: call, previousState: nil)
+        }
+        
         DispatchQueue.main.async {
             self.callViewModel.callState = callState
             self.viewModel.callState = callState

--- a/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
+++ b/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
@@ -64,6 +64,10 @@ class HomeViewController: UIViewController {
             },
             onDTMF: { [weak self] key in
                 self?.appDelegate.currentCall?.dtmf(dtmf: key)
+            },
+            onRedial: { [weak self] phoneNumber in
+                self?.callViewModel.sipAddress = phoneNumber
+                self?.onCallButton()
             }
         )
         

--- a/TelnyxWebRTCDemo/Views/CallHistoryBottomSheet.swift
+++ b/TelnyxWebRTCDemo/Views/CallHistoryBottomSheet.swift
@@ -1,0 +1,263 @@
+//
+//  CallHistoryBottomSheet.swift
+//  TelnyxWebRTCDemo
+//
+//  Created by AI SWE Agent on 02/06/2025.
+//  Copyright © 2025 Telnyx LLC. All rights reserved.
+//
+
+import SwiftUI
+import TelnyxRTC
+
+/// SwiftUI bottom sheet component for displaying call history
+public struct CallHistoryBottomSheet: View {
+    
+    @StateObject private var database = CallHistoryDatabase.shared
+    @Environment(\.dismiss) private var dismiss
+    
+    /// Current profile ID to filter call history
+    public let profileId: String
+    
+    /// Callback for when user wants to redial a number
+    public let onRedial: (String, String?) -> Void
+    
+    /// Callback for when user wants to clear history
+    public let onClearHistory: () -> Void
+    
+    @State private var showingClearAlert = false
+    @State private var filteredHistory: [CallHistoryEntry] = []
+    
+    public init(
+        profileId: String,
+        onRedial: @escaping (String, String?) -> Void,
+        onClearHistory: @escaping () -> Void
+    ) {
+        self.profileId = profileId
+        self.onRedial = onRedial
+        self.onClearHistory = onClearHistory
+    }
+    
+    public var body: some View {
+        NavigationView {
+            VStack(spacing: 0) {
+                // Header
+                headerView
+                
+                // Call History List
+                if filteredHistory.isEmpty {
+                    emptyStateView
+                } else {
+                    callHistoryList
+                }
+            }
+            .navigationBarHidden(true)
+            .onAppear {
+                updateFilteredHistory()
+            }
+            .onReceive(database.$callHistory) { _ in
+                updateFilteredHistory()
+            }
+        }
+        .alert("Clear Call History", isPresented: $showingClearAlert) {
+            Button("Cancel", role: .cancel) { }
+            Button("Clear", role: .destructive) {
+                database.clearCallHistory(for: profileId)
+                onClearHistory()
+            }
+        } message: {
+            Text("This will permanently delete all call history for this profile.")
+        }
+    }
+    
+    // MARK: - Header View
+    
+    private var headerView: some View {
+        HStack {
+            Button("Close") {
+                dismiss()
+            }
+            .foregroundColor(.blue)
+            
+            Spacer()
+            
+            Text("Call History")
+                .font(.headline)
+                .fontWeight(.semibold)
+            
+            Spacer()
+            
+            Button("Clear") {
+                showingClearAlert = true
+            }
+            .foregroundColor(.red)
+            .disabled(filteredHistory.isEmpty)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 16)
+        .background(Color(.systemBackground))
+        .overlay(
+            Rectangle()
+                .frame(height: 0.5)
+                .foregroundColor(Color(.separator)),
+            alignment: .bottom
+        )
+    }
+    
+    // MARK: - Empty State View
+    
+    private var emptyStateView: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "phone.circle")
+                .font(.system(size: 64))
+                .foregroundColor(.gray)
+            
+            Text("No Call History")
+                .font(.title2)
+                .fontWeight(.medium)
+                .foregroundColor(.primary)
+            
+            Text("Your recent calls will appear here")
+                .font(.body)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(.systemBackground))
+    }
+    
+    // MARK: - Call History List
+    
+    private var callHistoryList: some View {
+        List {
+            ForEach(filteredHistory, id: \.callId) { entry in
+                CallHistoryRow(
+                    entry: entry,
+                    onRedial: { phoneNumber, callerName in
+                        onRedial(phoneNumber, callerName)
+                        dismiss()
+                    }
+                )
+                .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+            }
+            .onDelete(perform: deleteEntries)
+        }
+        .listStyle(PlainListStyle())
+    }
+    
+    // MARK: - Helper Methods
+    
+    private func updateFilteredHistory() {
+        filteredHistory = database.getCallHistory(for: profileId)
+    }
+    
+    private func deleteEntries(at offsets: IndexSet) {
+        for index in offsets {
+            let entry = filteredHistory[index]
+            database.deleteCallHistoryEntry(callId: entry.callId)
+        }
+    }
+}
+
+// MARK: - Call History Row
+
+struct CallHistoryRow: View {
+    let entry: CallHistoryEntry
+    let onRedial: (String, String?) -> Void
+    
+    var body: some View {
+        HStack(spacing: 12) {
+            // Call Direction Icon
+            callDirectionIcon
+            
+            // Call Information
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text(entry.callerName ?? entry.phoneNumber)
+                        .font(.body)
+                        .fontWeight(.medium)
+                        .foregroundColor(.primary)
+                    
+                    Spacer()
+                    
+                    Text(entry.formattedTimestamp)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                
+                HStack {
+                    if entry.callerName != nil {
+                        Text(entry.phoneNumber)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    
+                    Spacer()
+                    
+                    if entry.duration > 0 {
+                        Text(entry.formattedDuration)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                
+                // Call Status
+                Text(entry.callStatus.capitalized)
+                    .font(.caption)
+                    .foregroundColor(statusColor)
+            }
+            
+            // Redial Button
+            Button(action: {
+                onRedial(entry.phoneNumber, entry.callerName)
+            }) {
+                Image(systemName: "phone.fill")
+                    .font(.system(size: 16))
+                    .foregroundColor(.white)
+                    .frame(width: 32, height: 32)
+                    .background(Color.green)
+                    .clipShape(Circle())
+            }
+        }
+        .padding(.vertical, 4)
+    }
+    
+    private var callDirectionIcon: some View {
+        Image(systemName: entry.isIncoming ? "phone.down.fill" : "phone.up.fill")
+            .font(.system(size: 16))
+            .foregroundColor(entry.isIncoming ? .blue : .green)
+            .frame(width: 24, height: 24)
+    }
+    
+    private var statusColor: Color {
+        switch entry.callStatus {
+        case "answered":
+            return .green
+        case "missed":
+            return .red
+        case "rejected":
+            return .orange
+        case "failed":
+            return .red
+        case "cancelled":
+            return .gray
+        default:
+            return .secondary
+        }
+    }
+}
+
+// MARK: - Preview
+
+struct CallHistoryBottomSheet_Previews: PreviewProvider {
+    static var previews: some View {
+        CallHistoryBottomSheet(
+            profileId: "test-profile",
+            onRedial: { phoneNumber, callerName in
+                print("Redial: \(phoneNumber)")
+            },
+            onClearHistory: {
+                print("Clear history")
+            }
+        )
+    }
+}

--- a/TelnyxWebRTCDemo/Views/CallView.swift
+++ b/TelnyxWebRTCDemo/Views/CallView.swift
@@ -4,6 +4,7 @@ import TelnyxRTC
 struct CallView: View {
     @ObservedObject var viewModel: CallViewModel
     @State var isPhoneNumber: Bool
+    @State private var showCallHistory = false
 
     let onStartCall: () -> Void
     let onEndCall: () -> Void
@@ -13,6 +14,7 @@ struct CallView: View {
     let onToggleSpeaker: () -> Void
     let onHold: (Bool) -> Void
     let onDTMF: (String) -> Void
+    let onRedial: ((String) -> Void)?
     
 
     var body: some View {
@@ -47,6 +49,17 @@ struct CallView: View {
                     }
                 )
             }
+        }.sheet(isPresented: $showCallHistory) {
+            CallHistoryBottomSheet(
+                profileId: CallHistoryManager.shared.currentProfileId,
+                onRedial: { phoneNumber, callerName in
+                    viewModel.sipAddress = phoneNumber
+                    onRedial?(phoneNumber)
+                },
+                onClearHistory: {
+                    // History cleared
+                }
+            )
         }
     }
     
@@ -91,16 +104,31 @@ struct CallView: View {
                 .padding(.vertical, 8)
             }
 
-            Button(action: {
-                onStartCall()
-            }) {
-                Image("Call")
-                    .foregroundColor(Color(hex: "#1D1D1D"))
-                    .frame(width: 60, height: 60)
-                    .background(Color(hex: "#00E3AA"))
-                    .clipShape(Circle())
+            HStack(spacing: 20) {
+                // Call History Button
+                Button(action: {
+                    showCallHistory = true
+                }) {
+                    Image(systemName: "clock.arrow.circlepath")
+                        .foregroundColor(Color(hex: "#1D1D1D"))
+                        .frame(width: 50, height: 50)
+                        .background(Color(hex: "#F5F3E4"))
+                        .clipShape(Circle())
+                }
+                .accessibilityIdentifier("callHistoryButton")
+                
+                // Call Button
+                Button(action: {
+                    onStartCall()
+                }) {
+                    Image("Call")
+                        .foregroundColor(Color(hex: "#1D1D1D"))
+                        .frame(width: 60, height: 60)
+                        .background(Color(hex: "#00E3AA"))
+                        .clipShape(Circle())
+                }
+                .accessibilityIdentifier(AccessibilityIdentifiers.callButton)
             }
-            .accessibilityIdentifier(AccessibilityIdentifiers.callButton)
             .padding()
             
             // Keep Keyboard below Textfiled
@@ -246,7 +274,8 @@ struct CallView_Previews: PreviewProvider {
             onMuteUnmuteSwitch: { _ in },
             onToggleSpeaker: {},
             onHold: { _ in },
-            onDTMF: { _ in }
+            onDTMF: { _ in },
+            onRedial: { _ in }
         )
     }
 }

--- a/TelnyxWebRTCDemo/Views/HomeView.swift
+++ b/TelnyxWebRTCDemo/Views/HomeView.swift
@@ -306,7 +306,8 @@ struct HomeView_Previews: PreviewProvider {
                     onMuteUnmuteSwitch: { _ in },
                     onToggleSpeaker: {},
                     onHold: { _ in },
-                    onDTMF: { _ in }
+                    onDTMF: { _ in },
+                    onRedial: { _ in }
                 )
             )
         )


### PR DESCRIPTION
- Implemented Core Data model for call history persistence
- Added CallHistoryDatabase with 20-call limit per profile
- Created CallHistoryManager for call lifecycle tracking
- Integrated with CXProvider actions (start/answer/end calls)
- Added onCallStateUpdated tracking in TxClientDelegate
- Built SwiftUI CallHistoryBottomSheet with redial functionality
- Added call history button to main CallView interface
- Profile-specific call history storage and retrieval
- Modern SwiftUI interface with call details and redial capability

Features:
- Track incoming and outgoing calls
- Store call duration, status, and timestamps
- Profile-specific history with 20-call limit
- Redial functionality from call history
- Core Data persistence layer
- Clean SwiftUI interface integration

