### PR TITLE
feat: add audio device reset to clear jitter buffers on network impro…

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -21,7 +21,7 @@ target 'TelnyxRTC' do
 
   # Pods for TelnyxRTC
   pod 'Starscream', '~> 4.0.8'
-  pod 'WebRTC-lib', "~> 124.0.0"
+  pod 'WebRTC-lib', "~> 139.0.0"
 
   target 'TelnyxRTCTests' do
     # Pods for testing

--- a/TelnyxRTC.xcodeproj/project.pbxproj
+++ b/TelnyxRTC.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		08C80C8CC74C9BC033B62062 /* Pods_TelnyxWebRTCDemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6E477492CA6207B0CA04BB3 /* Pods_TelnyxWebRTCDemo.framework */; };
+		0D2207BF83BD66C5E4FF28C0 /* Pods_TelnyxWebRTCDemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E11F8D788876E7BFC2A7FD94 /* Pods_TelnyxWebRTCDemo.framework */; };
 		3B0F56CB2C7F15830011A48A /* StatsMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0F56CA2C7F15830011A48A /* StatsMessage.swift */; };
 		3B1B4D132E2532B800A5DD2D /* RegionIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1B4D102E2532B800A5DD2D /* RegionIntegrationTests.swift */; };
 		3B1B4D142E2532B800A5DD2D /* RegionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B1B4D112E2532B800A5DD2D /* RegionTests.swift */; };
@@ -41,8 +41,11 @@
 		3BE7C7632E04292300FF74A1 /* RegionMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE7C7622E04292300FF74A1 /* RegionMenuView.swift */; };
 		3BE84BA82D9C944A00CA1B70 /* DestinationToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE84BA72D9C944A00CA1B70 /* DestinationToggle.swift */; };
 		3BF1D5842BEB7B8F0097453F /* TelnyxRTC.podspec in Resources */ = {isa = PBXBuildFile; fileRef = 3BF1D5832BEB7B8F0097453F /* TelnyxRTC.podspec */; };
-		5FCBE6F1F1CC93D7D34C1470 /* Pods_TelnyxRTC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A52AE951FE8A913D7516008 /* Pods_TelnyxRTC.framework */; };
+		5661AA25AE4E152C72930623 /* Pods_TelnyxRTC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEB7F316586B71822C51F0B0 /* Pods_TelnyxRTC.framework */; };
+		6EDDC8E5A782BFE7B1FEA7D9 /* Pods_TelnyxRTC_TelnyxRTCTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28F46FDD847E12B4F77F7B82 /* Pods_TelnyxRTC_TelnyxRTCTests.framework */; };
 		9906F63B2E391F5C00A02FE7 /* TxClientReconnectTimeoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9906F63A2E391F5C00A02FE7 /* TxClientReconnectTimeoutTests.swift */; };
+		990CA5572E6FB541004B3E15 /* CallQualityOptimizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 990CA5562E6FB535004B3E15 /* CallQualityOptimizer.swift */; };
+		990CA5592E6FC0D7004B3E15 /* NetworkQualityMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 990CA5582E6FC0D7004B3E15 /* NetworkQualityMonitor.swift */; };
 		9911247E2CF50092000C23BA /* Dictionary+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9911247D2CF50088000C23BA /* Dictionary+Extensions.swift */; };
 		991A6D442D3A96C100B29785 /* SplashScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991A6D432D3A96C100B29785 /* SplashScreen.swift */; };
 		991A6D492D3AB36E00B29785 /* SipCredentialsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991A6D482D3AB36E00B29785 /* SipCredentialsView.swift */; };
@@ -144,7 +147,6 @@
 		B3E1033225F7F94900227DCE /* incoming_call.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = B3E1033025F7F94900227DCE /* incoming_call.mp3 */; };
 		B3E1033325F7F94900227DCE /* ringback_tone.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = B3E1033125F7F94900227DCE /* ringback_tone.mp3 */; };
 		B84E50517AD67FE44AC37952 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
-		FC2835C766C287188726D1C1 /* Pods_TelnyxRTC_TelnyxRTCTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B2F433F3B81462AC009A0B69 /* Pods_TelnyxRTC_TelnyxRTCTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -196,8 +198,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		005E859F7E0040F33D8C24D6 /* Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig"; sourceTree = "<group>"; };
-		143AE1FD541DDAE74F2F3D38 /* Pods-TelnyxRTC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC.debug.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC/Pods-TelnyxRTC.debug.xcconfig"; sourceTree = "<group>"; };
+		045D0B1F5E61751A1806B971 /* Pods-TelnyxWebRTCDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxWebRTCDemo.release.xcconfig"; path = "Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo.release.xcconfig"; sourceTree = "<group>"; };
+		28F46FDD847E12B4F77F7B82 /* Pods_TelnyxRTC_TelnyxRTCTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxRTC_TelnyxRTCTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2E73C56031342B9D2E22B81B /* Pods-TelnyxRTC.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC.release.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC/Pods-TelnyxRTC.release.xcconfig"; sourceTree = "<group>"; };
 		3B0F56CA2C7F15830011A48A /* StatsMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsMessage.swift; sourceTree = "<group>"; };
 		3B0F56CC2C7F1CCA0011A48A /* Reachability.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Reachability.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B1B4D102E2532B800A5DD2D /* RegionIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionIntegrationTests.swift; sourceTree = "<group>"; };
@@ -228,9 +231,10 @@
 		3BE7C7622E04292300FF74A1 /* RegionMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionMenuView.swift; sourceTree = "<group>"; };
 		3BE84BA72D9C944A00CA1B70 /* DestinationToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DestinationToggle.swift; sourceTree = "<group>"; };
 		3BF1D5832BEB7B8F0097453F /* TelnyxRTC.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = TelnyxRTC.podspec; sourceTree = "<group>"; };
-		6ABC09607EB36CA9C6751337 /* Pods-TelnyxRTC.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC.release.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC/Pods-TelnyxRTC.release.xcconfig"; sourceTree = "<group>"; };
-		72EFA01F477DE11D105894B5 /* Pods-TelnyxWebRTCDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxWebRTCDemo.debug.xcconfig"; path = "Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo.debug.xcconfig"; sourceTree = "<group>"; };
+		42328124CA4CB78A40EDCF04 /* Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig"; sourceTree = "<group>"; };
 		9906F63A2E391F5C00A02FE7 /* TxClientReconnectTimeoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxClientReconnectTimeoutTests.swift; sourceTree = "<group>"; };
+		990CA5562E6FB535004B3E15 /* CallQualityOptimizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallQualityOptimizer.swift; sourceTree = "<group>"; };
+		990CA5582E6FC0D7004B3E15 /* NetworkQualityMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkQualityMonitor.swift; sourceTree = "<group>"; };
 		9911247D2CF50088000C23BA /* Dictionary+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extensions.swift"; sourceTree = "<group>"; };
 		991A6D432D3A96C100B29785 /* SplashScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashScreen.swift; sourceTree = "<group>"; };
 		991A6D462D3AB36E00B29785 /* SipCredentialHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SipCredentialHeader.swift; sourceTree = "<group>"; };
@@ -285,9 +289,6 @@
 		99D7C09B2E1E32DA00D47CE6 /* AudioWaveformView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioWaveformView.swift; sourceTree = "<group>"; };
 		99FF7B0F2D4BC4F700DB1408 /* DTMFKeyboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DTMFKeyboardView.swift; sourceTree = "<group>"; };
 		99FF7B112D4BC71800DB1408 /* DTMFKeyboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DTMFKeyboardViewModel.swift; sourceTree = "<group>"; };
-		9A52AE951FE8A913D7516008 /* Pods_TelnyxRTC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxRTC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		ABDDBB3BFF7B3DF99A132A9B /* Pods-TelnyxWebRTCDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxWebRTCDemo.release.xcconfig"; path = "Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo.release.xcconfig"; sourceTree = "<group>"; };
-		B2F433F3B81462AC009A0B69 /* Pods_TelnyxRTC_TelnyxRTCTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxRTC_TelnyxRTCTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B309D11125EF107F00A2AADF /* Starscream.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Starscream.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B309D1D525F020B300A2AADF /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		B309D1DA25F020D400A2AADF /* Method.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Method.swift; sourceTree = "<group>"; };
@@ -340,8 +341,11 @@
 		B3E1029925F2C16500227DCE /* ModifyMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyMessage.swift; sourceTree = "<group>"; };
 		B3E1033025F7F94900227DCE /* incoming_call.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = incoming_call.mp3; sourceTree = "<group>"; };
 		B3E1033125F7F94900227DCE /* ringback_tone.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = ringback_tone.mp3; sourceTree = "<group>"; };
-		C1D73C5BFA136BD2584C27AF /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig"; sourceTree = "<group>"; };
-		D6E477492CA6207B0CA04BB3 /* Pods_TelnyxWebRTCDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxWebRTCDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C962A5050D19848C0B26B1D6 /* Pods-TelnyxWebRTCDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxWebRTCDemo.debug.xcconfig"; path = "Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo.debug.xcconfig"; sourceTree = "<group>"; };
+		CEB7F316586B71822C51F0B0 /* Pods_TelnyxRTC.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxRTC.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA8A06F8C3A83FB0A51B5DEC /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig"; sourceTree = "<group>"; };
+		E11F8D788876E7BFC2A7FD94 /* Pods_TelnyxWebRTCDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TelnyxWebRTCDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E83E5BC5EE036F07635B1D63 /* Pods-TelnyxRTC.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC.debug.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC/Pods-TelnyxRTC.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -357,7 +361,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B309D13D25EF119E00A2AADF /* Starscream.framework in Frameworks */,
-				5FCBE6F1F1CC93D7D34C1470 /* Pods_TelnyxRTC.framework in Frameworks */,
+				5661AA25AE4E152C72930623 /* Pods_TelnyxRTC.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -367,7 +371,7 @@
 			files = (
 				B368BED625EDDBC90032AE52 /* TelnyxRTC.framework in Frameworks */,
 				B84E50517AD67FE44AC37952 /* (null) in Frameworks */,
-				FC2835C766C287188726D1C1 /* Pods_TelnyxRTC_TelnyxRTCTests.framework in Frameworks */,
+				6EDDC8E5A782BFE7B1FEA7D9 /* Pods_TelnyxRTC_TelnyxRTCTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -377,7 +381,7 @@
 			files = (
 				3B5CD8D92D833677006D3734 /* TelnyxRTC.framework in Frameworks */,
 				3BC03B4E2CC25F5F00FD2B29 /* Reachability.framework in Frameworks */,
-				08C80C8CC74C9BC033B62062 /* Pods_TelnyxWebRTCDemo.framework in Frameworks */,
+				0D2207BF83BD66C5E4FF28C0 /* Pods_TelnyxWebRTCDemo.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -387,12 +391,12 @@
 		8AB3A6A2ADA6A9FAC6C77491 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				143AE1FD541DDAE74F2F3D38 /* Pods-TelnyxRTC.debug.xcconfig */,
-				6ABC09607EB36CA9C6751337 /* Pods-TelnyxRTC.release.xcconfig */,
-				C1D73C5BFA136BD2584C27AF /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */,
-				005E859F7E0040F33D8C24D6 /* Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig */,
-				72EFA01F477DE11D105894B5 /* Pods-TelnyxWebRTCDemo.debug.xcconfig */,
-				ABDDBB3BFF7B3DF99A132A9B /* Pods-TelnyxWebRTCDemo.release.xcconfig */,
+				E83E5BC5EE036F07635B1D63 /* Pods-TelnyxRTC.debug.xcconfig */,
+				2E73C56031342B9D2E22B81B /* Pods-TelnyxRTC.release.xcconfig */,
+				DA8A06F8C3A83FB0A51B5DEC /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */,
+				42328124CA4CB78A40EDCF04 /* Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig */,
+				C962A5050D19848C0B26B1D6 /* Pods-TelnyxWebRTCDemo.debug.xcconfig */,
+				045D0B1F5E61751A1806B971 /* Pods-TelnyxWebRTCDemo.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -577,6 +581,8 @@
 				991124752CF4FE95000C23BA /* Stats */,
 				B309D22825F06C6900A2AADF /* Call.swift */,
 				B309D23025F06CA800A2AADF /* Peer.swift */,
+				990CA5582E6FC0D7004B3E15 /* NetworkQualityMonitor.swift */,
+				990CA5562E6FB535004B3E15 /* CallQualityOptimizer.swift */,
 			);
 			path = WebRTC;
 			sourceTree = "<group>";
@@ -761,9 +767,9 @@
 			children = (
 				3B0F56CC2C7F1CCA0011A48A /* Reachability.framework */,
 				B309D11125EF107F00A2AADF /* Starscream.framework */,
-				9A52AE951FE8A913D7516008 /* Pods_TelnyxRTC.framework */,
-				B2F433F3B81462AC009A0B69 /* Pods_TelnyxRTC_TelnyxRTCTests.framework */,
-				D6E477492CA6207B0CA04BB3 /* Pods_TelnyxWebRTCDemo.framework */,
+				CEB7F316586B71822C51F0B0 /* Pods_TelnyxRTC.framework */,
+				28F46FDD847E12B4F77F7B82 /* Pods_TelnyxRTC_TelnyxRTCTests.framework */,
+				E11F8D788876E7BFC2A7FD94 /* Pods_TelnyxWebRTCDemo.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -804,7 +810,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = B368BEC825EDDB610032AE52 /* Build configuration list for PBXNativeTarget "TelnyxRTC" */;
 			buildPhases = (
-				F50FB6AA580D6624E9B73705 /* [CP] Check Pods Manifest.lock */,
+				BCF96C6841A72EDA392FA229 /* [CP] Check Pods Manifest.lock */,
 				B368BEBB25EDDB610032AE52 /* Headers */,
 				B368BEBC25EDDB610032AE52 /* Sources */,
 				B368BEBD25EDDB610032AE52 /* Frameworks */,
@@ -824,11 +830,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = B368BEDB25EDDBC90032AE52 /* Build configuration list for PBXNativeTarget "TelnyxRTCTests" */;
 			buildPhases = (
-				C1CD2A8DEC34929FCC341135 /* [CP] Check Pods Manifest.lock */,
+				0E5E5F5D4221806E1F2EF17F /* [CP] Check Pods Manifest.lock */,
 				B368BECD25EDDBC90032AE52 /* Sources */,
 				B368BECE25EDDBC90032AE52 /* Frameworks */,
 				B368BECF25EDDBC90032AE52 /* Resources */,
-				105B8300D22F993FD61F48EA /* [CP] Embed Pods Frameworks */,
+				AC3D3BC5D793E9536F6494A4 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -844,12 +850,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = B368BEF925EDDD070032AE52 /* Build configuration list for PBXNativeTarget "TelnyxWebRTCDemo" */;
 			buildPhases = (
-				359B7BA161D8B4FAC4FA2223 /* [CP] Check Pods Manifest.lock */,
+				F24DF22C248A7BA4EC375E75 /* [CP] Check Pods Manifest.lock */,
 				B368BEE425EDDD060032AE52 /* Sources */,
 				B368BEE525EDDD060032AE52 /* Frameworks */,
 				B368BEE625EDDD060032AE52 /* Resources */,
 				3B5CD8DB2D833677006D3734 /* Embed Frameworks */,
-				2F98C0193BD502C670E7F6F6 /* [CP] Embed Pods Frameworks */,
+				B924F3D2CD9CF08B255B0316 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -953,63 +959,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		105B8300D22F993FD61F48EA /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		2F98C0193BD502C670E7F6F6 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		359B7BA161D8B4FAC4FA2223 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-TelnyxWebRTCDemo-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		C1CD2A8DEC34929FCC341135 /* [CP] Check Pods Manifest.lock */ = {
+		0E5E5F5D4221806E1F2EF17F /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1031,7 +981,49 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		F50FB6AA580D6624E9B73705 /* [CP] Check Pods Manifest.lock */ = {
+		AC3D3BC5D793E9536F6494A4 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B924F3D2CD9CF08B255B0316 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TelnyxWebRTCDemo/Pods-TelnyxWebRTCDemo-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		BCF96C6841A72EDA392FA229 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1047,6 +1039,28 @@
 			);
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/Pods-TelnyxRTC-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F24DF22C248A7BA4EC375E75 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-TelnyxWebRTCDemo-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1082,6 +1096,7 @@
 				996C67CE2CFEA6AF0056E508 /* RTCIceConnectionState+Extension.swift in Sources */,
 				B3BB8FA026BC076000DDCB84 /* GatewayMessage.swift in Sources */,
 				3BE7C75F2E0334AB00FF74A1 /* Region.swift in Sources */,
+				990CA5572E6FB541004B3E15 /* CallQualityOptimizer.swift in Sources */,
 				3BABEA392D5F595A00B7C79C /* NetworkMonitor.swift in Sources */,
 				3B21257C2DC8126B00E68EA6 /* CallQualityMetrics.swift in Sources */,
 				B309D1DB25F020D400A2AADF /* Method.swift in Sources */,
@@ -1118,6 +1133,7 @@
 				B309D22925F06C6900A2AADF /* Call.swift in Sources */,
 				996C67C42CFEA5AC0056E508 /* RTCContinualGatheringPolicy+Extension.swift in Sources */,
 				B309D1EC25F024B900A2AADF /* LoginMessage.swift in Sources */,
+				990CA5592E6FC0D7004B3E15 /* NetworkQualityMonitor.swift in Sources */,
 				99B6DFFA2CF5226F0010CA96 /* WebRTCStatsTag.swift in Sources */,
 				99CC5BAE2CF80D3A00EF43DC /* WebRTCEventHandler.swift in Sources */,
 				996C67D02CFEA6F30056E508 /* RTCIceGatheringState+Extension.swift in Sources */,
@@ -1411,7 +1427,7 @@
 		};
 		B368BEC925EDDB610032AE52 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 143AE1FD541DDAE74F2F3D38 /* Pods-TelnyxRTC.debug.xcconfig */;
+			baseConfigurationReference = E83E5BC5EE036F07635B1D63 /* Pods-TelnyxRTC.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -1451,7 +1467,7 @@
 		};
 		B368BECA25EDDB610032AE52 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6ABC09607EB36CA9C6751337 /* Pods-TelnyxRTC.release.xcconfig */;
+			baseConfigurationReference = 2E73C56031342B9D2E22B81B /* Pods-TelnyxRTC.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -1485,7 +1501,7 @@
 		};
 		B368BED925EDDBC90032AE52 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C1D73C5BFA136BD2584C27AF /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */;
+			baseConfigurationReference = DA8A06F8C3A83FB0A51B5DEC /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
@@ -1506,7 +1522,7 @@
 		};
 		B368BEDA25EDDBC90032AE52 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 005E859F7E0040F33D8C24D6 /* Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig */;
+			baseConfigurationReference = 42328124CA4CB78A40EDCF04 /* Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
@@ -1527,7 +1543,7 @@
 		};
 		B368BEFA25EDDD070032AE52 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 72EFA01F477DE11D105894B5 /* Pods-TelnyxWebRTCDemo.debug.xcconfig */;
+			baseConfigurationReference = C962A5050D19848C0B26B1D6 /* Pods-TelnyxWebRTCDemo.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -1554,7 +1570,7 @@
 		};
 		B368BEFB25EDDD070032AE52 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = ABDDBB3BFF7B3DF99A132A9B /* Pods-TelnyxWebRTCDemo.release.xcconfig */;
+			baseConfigurationReference = 045D0B1F5E61751A1806B971 /* Pods-TelnyxWebRTCDemo.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/TelnyxRTC/Telnyx/WebRTC/CallQualityOptimizer.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/CallQualityOptimizer.swift
@@ -1,0 +1,257 @@
+import Foundation
+import WebRTC
+import AVFoundation
+
+class CallQualityOptimizer {
+    static let shared = CallQualityOptimizer()
+    
+    let enabled = true
+    
+    let avg_bitrate = 16000
+    let minptime = 20
+    let ptime = 40
+    
+    private var networkQualityMonitor = NetworkQualityMonitor.shared
+    private var currentPeerConnection: RTCPeerConnection?
+    private var isAudioResetInProgress = false
+    
+    func improveRTCConfig(_ config: RTCConfiguration) {
+        if !enabled { return }
+        
+        config.enableDscp = true
+        config.audioJitterBufferMaxPackets = 8
+        config.audioJitterBufferFastAccelerate = true
+    }
+    
+    func adjustBitrate(for pc: RTCPeerConnection) {
+        if !enabled { return }
+        
+        guard let sender = pc.senders.first(where: { $0.track?.kind == "audio" }) else { return }
+        let params = sender.parameters
+        guard !params.encodings.isEmpty else { return }
+        Logger.log.i(message: "Peer:: Adjusting Bitrate was \(String(describing: params.encodings[0].maxBitrateBps)) -> \(avg_bitrate)")
+        
+        params.encodings[0].maxBitrateBps = NSNumber(value: avg_bitrate)
+        sender.parameters = params
+    }
+    
+    func startNetworkMonitoring(for pc: RTCPeerConnection) {
+        if !enabled { return }
+        
+        currentPeerConnection = pc
+        networkQualityMonitor.startMonitoring()
+        
+        // Set up network improvement detection callback
+        networkQualityMonitor.onNetworkImprovementDetected = { [weak self] in
+            self?.handleNetworkImprovementDetected()
+        }
+        
+        // Set up network quality change callback for general monitoring
+        networkQualityMonitor.onNetworkQualityChange = { quality in
+            Logger.log.i(message: "CallQualityOptimizer:: Network quality changed to \(quality)")
+        }
+        
+        Logger.log.i(message: "CallQualityOptimizer:: Started network quality monitoring")
+    }
+    
+    func stopNetworkMonitoring() {
+        networkQualityMonitor.stopMonitoring()
+        currentPeerConnection = nil
+        isAudioResetInProgress = false
+        Logger.log.i(message: "CallQualityOptimizer:: Stopped network quality monitoring")
+    }
+    
+    func updateNetworkMetrics(rtt: Double, jitter: Double, packetLoss: Double = 0) {
+        if !enabled { return }
+        
+        networkQualityMonitor.updateNetworkMetrics(rtt: rtt, jitter: jitter, packetLoss: packetLoss)
+        Logger.log.i(message: "CallQualityOptimizer:: Updated metrics - RTT: \(rtt * 1000)ms, Jitter: \(jitter * 1000)ms, PacketLoss: \(packetLoss)%")
+    }
+    
+    private func handleNetworkImprovementDetected() {
+        guard let pc = currentPeerConnection, !isAudioResetInProgress else { return }
+        
+        Logger.log.i(message: "CallQualityOptimizer:: Network improvement detected! Resetting audio device to clear jitter buffers...")
+        
+        // Reset audio device to clear jitter buffers instead of ICE restart
+        resetAudioDeviceAndClearBuffers(for: pc)
+    }
+    
+    private func resetAudioDeviceAndClearBuffers(for pc: RTCPeerConnection) {
+        guard !isAudioResetInProgress else { return }
+        
+        isAudioResetInProgress = true
+        
+        Logger.log.i(message: "CallQualityOptimizer:: Starting audio device reset to clear jitter buffers...")
+        
+        self.forceResetAudioDevice()
+        
+//        // Additional ultra-aggressive reset for persistent delays
+//        DispatchQueue.main.asyncAfter(deadline: .now() + 8.0) {
+//            self.ultraAggressiveReset()
+//        }
+        
+        Logger.log.i(message: "CallQualityOptimizer:: Audio device reset completed successfully")
+        isAudioResetInProgress = false
+    }
+    
+    private func forceResetAudioDevice() {
+        Logger.log.i(message: "CallQualityOptimizer:: Force resetting audio device...")
+        
+        // Execute 3 reset cycles sequentially
+        executeResetCycle(cycle: 1, totalCycles: 3)
+    }
+    
+    private func executeResetCycle(cycle: Int, totalCycles: Int) {
+        Logger.log.i(message: "CallQualityOptimizer:: Executing reset cycle \(cycle)/\(totalCycles)...")
+        
+        let rtcAudioSession = RTCAudioSession.sharedInstance()
+        let audioSession = AVAudioSession.sharedInstance()
+        
+        // Step 1: Deactivate audio device
+        Logger.log.i(message: "CallQualityOptimizer:: Cycle \(cycle) - Deactivating audio device...")
+        rtcAudioSession.audioSessionDidDeactivate(audioSession)
+        rtcAudioSession.isAudioEnabled = false
+        
+        // Step 2: Deactivate audio session
+        do {
+            try audioSession.setActive(false, options: .notifyOthersOnDeactivation)
+            Logger.log.i(message: "CallQualityOptimizer:: Cycle \(cycle) - Audio session deactivated")
+        } catch {
+            Logger.log.e(message: "CallQualityOptimizer:: Cycle \(cycle) - Failed to deactivate audio session: \(error)")
+        }
+        
+        // Step 3: Wait for buffers to clear (increasing wait time per cycle)
+        let waitTime = Double(cycle) * 1  // 0.5s, 1.0s, 1.5s
+        DispatchQueue.main.asyncAfter(deadline: .now() + waitTime) {
+            // Step 4: Reactivate with fresh configuration
+            Logger.log.i(message: "CallQualityOptimizer:: Cycle \(cycle) - Reactivating with fresh configuration...")
+            
+            do {
+                try audioSession.setCategory(.playAndRecord, 
+                                           mode: .voiceChat, 
+                                           options: [.allowBluetooth, .duckOthers])
+                try audioSession.setActive(true)
+                Logger.log.i(message: "CallQualityOptimizer:: Cycle \(cycle) - Audio session reactivated")
+            } catch {
+                Logger.log.e(message: "CallQualityOptimizer:: Cycle \(cycle) - Failed to reactivate audio session: \(error)")
+            }
+            
+            // Step 5: Re-enable RTC audio session
+            rtcAudioSession.audioSessionDidActivate(audioSession)
+            rtcAudioSession.isAudioEnabled = true
+            
+            Logger.log.i(message: "CallQualityOptimizer:: Cycle \(cycle) - Completed")
+            
+            // Step 6: Execute next cycle or finish
+            if cycle < totalCycles {
+                // Wait a bit before next cycle
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    self.executeResetCycle(cycle: cycle + 1, totalCycles: totalCycles)
+                }
+            } else {
+                Logger.log.i(message: "CallQualityOptimizer:: All reset cycles completed successfully")
+            }
+        }
+    }
+    
+    
+    private func softResetAudioSession() {
+        Logger.log.i(message: "CallQualityOptimizer:: Soft resetting audio session...")
+        
+        // Soft reset without deactivating the audio session to preserve call
+        do {
+            let audioSession = AVAudioSession.sharedInstance()
+            
+            // Only reconfigure the audio session without deactivating
+            try audioSession.setCategory(.playAndRecord, 
+                                       mode: .voiceChat, 
+                                       options: [.allowBluetooth, .duckOthers])
+            
+            // Force audio session to refresh its configuration
+            try audioSession.setPreferredSampleRate(16000)
+            try audioSession.setPreferredIOBufferDuration(0.005) // 5ms buffer for low latency
+            
+            Logger.log.i(message: "CallQualityOptimizer:: Audio session soft reset completed")
+        } catch {
+            Logger.log.e(message: "CallQualityOptimizer:: Failed to soft reset audio session: \(error)")
+        }
+    }
+    
+    func optimizeSDP(_ original: RTCSessionDescription) -> RTCSessionDescription {
+        if !enabled { return original }
+        
+        Logger.log.i(message: "Peer:: SDP Original:\n\(original.sdp)")
+        
+        let optimized = optimizeForWorstCase(original.sdp)
+        let validation = validateOptimizedSDP(optimized)
+        
+        if !validation.isValid {
+            Logger.log.i(message: "Peer:: SDP Optimization Warning: \(validation.issues.joined(separator: ", "))")
+            Logger.log.i(message: optimized)
+            // Return original if validation fails
+            return original
+        }
+        
+        Logger.log.i(message: "Peer:: SDP Optimization Succeeded\n\(optimized)")
+        return RTCSessionDescription(type: original.type, sdp: optimized)
+    }
+    
+    private func optimizeForWorstCase(_ originalSDP: String) -> String {
+        let lines = originalSDP.components(separatedBy: "\r\n")
+        var processedLines: [String] = []
+        
+        for line in lines {
+            let trimmedLine = line.trimmingCharacters(in: .whitespaces)
+            
+            // Ultra-conservative Opus settings optimized for extreme cellular conditions
+            if trimmedLine.hasPrefix("a=fmtp:111") {
+                // Extreme cellular optimization: handles 1sec+ RTT, network switching
+                processedLines.append("a=fmtp:111 minptime=\(minptime);useinbandfec=1;usedtx=0;maxaveragebitrate=\(avg_bitrate);maxplaybackrate=\(avg_bitrate);stereo=0;sprop-stereo=0;cbr=1")
+            }
+            // Change Opus sample rate from 48000 to 16000 to match bitrate
+            else if trimmedLine.contains("opus/48000") {
+                processedLines.append(trimmedLine.replacingOccurrences(of: "opus/48000", with: "opus/16000"))
+            }
+            // Change telephone-event sample rate from 48000 to 16000 to match Opus
+            else if trimmedLine.contains("telephone-event/48000") {
+                processedLines.append(trimmedLine.replacingOccurrences(of: "telephone-event/48000", with: "telephone-event/16000"))
+            }
+            // Keep all other essential SDP attributes
+            else {
+                processedLines.append(trimmedLine)
+            }
+        }
+        
+        // Use the original separator when rejoining
+        return processedLines.joined(separator: "\r\n")
+    }
+    
+    /// Validation function to ensure the optimized SDP maintains essential functionality
+    private func validateOptimizedSDP(_ sdp: String) -> (isValid: Bool, issues: [String]) {
+        let lines = sdp.components(separatedBy: .newlines)
+        var issues: [String] = []
+        
+        // Check for essential components
+        let hasVersion = lines.contains { $0.hasPrefix("v=") }
+        let hasOrigin = lines.contains { $0.hasPrefix("o=") }
+        let hasMedia = lines.contains { $0.hasPrefix("m=audio") }
+        let hasOpus = lines.contains { $0.contains("opus/16000") }
+        let hasPCMU = lines.contains { $0.contains("PCMU/8000") }
+        let hasDTMF = lines.contains { $0.contains("telephone-event/16000") } ||
+        lines.contains { $0.contains("telephone-event/8000") }
+        let hasICE = lines.contains { $0.hasPrefix("a=ice-ufrag") }
+        let hasBitrateLimit = lines.contains { $0.contains("maxaveragebitrate") }
+        
+        if !hasVersion { issues.append("Missing version line") }
+        if !hasOrigin { issues.append("Missing origin line") }
+        if !hasMedia { issues.append("Missing audio media line") }
+        if !hasOpus { issues.append("Missing Opus codec") }
+        if !hasPCMU { issues.append("Missing PCMU fallback codec") }
+        if !hasDTMF { issues.append("Missing DTMF support") }
+        if !hasICE { issues.append("Missing ICE credentials") }
+        if !hasBitrateLimit { issues.append("Missing bitrate optimization") }
+        
+        return (isValid: issues.isEmpty, issues: issues)
+    }
+}

--- a/TelnyxRTC/Telnyx/WebRTC/NetworkQualityMonitor.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/NetworkQualityMonitor.swift
@@ -1,0 +1,267 @@
+import Foundation
+import WebRTC
+import Network
+
+class NetworkQualityMonitor {
+    static let shared = NetworkQualityMonitor()
+    
+    private var rttHistory: [Double] = []
+    private var jitterHistory: [Double] = []
+    private var packetLossHistory: [Double] = []
+    private let maxHistorySize = 10
+    
+    // Thresholds for network quality detection
+    private let goodRttThreshold: Double = 0.1 // 100ms
+    private let poorRttThreshold: Double = 0.5 // 500ms
+    private let improvementThreshold: Double = 0.3 // 300ms improvement
+    
+    private var lastNetworkQuality: NetworkQuality = .unknown
+    private var isMonitoring = false
+    private var lastNetworkType: NWInterface.InterfaceType?
+    private var networkPathMonitor: NWPathMonitor?
+    private var networkQueue = DispatchQueue(label: "NetworkMonitor")
+    
+    // ICE restart state
+    private var lastICERestartTime: Date?
+    private let minICERestartInterval: TimeInterval = 30 // 30 seconds minimum between restarts
+    
+    enum NetworkQuality {
+        case excellent
+        case good
+        case fair
+        case poor
+        case unknown
+    }
+    
+    var onNetworkQualityChange: ((NetworkQuality) -> Void)?
+    var onNetworkImprovementDetected: (() -> Void)?
+    
+    private init() {
+        setupNetworkPathMonitoring()
+    }
+    
+    func startMonitoring() {
+        isMonitoring = true
+        rttHistory.removeAll()
+    }
+    
+    func stopMonitoring() {
+        isMonitoring = false
+        rttHistory.removeAll()
+    }
+    
+    func updateNetworkMetrics(rtt: Double, jitter: Double, packetLoss: Double) {
+        guard isMonitoring else { return }
+        
+        // Add to history
+        rttHistory.append(rtt)
+        jitterHistory.append(jitter)
+        packetLossHistory.append(packetLoss)
+        
+        // Keep history size manageable
+        if rttHistory.count > maxHistorySize {
+            rttHistory.removeFirst()
+            jitterHistory.removeFirst()
+            packetLossHistory.removeFirst()
+        }
+        
+        // Need at least 3 samples for reliable detection
+        guard rttHistory.count >= 3 else { return }
+        
+        // Calculate averages
+        let avgRTT = rttHistory.reduce(0, +) / Double(rttHistory.count)
+        let avgJitter = jitterHistory.reduce(0, +) / Double(jitterHistory.count)
+        let avgPacketLoss = packetLossHistory.reduce(0, +) / Double(packetLossHistory.count)
+        
+        Logger.log.i(message: "NetworkQualityMonitor:: Metrics - RTT: \(avgRTT * 1000)ms, Jitter: \(avgJitter * 1000)ms, PacketLoss: \(avgPacketLoss)%")
+        
+        // Detect network improvement using multiple indicators
+        if detectNetworkImprovement(avgRTT: avgRTT, avgJitter: avgJitter, avgPacketLoss: avgPacketLoss) {
+            Logger.log.i(message: "NetworkQualityMonitor:: Network improvement detected! Triggering ICE restart...")
+            onNetworkImprovementDetected?()
+        }
+        
+        // Update quality for general monitoring
+        let currentQuality = determineNetworkQuality(avgRTT)
+        if currentQuality != lastNetworkQuality {
+            lastNetworkQuality = currentQuality
+            onNetworkQualityChange?(currentQuality)
+        }
+    }
+    
+    func updateRTT(_ rtt: Double) {
+        // Legacy method for backward compatibility
+        updateNetworkMetrics(rtt: rtt, jitter: 0, packetLoss: 0)
+    }
+    
+    private func determineNetworkQuality(_ rtt: Double) -> NetworkQuality {
+        switch rtt {
+        case 0..<goodRttThreshold:
+            return .excellent
+        case goodRttThreshold..<0.2:
+            return .good
+        case 0.2..<0.4:
+            return .fair
+        case 0.4..<poorRttThreshold:
+            return .poor
+        default:
+            return .poor
+        }
+    }
+    
+    private func shouldTriggerICEUpdate(currentQuality: NetworkQuality, previousQuality: NetworkQuality) -> Bool {
+        // Trigger ICE update if we've improved from poor to good or better
+        switch (previousQuality, currentQuality) {
+        case (.poor, .excellent), (.poor, .good), (.fair, .excellent):
+            return true
+        case (.unknown, .excellent), (.unknown, .good):
+            return true
+        default:
+            return false
+        }
+    }
+    
+    func getCurrentQuality() -> NetworkQuality {
+        return lastNetworkQuality
+    }
+    
+    func getAverageRTT() -> Double {
+        guard !rttHistory.isEmpty else { return 0 }
+        return rttHistory.reduce(0, +) / Double(rttHistory.count)
+    }
+    
+    // MARK: - Network Improvement Detection
+    
+    private func detectNetworkImprovement(avgRTT: Double, avgJitter: Double, avgPacketLoss: Double) -> Bool {
+        // Check if enough time has passed since last ICE restart
+        if let lastRestart = lastICERestartTime,
+           Date().timeIntervalSince(lastRestart) < minICERestartInterval {
+            return false
+        }
+        
+        // Detect improvement based on multiple indicators
+        let rttImprovement = detectRTTImprovement(avgRTT)
+        let jitterImprovement = detectJitterImprovement(avgJitter)
+        let packetLossImprovement = detectPacketLossImprovement(avgPacketLoss)
+        let networkTypeChange = detectNetworkTypeChange()
+        
+        // Trigger ICE restart if we detect significant improvement
+        let shouldRestart = rttImprovement || jitterImprovement || packetLossImprovement || networkTypeChange
+        
+        if shouldRestart {
+            lastICERestartTime = Date()
+            Logger.log.i(message: "NetworkQualityMonitor:: ICE restart triggered - RTT: \(rttImprovement), Jitter: \(jitterImprovement), PacketLoss: \(packetLossImprovement), NetworkType: \(networkTypeChange)")
+        }
+        
+        return shouldRestart
+    }
+    
+    private func detectRTTImprovement(_ avgRTT: Double) -> Bool {
+        // Look for significant RTT improvement in recent samples
+        guard rttHistory.count >= 3 else { return false }
+        
+        let recentRTT = Array(rttHistory.suffix(2))
+        let olderRTT = Array(rttHistory.prefix(rttHistory.count - 2))
+        
+        let recentAvg = recentRTT.reduce(0, +) / Double(recentRTT.count)
+        let olderAvg = olderRTT.reduce(0, +) / Double(olderRTT.count)
+        
+        // More sensitive detection: look for RTT improvement from high to low values
+        let improvement = olderAvg - recentAvg
+        let wasHighRTT = olderAvg > 0.5  // Was RTT > 500ms
+        let isLowRTT = recentAvg < 0.2   // Is RTT < 200ms
+        let significantImprovement = improvement > 0.2 || (wasHighRTT && isLowRTT)
+        
+        Logger.log.i(message: "NetworkQualityMonitor:: RTT improvement check - Older: \(olderAvg * 1000)ms, Recent: \(recentAvg * 1000)ms, Improvement: \(improvement * 1000)ms, WasHigh: \(wasHighRTT), IsLow: \(isLowRTT), Significant: \(significantImprovement)")
+        
+        return significantImprovement
+    }
+    
+    private func detectJitterImprovement(_ avgJitter: Double) -> Bool {
+        // Look for significant jitter improvement
+        guard jitterHistory.count >= 5 else { return false }
+        
+        let recentJitter = Array(jitterHistory.suffix(3))
+        let olderJitter = Array(jitterHistory.prefix(jitterHistory.count - 3))
+        
+        let recentAvg = recentJitter.reduce(0, +) / Double(recentJitter.count)
+        let olderAvg = olderJitter.reduce(0, +) / Double(olderJitter.count)
+        
+        // Significant improvement: recent jitter is much better than older jitter
+        let improvement = olderAvg - recentAvg
+        let significantImprovement = improvement > 0.05 // 50ms improvement
+        
+        Logger.log.i(message: "NetworkQualityMonitor:: Jitter improvement check - Older: \(olderAvg * 1000)ms, Recent: \(recentAvg * 1000)ms, Improvement: \(improvement * 1000)ms, Significant: \(significantImprovement)")
+        
+        return significantImprovement
+    }
+    
+    private func detectPacketLossImprovement(_ avgPacketLoss: Double) -> Bool {
+        // Look for significant packet loss improvement
+        guard packetLossHistory.count >= 5 else { return false }
+        
+        let recentLoss = Array(packetLossHistory.suffix(3))
+        let olderLoss = Array(packetLossHistory.prefix(packetLossHistory.count - 3))
+        
+        let recentAvg = recentLoss.reduce(0, +) / Double(recentLoss.count)
+        let olderAvg = olderLoss.reduce(0, +) / Double(olderLoss.count)
+        
+        // Significant improvement: recent packet loss is much better than older
+        let improvement = olderAvg - recentAvg
+        let significantImprovement = improvement > 5.0 // 5% improvement
+        
+        Logger.log.i(message: "NetworkQualityMonitor:: Packet loss improvement check - Older: \(olderAvg)%, Recent: \(recentAvg)%, Improvement: \(improvement)%, Significant: \(significantImprovement)")
+        
+        return significantImprovement
+    }
+    
+    private func detectNetworkTypeChange() -> Bool {
+        // Check if network type changed (e.g., cellular to WiFi)
+        guard let currentType = getCurrentNetworkType() else { return false }
+        
+        if let lastType = lastNetworkType, lastType != currentType {
+            Logger.log.i(message: "NetworkQualityMonitor:: Network type changed from \(lastType) to \(currentType)")
+            lastNetworkType = currentType
+            return true
+        }
+        
+        lastNetworkType = currentType
+        return false
+    }
+    
+    private func getCurrentNetworkType() -> NWInterface.InterfaceType? {
+        // This would need to be implemented based on your network monitoring setup
+        // For now, return nil to disable this check
+        return nil
+    }
+    
+    // MARK: - Network Path Monitoring
+    
+    private func setupNetworkPathMonitoring() {
+        networkPathMonitor = NWPathMonitor()
+        networkPathMonitor?.pathUpdateHandler = { [weak self] path in
+            DispatchQueue.main.async {
+                self?.handleNetworkPathUpdate(path)
+            }
+        }
+        networkPathMonitor?.start(queue: networkQueue)
+    }
+    
+    private func handleNetworkPathUpdate(_ path: NWPath) {
+        let currentType = path.availableInterfaces.first?.type
+        
+        if let type = currentType, type != lastNetworkType {
+            Logger.log.i(message: "NetworkQualityMonitor:: Network path changed to \(type)")
+            lastNetworkType = type
+            
+            // Trigger ICE restart on network type change
+            if isMonitoring {
+                onNetworkImprovementDetected?()
+            }
+        }
+    }
+    
+    deinit {
+        networkPathMonitor?.cancel()
+    }
+}

--- a/TelnyxWebRTCDemo/Views/CallQualityMetricsView.swift
+++ b/TelnyxWebRTCDemo/Views/CallQualityMetricsView.swift
@@ -91,6 +91,18 @@ struct CallQualityMetricsView: View {
                 if let bytesSent = stats["bytesSent"] as? Int {
                     audioStatRow(title: "Bytes Sent:", value: "\(bytesSent)")
                 }
+                if let jitterBufferDelay = stats["jitterBufferDelay"] as? Double {
+                    audioStatRow(title: "Jitter Buffer Delay:", value: "\(String(format: "%.3f", jitterBufferDelay)) s")
+                }
+                if let jitterBufferEmittedCount = stats["jitterBufferEmittedCount"] as? Int {
+                    audioStatRow(title: "Jitter Buffer Emitted:", value: "\(jitterBufferEmittedCount)")
+                }
+                if let jitterBufferDelay = stats["jitterBufferDelay"] as? Double,
+                   let jitterBufferEmittedCount = stats["jitterBufferEmittedCount"] as? Int,
+                   jitterBufferEmittedCount > 0 {
+                    let avg = jitterBufferDelay / Double(jitterBufferEmittedCount)
+                    audioStatRow(title: "JB Avg Delay:", value: "\(String(format: "%.3f", avg)) s")
+                }
             }
         }
         .padding(.horizontal, 8)


### PR DESCRIPTION
<!-- Ticket details and link -->
[ENGDESK-44292 - Implement Audio Device Reset to Clear Jitter Buffers on Network Improvement](https://telnyx.atlassian.net/browse/ENGDESK-44292)
---
<!-- Describe your change here -->
This PR implements an audio device reset mechanism to clear WebRTC jitter buffers when network conditions improve, addressing the issue where RTT remains persistently high after network improvement when using `forceRelayCandidates=true`.

## :older_man: :baby: Behaviors
### Before changes
- When using TURN servers with `forceRelayCandidates=true` and simulating network degradation (e.g., "Very Bad Network" via Network Link Conditioner), RTT increases as expected
- However, when the network improves (e.g., switching back to "WiFi"), the RTT remains elevated and doesn't recover to normal levels
- WebRTC's jitter buffers maintain old network state data and don't clear automatically when network conditions improve
- Audio quality remains degraded even after network improvement due to persistent buffers

### After changes
- Network quality monitoring detects improvements in RTT, jitter, and packet loss
- Automatic audio device reset triggers when significant network improvement is detected
- Sequential 3-cycle audio device reset clears jitter buffers by deactivating/reactivating audio session
- RTT recovers to normal levels after network improvement
- Audio quality improves immediately when network conditions improve
- SDP optimization ensures 16kbps audio bitrate for better performance
