### PR TITLE
[ENGDESK-42548] [FIX] Termination cause codes

### DIFF
--- a/TelnyxRTC/Telnyx/WebRTC/Call.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call.swift
@@ -532,7 +532,16 @@ extension Call {
         
         // Create a termination reason for local hangup
         // Use USER_BUSY
-        let causeCode: CauseCode = (callState == .ACTIVE) ? .NORMAL_CLEARING : .USER_BUSY
+        let causeCode: CauseCode
+
+        switch callState {
+        case .ACTIVE:
+            causeCode = .NORMAL_CLEARING
+        case .RINGING, .CONNECTING:
+            causeCode = .USER_BUSY
+        default:
+            causeCode = .NORMAL_CLEARING
+        }
 
         let terminationReason = CallTerminationReason(
             cause: ByeMessage.getCauseFromCode(causeCode: causeCode),

--- a/TelnyxRTC/Telnyx/WebRTC/Call.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call.swift
@@ -532,11 +532,13 @@ extension Call {
         
         // Create a termination reason for local hangup
         // Use USER_BUSY
+        let causeCode: CauseCode = (callState == .ACTIVE) ? .NORMAL_CLEARING : .USER_BUSY
+
         let terminationReason = CallTerminationReason(
-            cause: ByeMessage.getCauseFromCode(causeCode: CauseCode.USER_BUSY),
-            causeCode: CauseCode.USER_BUSY.rawValue
+            cause: ByeMessage.getCauseFromCode(causeCode: causeCode),
+            causeCode: causeCode.rawValue
         )
-        
+
         let byeMessage = ByeMessage(sessionId: sessionId, callId: callId.uuidString, causeCode: .USER_BUSY)
         let message = byeMessage.encode() ?? ""
         self.socket?.sendMessage(message: message)


### PR DESCRIPTION
<!-- Ticket details and link -->
[ENGDESK-42548](https://telnyx.atlassian.net/browse/ENGDESK-42548)
---

Background

There is a minor bug in the iOS SDK where the call termination cause code is incorrect regardless of the scenario.

Current Behavior

Rejecting an incoming call uses 

USER_BUSY

 cause code ✓ (correct)

Ending an existing call uses 

USER_BUSY

 cause code ✗ (incorrect)

Expected Behavior

Incoming call that is rejected  -> USER_BUSY  cause code

Existing call that is ended  -> NORMAL_CLEARING cause code

Ensured that on the SDK side, when ending a call, we are using the appropriate cause code (NORMAL_CLEARING).



[ENGDESK-42548]: https://telnyx.atlassian.net/browse/ENGDESK-42548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ