### PR TITLE
[WEBRTC-2877] Add .llm-repo-instructions file for iOS WebRTC SDK

### DIFF
--- a/.llm-repo-instructions
+++ b/.llm-repo-instructions
@@ -1,0 +1,50 @@
+[meta]
+version=1.0
+format_rules=Simple guidelines, one instruction per line. Write in clear English.
+
+[ai_swe_agent]
+When opening a PR, add the Jira ticket ID.
+Follow this pattern: [WEBRTC-XXX] - Title.
+Always open PRs as drafts.
+Use the format described at .github/pull_request_template.md, including a clear description of the changes, any relevant issue numbers, and testing instructions.
+
+Don't change the verto message json structure without confirming first.
+When making changes to the SDK, ensure that you update the demo application (TelnyxWebRTCDemo) accordingly to demonstrate the new functionality.
+Follow the established architecture patterns for WebRTC, including peer connection management, ICE candidate handling, and call state management.
+Ensure that all new features and bug fixes are accompanied by appropriate unit tests in the TelnyxRTCTests module.
+
+Follow the Swift Style Guide for general Swift coding conventions.
+Use SwiftUI for any new UI components implemented in the demo app.
+Any SwiftUI view must include a .preview provider for visual inspection.
+Ensure proper use of @State, @ObservedObject, @StateObject, and other SwiftUI property wrappers.
+
+Do not run iOS tests manually; they are automatically run when a Pull Request is created.
+However, if adding new unit tests, you can run specific test classes in Xcode to verify they work during development.
+
+When working with WebRTC components, ensure proper cleanup of peer connections and media streams to prevent memory leaks.
+Always handle audio permissions and device management properly when making changes to call functionality.
+When modifying authentication flows, ensure both credential and token login methods are supported.
+When adding push notification features, ensure proper integration with Apple Push Notification service (APNs).
+
+Avoid descriptive comments, only add comments if the code is too complex.
+Use meaningful variable and function names that make the code self-documenting.
+
+Do not modify public SDK contracts unless explicitly requested or previously validated.
+If a public contract is changed, document the change appropriately so other developers can understand it.
+If the public contract is updated, ensure the README.md file is updated to reflect usage of the new version.
+If SDK errors are modified, document them in docs-markdown/error-handling/error-handling.md (if applicable).
+If WebRTC stats are modified, update the documentation in docs-markdown/webrtc-stats/webrtc-stats.md.
+
+Check whether any changes are needed in the demo app to ensure it compiles correctly and apply them as necessary.
+Any new files created must be added to the project structure to ensure the app builds successfully.
+Avoid adding new third-party libraries unless explicitly requested.
+Ensure any implemented code is compatible with the currently supported iOS version in the project.
+If updating the deployment target is absolutely necessary, it must be validated first.
+Prefer alternative implementations that do not require updating the iOS version.
+
+When adding new public APIs, ensure they are properly documented with Swift documentation comments (///).
+Maintain backward compatibility when possible, especially for public SDK interfaces.
+Follow iOS-specific patterns for delegate protocols, completion handlers, and async/await where appropriate.
+Ensure proper memory management using ARC (Automatic Reference Counting) and avoid retain cycles.
+
+Branch naming: start with feat/ fix/ chore/ depending on the case, then the ticket number. Like feat/WEBRTC-2877.


### PR DESCRIPTION
## Summary

This PR adds a  file to the root of the iOS WebRTC SDK project, adapted from the Android version to provide AI agents with iOS-specific guidelines.

## Changes

- Created  file at project root
- Adapted content from Android version with iOS-specific guidelines:
  - SwiftUI requirements and preview providers
  - iOS testing guidelines (automatic execution on PR creation)
  - Swift coding conventions and memory management
  - iOS-specific documentation paths
  - Compatibility requirements for supported iOS versions
  - Proper branch naming conventions

## Related Issues

- Resolves WEBRTC-2877

## Testing

- File follows the same format as the Android version
- Contains iOS-specific adaptations as requested
- No functional changes to the SDK or demo app

## Documentation

The file includes references to:
-  for SDK error documentation
-  for WebRTC stats documentation
- README.md update requirements for public contract changes