### PR TITLE
[WEBRTC-2921] - [iOS] Update actions to use Xcode 16

### DIFF
--- a/.github/workflows/ios_fastlane_tests.yml
+++ b/.github/workflows/ios_fastlane_tests.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Select Xcode Version
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '15.4.0'
+        xcode-version: '16.4.0'
     
     - name: Setup ruby
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/release-02-generate-docs.yml
+++ b/.github/workflows/release-02-generate-docs.yml
@@ -37,7 +37,7 @@ jobs:
     - name: 🧰 Select the latest Xcode version
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '15.4.0'
+        xcode-version: '16.4.0'
 
     - name: 💎 Setup Ruby 3.3.0
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/tests-ui-sample-app-firebase.yml
+++ b/.github/workflows/tests-ui-sample-app-firebase.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Select Xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.4.0'
+          xcode-version: '16.4.0'
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Ticket: WEBRTC-2921

Summary
- Update GitHub Actions to use Xcode 16.4.0 via maxim-lobanov/setup-xcode@v1.
- Updated workflows:
  - ios_fastlane_tests.yml
  - release-02-generate-docs.yml
  - tests-ui-sample-app-firebase.yml

Rationale
- Xcode 15.4.0 is no longer available on GitHub macOS runners (error: Could not find Xcode version 15.4.0).
- 16.4.0 is available and stable on runners.

Validation notes
- Only CI configuration changed; no source code modifications.
- CI on this PR should pick up Xcode 16.4.0 and proceed.

Branch
- fix/WEBRTC-2921-github-actions

Testing
- Trigger ios_fastlane_tests and tests-ui-sample-app-firebase from the PR if not auto-triggered. Confirm Xcode 16.4.0 is selected and jobs succeed.