### PR TITLE
[WEBRTC-2965] - Add forceRelayCandidate toggle option to WebRTC demo app hidden menu

### DIFF
--- a/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
@@ -300,6 +300,9 @@ extension AppDelegate : CXProviderDelegate {
         if selectedCredentials?.isToken ?? false {
             let token = selectedCredentials?.username ?? ""
             let deviceToken = userDefaults.getPushToken()
+            // Get settings from UserDefaults
+            let forceRelayCandidate = userDefaults.getForceRelayCandidate()
+            let webrtcStats = userDefaults.getWebRTCStats()
             //Sets the login credentials and the ringtone/ringback configurations if required.
             //Ringtone / ringback tone files are not mandatory.
             let txConfig = TxConfig(token: token,
@@ -310,9 +313,9 @@ extension AppDelegate : CXProviderDelegate {
                                     logLevel: .all,
                                     reconnectClient: true,
                                     // Enable WebRTC stats debug
-                                    debug: true,
+                                    debug: webrtcStats,
                                     // Force relay candidate
-                                    forceRelayCandidate: false,
+                                    forceRelayCandidate: forceRelayCandidate,
                                     // Enable Call Quality Metrics
                                     enableQualityMetrics: true)
             
@@ -325,6 +328,9 @@ extension AppDelegate : CXProviderDelegate {
             let sipUser = selectedCredentials?.username ?? ""
             let password = selectedCredentials?.password ?? ""
             let deviceToken = userDefaults.getPushToken()
+            // Get settings from UserDefaults
+            let forceRelayCandidate = userDefaults.getForceRelayCandidate()
+            let webrtcStats = userDefaults.getWebRTCStats()
             //Sets the login credentials and the ringtone/ringback configurations if required.
             //Ringtone / ringback tone files are not mandatory.
             let txConfig = TxConfig(sipUser: sipUser,
@@ -336,9 +342,9 @@ extension AppDelegate : CXProviderDelegate {
                                     logLevel: .all,
                                     reconnectClient: true,
                                     // Enable WebRTC stats debug
-                                    debug: true,
+                                    debug: webrtcStats,
                                     // Force relay candidate
-                                    forceRelayCandidate: false,
+                                    forceRelayCandidate: forceRelayCandidate,
                                     // Enable Call Quality Metrics
                                     enableQualityMetrics: true)
             

--- a/TelnyxWebRTCDemo/Extensions/UserDefaultExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/UserDefaultExtension.swift
@@ -15,6 +15,7 @@ enum UserDefaultsKey: String {
     case callDestination = "CALL_DESTINATION"
     case webrtcEnvironment = "WEBRTC_ENVIRONMENT"
     case forceRelayCandidate = "FORCE_RELAY_CANDIDATE"
+    case webrtcStats = "WEBRTC_STATS"
 }
 
 extension UserDefaults {
@@ -57,6 +58,19 @@ extension UserDefaults {
     
     func getForceRelayCandidate() -> Bool {
         return bool(forKey: UserDefaultsKey.forceRelayCandidate.rawValue)
+    }
+    
+    // MARK: - WebRTC Stats
+    func saveWebRTCStats(_ enabled: Bool) {
+        set(enabled, forKey: UserDefaultsKey.webrtcStats.rawValue)
+    }
+    
+    func getWebRTCStats() -> Bool {
+        // Default to true if not set
+        if object(forKey: UserDefaultsKey.webrtcStats.rawValue) == nil {
+            return true
+        }
+        return bool(forKey: UserDefaultsKey.webrtcStats.rawValue)
     }
 }
 

--- a/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
+++ b/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
@@ -240,6 +240,13 @@ extension HomeViewController {
             self.userDefaults.saveForceRelayCandidate(!currentForceRelay)
         }))
 
+        // WebRTC Stats toggle
+        let currentWebRTCStats = userDefaults.getWebRTCStats()
+        let webRTCStatsTitle = currentWebRTCStats ? "Disable WebRTC Stats" : "Enable WebRTC Stats"
+        alert.addAction(UIAlertAction(title: webRTCStatsTitle, style: .default, handler: { _ in
+            self.userDefaults.saveWebRTCStats(!currentWebRTCStats)
+        }))
+
         alert.addAction(UIAlertAction(title: "Copy APNS token", style: .default, handler: { _ in
             // To copy the APNS push token to pasteboard
             let token = UserDefaults().getPushToken()
@@ -368,8 +375,9 @@ extension HomeViewController {
                                 deviceToken: String?) throws -> TxConfig {
         var txConfig: TxConfig?
         
-        // Get the forceRelayCandidate setting from UserDefaults
+        // Get the forceRelayCandidate and webrtcStats settings from UserDefaults
         let forceRelayCandidate = userDefaults.getForceRelayCandidate()
+        let webrtcStats = userDefaults.getWebRTCStats()
 
         // Set the connection configuration object.
         // We can login with a user token: https://developers.telnyx.com/docs/v2/webrtc/quickstart
@@ -383,7 +391,7 @@ extension HomeViewController {
                                 logLevel: .all,
                                 reconnectClient: true,
                                 // Enable webrtc stats debug
-                                debug: true,
+                                debug: webrtcStats,
                                 // Force relay candidate
                                 forceRelayCandidate: forceRelayCandidate,
                                 // Enable Call Quality Metrics
@@ -399,7 +407,7 @@ extension HomeViewController {
                                 logLevel: .all,
                                 reconnectClient: true,
                                 // Enable webrtc stats debug
-                                debug: true,
+                                debug: webrtcStats,
                                 // Force relay candidate.
                                 forceRelayCandidate: forceRelayCandidate,
                                 // Enable Call Quality Metrics


### PR DESCRIPTION
<!-- Ticket details and link -->
[WEBRTC-2965 - Add forceRelayCandidate toggle option to WebRTC demo app hidden menu](https://telnyx.atlassian.net/browse/WEBRTC-2965)
---
<!-- Describe your change here -->
This PR adds new configuration options in the hidden menu of the WebRTC demo app to enable/disable the `forceRelayCandidate` and `webrtcStats` settings. This enhancement is needed for debugging and testing call latency issues, particularly with mobile data connections.

## :older_man: :baby: Behaviors
### Before changes
- The `forceRelayCandidate` setting was hardcoded to `false` in the TxConfig creation
- The `webrtcStats` setting was hardcoded to `true` in the TxConfig creation
- AppDelegateCallKitExtension had hardcoded values instead of using stored settings
- No way to toggle these settings without modifying the code

### After changes
- Added toggle options in the hidden menu (accessed by long-pressing the app logo)
- Both settings are stored in UserDefaults for persistence across app sessions
- Applied consistently in both HomeViewController and AppDelegateCallKitExtension whenever a new TxConfig is created
- Default values: `forceRelayCandidate` = false, `webrtcStats` = true

## TODO
None - implementation is complete.

## ✋ Manual testing
1. Build and run the demo app
2. Long-press the Telnyx logo to access the hidden menu
3. Verify both "Enable/Disable Force Relay Candidate" and "Enable/Disable WebRTC Stats" options appear
4. Toggle the settings and verify the menu text changes appropriately
5. Connect to Telnyx and make a call to verify the settings are applied
6. Test both incoming calls (AppDelegateCallKitExtension) and outgoing calls (HomeViewController)
7. Restart the app and verify the settings persist

## Known Issues
None

## Screenshots
N/A - These are hidden menu options for debugging purposes

## Technical Details
### Force Relay Candidate
- **When enabled (true)**: Forces TURN relay only, fewer ICE candidates, may reduce call quality but prevents iOS permission popup
- **When disabled (false)**: Uses all ICE candidate types for better call quality but may show iOS permission popup

### WebRTC Stats
- **When enabled (true)**: Enables WebRTC statistics collection and debugging
- **When disabled (false)**: Disables WebRTC statistics collection

### Changes Made:
- Added `forceRelayCandidate` and `webrtcStats` keys to `UserDefaultsKey` enum
- Added corresponding save/get methods to UserDefaults extension
- Updated `showHiddenOptions()` method to include both toggle options
- Modified `createTxConfig()` method in HomeViewController to use stored settings
- Updated `processVoIPNotification()` method in AppDelegateCallKitExtension to use stored settings instead of hardcoded values
- Ensured consistent behavior across all TxConfig creation points