### PR TITLE
WEBRTC-2903: Preferred Codec on invite - iOS

### DIFF
--- a/TelnyxRTC/Telnyx/Models/TxCallOptions.swift
+++ b/TelnyxRTC/Telnyx/Models/TxCallOptions.swift
@@ -27,6 +27,33 @@ struct TxCallOptions {
     var useStereo: Bool = false
     var screenShare: Bool = false
     var userVariables: [String: Any]?
+    
+    /// Preferred audio codecs in order of preference
+    var preferredCodecs: [TxCodecCapability]?
+    
+    init(destinationNumber: String? = nil, 
+         remoteCallerName: String = "Outbound Call",
+         remoteCallerNumber: String? = nil,
+         clientState: String? = nil,
+         audio: Bool = true,
+         video: Bool = false,
+         attach: Bool = false,
+         useStereo: Bool = false,
+         screenShare: Bool = false,
+         userVariables: [String: Any]? = nil,
+         preferredCodecs: [TxCodecCapability]? = nil) {
+        self.destinationNumber = destinationNumber
+        self.remoteCallerName = remoteCallerName
+        self.remoteCallerNumber = remoteCallerNumber
+        self.clientState = clientState
+        self.audio = audio
+        self.video = video
+        self.attach = attach
+        self.useStereo = useStereo
+        self.screenShare = screenShare
+        self.userVariables = userVariables
+        self.preferredCodecs = preferredCodecs
+    }
 
     func encode() -> [String : Any] {
         var dictionary = [String: Any]()

--- a/TelnyxRTC/Telnyx/Models/TxCodecCapability.swift
+++ b/TelnyxRTC/Telnyx/Models/TxCodecCapability.swift
@@ -1,0 +1,59 @@
+//
+//  TxCodecCapability.swift
+//  TelnyxRTC
+//
+//  Created by AI SWE Agent on 08/10/2025.
+//  Copyright © 2025 Telnyx LLC. All rights reserved.
+//
+
+import Foundation
+import WebRTC
+
+/// Represents an audio codec capability that can be used for preferred codec selection
+/// This mirrors the RTCRtpCodecCapability structure from WebRTC
+public struct TxCodecCapability: Codable, Equatable {
+    /// The MIME type of the codec (e.g., "audio/opus", "audio/PCMA")
+    public let mimeType: String
+    
+    /// The clock rate of the codec in Hz
+    public let clockRate: Int
+    
+    /// The number of audio channels (typically 1 or 2)
+    public let channels: Int?
+    
+    /// The SDP format-specific parameters line
+    public let sdpFmtpLine: String?
+    
+    public init(mimeType: String, clockRate: Int, channels: Int? = nil, sdpFmtpLine: String? = nil) {
+        self.mimeType = mimeType
+        self.clockRate = clockRate
+        self.channels = channels
+        self.sdpFmtpLine = sdpFmtpLine
+    }
+    
+    /// Creates a TxCodecCapability from an RTCRtpCodecCapability
+    internal init(from rtcCodec: RTCRtpCodecCapability) {
+        self.mimeType = rtcCodec.mimeType
+        self.clockRate = Int(rtcCodec.clockRate)
+        self.channels = rtcCodec.numChannels > 0 ? Int(rtcCodec.numChannels) : nil
+        self.sdpFmtpLine = rtcCodec.parameters.isEmpty ? nil : rtcCodec.parameters.map { "\($0.key)=\($0.value)" }.joined(separator: ";")
+    }
+    
+    /// Converts this TxCodecCapability to a dictionary for JSON serialization
+    internal func toDictionary() -> [String: Any] {
+        var dict: [String: Any] = [
+            "mimeType": mimeType,
+            "clockRate": clockRate
+        ]
+        
+        if let channels = channels {
+            dict["channels"] = channels
+        }
+        
+        if let sdpFmtpLine = sdpFmtpLine {
+            dict["sdpFmtpLine"] = sdpFmtpLine
+        }
+        
+        return dict
+    }
+}

--- a/TelnyxRTC/Telnyx/Verto/InviteMessage.swift
+++ b/TelnyxRTC/Telnyx/Verto/InviteMessage.swift
@@ -36,6 +36,10 @@ class InviteMessage : Message {
         if let clientState = callOptions.clientState {
             dialogParams["clientState"] = clientState
         }
+        
+        if let preferredCodecs = callOptions.preferredCodecs, !preferredCodecs.isEmpty {
+            dialogParams["preferred_codecs"] = preferredCodecs.map { $0.toDictionary() }
+        }
 
         params["User-Agent"] = Message.USER_AGENT
 

--- a/TelnyxRTC/Telnyx/WebRTC/Call.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call.swift
@@ -462,13 +462,14 @@ public class Call {
         Creates an offer to start the calling process
      */
     private func invite(callerName: String, callerNumber: String, destinationNumber: String, clientState: String? = nil,
-                        customHeaders:[String:String] = [:],debug:Bool = false) {
+                        customHeaders:[String:String] = [:], preferredCodecs: [TxCodecCapability]? = nil, debug:Bool = false) {
         self.direction = .OUTBOUND
         self.inviteCustomHeaders = customHeaders
         self.callInfo?.callerName = callerName
         self.callInfo?.callerNumber = callerNumber
         self.callOptions = TxCallOptions(destinationNumber: destinationNumber,
-                                         clientState: clientState)
+                                         clientState: clientState,
+                                         preferredCodecs: preferredCodecs)
 
         self.enableQualityMetrics = debug
         // We need to:
@@ -586,12 +587,13 @@ extension Call {
                           destinationNumber: String,
                           clientState: String? = nil,
                           customHeaders:[String:String] = [:],
+                          preferredCodecs: [TxCodecCapability]? = nil,
                           debug: Bool = false) {
         if (destinationNumber.isEmpty) {
             Logger.log.e(message: "Call:: Please enter a destination number.")
             return
         }
-        invite(callerName: callerName, callerNumber: callerNumber, destinationNumber: destinationNumber, clientState: clientState, customHeaders: customHeaders,debug: debug)
+        invite(callerName: callerName, callerNumber: callerNumber, destinationNumber: destinationNumber, clientState: clientState, customHeaders: customHeaders, preferredCodecs: preferredCodecs, debug: debug)
     }
 
     /// Hangup or reject an incoming call.

--- a/TelnyxRTCTests/TxClientCodecTests.swift
+++ b/TelnyxRTCTests/TxClientCodecTests.swift
@@ -1,0 +1,93 @@
+//
+//  TxClientCodecTests.swift
+//  TelnyxRTCTests
+//
+//  Created by AI SWE Agent on 08/10/2025.
+//  Copyright © 2025 Telnyx LLC. All rights reserved.
+//
+
+import XCTest
+@testable import TelnyxRTC
+
+class TxClientCodecTests: XCTestCase {
+    
+    var txClient: TxClient!
+    
+    override func setUp() {
+        super.setUp()
+        // Initialize TxClient with test configuration
+        let txConfig = TxConfig(sipUser: "testuser", 
+                               sipPassword: "testpass", 
+                               sipCallerIDName: "Test User", 
+                               sipCallerIDNumber: "1234567890")
+        txClient = TxClient(txConfig: txConfig)
+    }
+    
+    override func tearDown() {
+        txClient = nil
+        super.tearDown()
+    }
+    
+    func testGetSupportedAudioCodecs() {
+        // Test that getSupportedAudioCodecs returns an array
+        let supportedCodecs = txClient.getSupportedAudioCodecs()
+        
+        // Should return an array (may be empty in test environment)
+        XCTAssertNotNil(supportedCodecs)
+        XCTAssertTrue(supportedCodecs is [TxCodecCapability])
+        
+        // If codecs are available, verify they have valid properties
+        for codec in supportedCodecs {
+            XCTAssertFalse(codec.mimeType.isEmpty, "Codec mimeType should not be empty")
+            XCTAssertGreaterThan(codec.clockRate, 0, "Codec clockRate should be greater than 0")
+        }
+    }
+    
+    func testNewCallWithPreferredCodecs() {
+        // Test that newCall method accepts preferred codecs parameter
+        let preferredCodecs = [
+            TxCodecCapability(mimeType: "audio/opus", clockRate: 48000, channels: 2),
+            TxCodecCapability(mimeType: "audio/PCMA", clockRate: 8000)
+        ]
+        
+        // This test verifies the method signature accepts the parameter
+        // In a real test environment, you would need to mock the socket connection
+        do {
+            let call = try txClient.newCall(
+                callerName: "Test Caller",
+                callerNumber: "1234567890",
+                destinationNumber: "0987654321",
+                callId: UUID(),
+                preferredCodecs: preferredCodecs
+            )
+            
+            // If we get here without throwing, the method signature is correct
+            XCTAssertNotNil(call)
+        } catch TxError.callFailed(let reason) {
+            // Expected to fail due to missing session/socket in test environment
+            XCTAssertEqual(reason, .sessionIdIsRequired)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+    
+    func testNewCallWithoutPreferredCodecs() {
+        // Test that newCall method works without preferred codecs (backward compatibility)
+        do {
+            let call = try txClient.newCall(
+                callerName: "Test Caller",
+                callerNumber: "1234567890",
+                destinationNumber: "0987654321",
+                callId: UUID()
+            )
+            
+            // If we get here without throwing, the method signature is correct
+            XCTAssertNotNil(call)
+        } catch TxError.callFailed(let reason) {
+            // Expected to fail due to missing session/socket in test environment
+            XCTAssertEqual(reason, .sessionIdIsRequired)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+}

--- a/TelnyxRTCTests/TxCodecCapabilityTests.swift
+++ b/TelnyxRTCTests/TxCodecCapabilityTests.swift
@@ -1,0 +1,117 @@
+//
+//  TxCodecCapabilityTests.swift
+//  TelnyxRTCTests
+//
+//  Created by AI SWE Agent on 08/10/2025.
+//  Copyright © 2025 Telnyx LLC. All rights reserved.
+//
+
+import XCTest
+@testable import TelnyxRTC
+
+class TxCodecCapabilityTests: XCTestCase {
+    
+    func testTxCodecCapabilityInitialization() {
+        // Test basic initialization
+        let codec = TxCodecCapability(
+            mimeType: "audio/opus",
+            clockRate: 48000,
+            channels: 2,
+            sdpFmtpLine: "minptime=10;useinbandfec=1"
+        )
+        
+        XCTAssertEqual(codec.mimeType, "audio/opus")
+        XCTAssertEqual(codec.clockRate, 48000)
+        XCTAssertEqual(codec.channels, 2)
+        XCTAssertEqual(codec.sdpFmtpLine, "minptime=10;useinbandfec=1")
+    }
+    
+    func testTxCodecCapabilityWithoutOptionalFields() {
+        // Test initialization without optional fields
+        let codec = TxCodecCapability(
+            mimeType: "audio/PCMA",
+            clockRate: 8000
+        )
+        
+        XCTAssertEqual(codec.mimeType, "audio/PCMA")
+        XCTAssertEqual(codec.clockRate, 8000)
+        XCTAssertNil(codec.channels)
+        XCTAssertNil(codec.sdpFmtpLine)
+    }
+    
+    func testTxCodecCapabilityToDictionary() {
+        // Test conversion to dictionary
+        let codec = TxCodecCapability(
+            mimeType: "audio/opus",
+            clockRate: 48000,
+            channels: 2,
+            sdpFmtpLine: "minptime=10;useinbandfec=1"
+        )
+        
+        let dictionary = codec.toDictionary()
+        
+        XCTAssertEqual(dictionary["mimeType"] as? String, "audio/opus")
+        XCTAssertEqual(dictionary["clockRate"] as? Int, 48000)
+        XCTAssertEqual(dictionary["channels"] as? Int, 2)
+        XCTAssertEqual(dictionary["sdpFmtpLine"] as? String, "minptime=10;useinbandfec=1")
+    }
+    
+    func testTxCodecCapabilityToDictionaryWithoutOptionalFields() {
+        // Test conversion to dictionary without optional fields
+        let codec = TxCodecCapability(
+            mimeType: "audio/PCMA",
+            clockRate: 8000
+        )
+        
+        let dictionary = codec.toDictionary()
+        
+        XCTAssertEqual(dictionary["mimeType"] as? String, "audio/PCMA")
+        XCTAssertEqual(dictionary["clockRate"] as? Int, 8000)
+        XCTAssertNil(dictionary["channels"])
+        XCTAssertNil(dictionary["sdpFmtpLine"])
+    }
+    
+    func testTxCodecCapabilityEquality() {
+        // Test equality
+        let codec1 = TxCodecCapability(
+            mimeType: "audio/opus",
+            clockRate: 48000,
+            channels: 2,
+            sdpFmtpLine: "minptime=10;useinbandfec=1"
+        )
+        
+        let codec2 = TxCodecCapability(
+            mimeType: "audio/opus",
+            clockRate: 48000,
+            channels: 2,
+            sdpFmtpLine: "minptime=10;useinbandfec=1"
+        )
+        
+        let codec3 = TxCodecCapability(
+            mimeType: "audio/PCMA",
+            clockRate: 8000
+        )
+        
+        XCTAssertEqual(codec1, codec2)
+        XCTAssertNotEqual(codec1, codec3)
+    }
+    
+    func testTxCodecCapabilityCodable() {
+        // Test Codable conformance
+        let codec = TxCodecCapability(
+            mimeType: "audio/opus",
+            clockRate: 48000,
+            channels: 2,
+            sdpFmtpLine: "minptime=10;useinbandfec=1"
+        )
+        
+        do {
+            let data = try JSONEncoder().encode(codec)
+            let decodedCodec = try JSONDecoder().decode(TxCodecCapability.self, from: data)
+            
+            XCTAssertEqual(codec, decodedCodec)
+        } catch {
+            XCTFail("Failed to encode/decode TxCodecCapability: \(error)")
+        }
+    }
+}

--- a/TelnyxWebRTCDemo/ViewControllers/HomeViewController+VoIPExtension.swift
+++ b/TelnyxWebRTCDemo/ViewControllers/HomeViewController+VoIPExtension.swift
@@ -254,10 +254,23 @@ extension HomeViewController : VoIPDelegate {
             
             let destinationNumber = self.callViewModel.sipAddress
             
+            // Example: Get supported codecs and set preferred codecs
+            // Uncomment the following lines to use preferred codec functionality:
+            /*
+            let supportedCodecs = telnyxClient?.getSupportedAudioCodecs() ?? []
+            print("Supported audio codecs: \(supportedCodecs)")
+            
+            // Example: Prefer Opus codec if available
+            let preferredCodecs = supportedCodecs.filter { $0.mimeType.lowercased().contains("opus") }
+            */
+            
             let call = try telnyxClient?.newCall(callerName: sipCred.callerName ?? "",
                                                  callerNumber: sipCred.callerNumber ?? "",
                                                  destinationNumber: destinationNumber,
-                                                 callId: callUUID,customHeaders: headers,debug: true)
+                                                 callId: callUUID,
+                                                 customHeaders: headers,
+                                                 // preferredCodecs: preferredCodecs, // Uncomment to use preferred codecs
+                                                 debug: true)
             
             
             CallHistoryManager.shared.handleStartCallAction(


### PR DESCRIPTION
## Summary

This PR implements preferred codec functionality for the iOS WebRTC SDK, allowing developers to specify codec preferences when making calls.

## Jira Ticket
[WEBRTC-2903](https://telnyx.atlassian.net/browse/WEBRTC-2903)

## Changes Made

### Core Implementation
- **TxCodecCapability**: New model representing audio codec capabilities (mirrors RTCRtpCodecCapability)
- **getSupportedAudioCodecs()**: New method in TxClient to retrieve available audio codecs
- **newCall() method**: Updated to accept optional  parameter
- **InviteMessage**: Updated to include  in dialog parameters

### Testing
- **TxCodecCapabilityTests**: Comprehensive unit tests for the codec model
- **TxClientCodecTests**: Tests for the new client methods and functionality
- **Demo App**: Updated with usage examples (commented out for reference)

### API Changes
The newCall method signature has been updated to include an optional preferredCodecs parameter:

```swift
public func newCall(callerName: String,
                    callerNumber: String,
                    destinationNumber: String,
                    callId: UUID,
                    clientState: String? = nil,
                    customHeaders:[String:String] = [:],
                    preferredCodecs: [TxCodecCapability]? = nil,
                    debug:Bool = false) throws -> Call
```

### Usage Example
```swift
// Get supported codecs
let supportedCodecs = telnyxClient.getSupportedAudioCodecs()

// Filter for preferred codecs (e.g., Opus)
let preferredCodecs = supportedCodecs.filter { $0.mimeType.lowercased().contains("opus") }

// Make a call with preferred codecs
let call = try telnyxClient.newCall(
    callerName: "John Doe",
    callerNumber: "1234567890",
    destinationNumber: "0987654321",
    callId: UUID(),
    preferredCodecs: preferredCodecs
)
```

## Backward Compatibility
✅ All existing code continues to work without changes - the preferredCodecs parameter is optional.

## Implementation Details
- Follows the same pattern as the JavaScript SDK implementation
- Uses RTCPeerConnectionFactory to get actual codec capabilities from WebRTC
- Serializes preferred codecs to JSON format for transmission in invite messages
- Maintains type safety with Swift's strong typing system

## Testing
- Unit tests cover all new functionality
- Tests verify codec model serialization/deserialization
- Tests ensure backward compatibility
- Demo app includes usage examples

Ready for review! 🚀