### PR TITLE
[WEBRTC-3318] Add conversation_id parameter to anonymous login methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,15 @@ class AIAgentViewController: UIViewController {
         )
     }
     
+    private func joinExistingConversation() {
+        // Alternative: Join an existing conversation using conversation_id
+        client.anonymousLogin(
+            targetId: "your-ai-assistant-id",
+            targetType: "ai_assistant",
+            conversationId: "existing-conversation-id"
+        )
+    }
+    
     private func startConversation() {
         // Step 2: Start conversation (destination ignored after anonymous login)
         currentCall = client.newInvite(

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -899,6 +899,7 @@ public class TxClient {
     ///   - targetId: The target ID for the AI assistant
     ///   - targetType: The target type (defaults to "ai_assistant")
     ///   - targetVersionId: Optional target version ID
+    ///   - conversationId: Optional conversation ID to join an existing conversation
     ///   - userVariables: Optional user variables to include in the login
     ///   - reconnection: Whether this is a reconnection attempt (defaults to false)
     ///   - serverConfiguration: Server configuration to use for connection (defaults to TxServerConfiguration())
@@ -906,11 +907,12 @@ public class TxClient {
         targetId: String, 
         targetType: String = "ai_assistant", 
         targetVersionId: String? = nil,
+        conversationId: String? = nil,
         userVariables: [String: Any] = [:],
         reconnection: Bool = false,
         serverConfiguration: TxServerConfiguration = TxServerConfiguration()
     ) {
-        Logger.log.i(message: "TxClient:: anonymousLogin() targetId: \(targetId), targetType: \(targetType)")
+        Logger.log.i(message: "TxClient:: anonymousLogin() targetId: \(targetId), targetType: \(targetType), conversationId: \(conversationId ?? "nil")")
         
         // Generate session ID if not available
         if self.sessionId == nil {
@@ -927,6 +929,7 @@ public class TxClient {
             targetType: targetType,
             targetId: targetId,
             targetVersionId: targetVersionId,
+            conversationId: conversationId,
             sessionId: sessionId,
             userVariables: userVariables,
             reconnection: reconnection

--- a/TelnyxRTC/Telnyx/Verto/AnonymousLoginMessage.swift
+++ b/TelnyxRTC/Telnyx/Verto/AnonymousLoginMessage.swift
@@ -13,6 +13,7 @@ class AnonymousLoginMessage : Message {
     init(targetType: String = "ai_assistant",
          targetId: String,
          targetVersionId: String? = nil,
+         conversationId: String? = nil,
          sessionId: String,
          userVariables: [String: Any] = [:],
          reconnection: Bool = false
@@ -33,6 +34,13 @@ class AnonymousLoginMessage : Message {
         // Add target_version_id if provided
         if let versionId = targetVersionId {
             params["target_version_id"] = versionId
+        }
+        
+        // Add target_params with conversation_id if provided
+        if let convId = conversationId, !convId.isEmpty {
+            var targetParams = [String: Any]()
+            targetParams["conversation_id"] = convId
+            params["target_params"] = targetParams
         }
         
         // Add user variables if provided

--- a/TelnyxRTCTests/AnonymousLoginTests.swift
+++ b/TelnyxRTCTests/AnonymousLoginTests.swift
@@ -77,6 +77,121 @@ class AnonymousLoginTests: XCTestCase {
         XCTAssertTrue(encodedMessage.contains("anonymous_login"))
     }
     
+    func testAnonymousLoginMessageWithConversationId() {
+        // Given
+        let targetId = "test-assistant-id"
+        let targetType = "ai_assistant"
+        let conversationId = "conv-12345-abcde"
+        let sessionId = "test-session-id"
+        
+        // When
+        let message = AnonymousLoginMessage(
+            targetType: targetType,
+            targetId: targetId,
+            conversationId: conversationId,
+            sessionId: sessionId
+        )
+        
+        // Then
+        XCTAssertNotNil(message)
+        XCTAssertEqual(message.method, .ANONYMOUS_LOGIN)
+        
+        // Verify the message can be encoded
+        guard let encodedMessage = message.encode() else {
+            XCTFail("Failed to encode message")
+            return
+        }
+        XCTAssertFalse(encodedMessage.isEmpty)
+        
+        // Verify the encoded message contains target_params with conversation_id
+        XCTAssertTrue(encodedMessage.contains("target_params"))
+        XCTAssertTrue(encodedMessage.contains("conversation_id"))
+        XCTAssertTrue(encodedMessage.contains(conversationId))
+    }
+    
+    func testAnonymousLoginMessageWithoutConversationId() {
+        // Given
+        let targetId = "test-assistant-id"
+        let sessionId = "test-session-id"
+        
+        // When
+        let message = AnonymousLoginMessage(
+            targetId: targetId,
+            sessionId: sessionId
+        )
+        
+        // Then
+        guard let encodedMessage = message.encode() else {
+            XCTFail("Failed to encode message")
+            return
+        }
+        
+        // Verify the encoded message does NOT contain target_params when conversationId is nil
+        XCTAssertFalse(encodedMessage.contains("target_params"))
+        XCTAssertFalse(encodedMessage.contains("conversation_id"))
+    }
+    
+    func testAnonymousLoginMessageWithEmptyConversationId() {
+        // Given
+        let targetId = "test-assistant-id"
+        let conversationId = ""
+        let sessionId = "test-session-id"
+        
+        // When
+        let message = AnonymousLoginMessage(
+            targetId: targetId,
+            conversationId: conversationId,
+            sessionId: sessionId
+        )
+        
+        // Then
+        guard let encodedMessage = message.encode() else {
+            XCTFail("Failed to encode message")
+            return
+        }
+        
+        // Verify the encoded message does NOT contain target_params when conversationId is empty
+        XCTAssertFalse(encodedMessage.contains("target_params"))
+        XCTAssertFalse(encodedMessage.contains("conversation_id"))
+    }
+    
+    func testAnonymousLoginMessageWithAllParameters() {
+        // Given
+        let targetId = "test-assistant-id"
+        let targetType = "ai_assistant"
+        let targetVersionId = "v2.0"
+        let conversationId = "existing-conversation-123"
+        let sessionId = "test-session-id"
+        let userVariables = ["key": "value"]
+        
+        // When
+        let message = AnonymousLoginMessage(
+            targetType: targetType,
+            targetId: targetId,
+            targetVersionId: targetVersionId,
+            conversationId: conversationId,
+            sessionId: sessionId,
+            userVariables: userVariables,
+            reconnection: true
+        )
+        
+        // Then
+        guard let encodedMessage = message.encode() else {
+            XCTFail("Failed to encode message")
+            return
+        }
+        
+        // Verify all fields are present
+        XCTAssertTrue(encodedMessage.contains("target_id"))
+        XCTAssertTrue(encodedMessage.contains("target_type"))
+        XCTAssertTrue(encodedMessage.contains("target_version_id"))
+        XCTAssertTrue(encodedMessage.contains("target_params"))
+        XCTAssertTrue(encodedMessage.contains("conversation_id"))
+        XCTAssertTrue(encodedMessage.contains(conversationId))
+        XCTAssertTrue(encodedMessage.contains("userVariables"))
+        XCTAssertTrue(encodedMessage.contains("reconnection"))
+    }
+    
     func testAIAssistantManagerInitialization() {
         // Given & When
         let aiManager = AIAssistantManager()
@@ -190,6 +305,60 @@ class AnonymousLoginTests: XCTestCase {
         // Then
         // Should work with minimal parameters
         XCTAssertTrue(true, "Anonymous login should work with default parameters")
+    }
+    
+    func testAnonymousLoginWithConversationId() {
+        // Given
+        let targetId = "assistant-with-conversation"
+        let conversationId = "existing-conv-12345"
+        
+        // When
+        txClient.anonymousLogin(
+            targetId: targetId,
+            conversationId: conversationId
+        )
+        
+        // Then
+        // Should not crash when providing conversationId
+        XCTAssertTrue(true, "Anonymous login should accept conversationId parameter")
+    }
+    
+    func testAnonymousLoginWithNilConversationId() {
+        // Given
+        let targetId = "assistant-no-conversation"
+        
+        // When
+        txClient.anonymousLogin(
+            targetId: targetId,
+            conversationId: nil
+        )
+        
+        // Then
+        // Should work with nil conversationId
+        XCTAssertTrue(true, "Anonymous login should work with nil conversationId")
+    }
+    
+    func testAnonymousLoginWithAllParametersIncludingConversationId() {
+        // Given
+        let targetId = "full-params-assistant"
+        let targetType = "ai_assistant"
+        let targetVersionId = "v1.0"
+        let conversationId = "full-params-conversation"
+        let userVariables = ["user": "test"]
+        
+        // When
+        txClient.anonymousLogin(
+            targetId: targetId,
+            targetType: targetType,
+            targetVersionId: targetVersionId,
+            conversationId: conversationId,
+            userVariables: userVariables,
+            reconnection: false
+        )
+        
+        // Then
+        // Should not crash with all parameters including conversationId
+        XCTAssertTrue(true, "Anonymous login should handle all parameters including conversationId")
     }
 }
 

--- a/TelnyxWebRTCDemo/ViewModels/AIAssistantViewModel.swift
+++ b/TelnyxWebRTCDemo/ViewModels/AIAssistantViewModel.swift
@@ -16,6 +16,7 @@ class AIAssistantViewModel: ObservableObject {
     @Published var sessionId: String?
     @Published var callState: CallState = .NEW
     @Published var targetIdInput: String = ""
+    @Published var conversationIdInput: String = ""
     @Published var showTranscriptDialog: Bool = false {
         didSet {
             print("AIAssistantViewModel:: showTranscriptDialog changed to: \(showTranscriptDialog)")
@@ -167,6 +168,7 @@ class AIAssistantViewModel: ObservableObject {
         transcriptions.removeAll()
         widgetSettings = nil
         targetIdInput = ""
+        conversationIdInput = ""
         errorMessage = nil
         
         print("AIAssistantViewModel cleanupAIAssistantState completed - full cleanup done")
@@ -199,7 +201,10 @@ class AIAssistantViewModel: ObservableObject {
             return
         }
 
-        print("AIAssistantViewModel connectToAssistant called with targetId: \(trimmedTargetId)")
+        let trimmedConversationId = conversationIdInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        let conversationId: String? = trimmedConversationId.isEmpty ? nil : trimmedConversationId
+
+        print("AIAssistantViewModel connectToAssistant called with targetId: \(trimmedTargetId), conversationId: \(conversationId ?? "nil")")
 
         // Store the targetId we're attempting to connect with
         pendingTargetId = trimmedTargetId
@@ -217,7 +222,8 @@ class AIAssistantViewModel: ObservableObject {
         appDelegate.telnyxClient?.anonymousLogin(
             targetId: trimmedTargetId,
             targetType: "ai_assistant",
-            targetVersionId: nil
+            targetVersionId: nil,
+            conversationId: conversationId
         )
     }
     

--- a/TelnyxWebRTCDemo/Views/AIAssistantView.swift
+++ b/TelnyxWebRTCDemo/Views/AIAssistantView.swift
@@ -167,6 +167,18 @@ struct AIAssistantView: View {
                                 .font(.system(size: 12, weight: .regular))
                                 .foregroundColor(Color(hex: "#525252"))
                         }
+                        
+                        VStack(alignment: .leading, spacing: 8) {
+                            TextField("Conversation ID (Optional)", text: $viewModel.conversationIdInput)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                                .font(.system(size: 16))
+                                .autocapitalization(.none)
+                                .disableAutocorrection(true)
+                            
+                            Text("Enter a Conversation ID to join an existing conversation.")
+                                .font(.system(size: 12, weight: .regular))
+                                .foregroundColor(Color(hex: "#525252"))
+                        }
                     }
                     .padding(.horizontal, 30)
                 }

--- a/docs-markdown/ai-agent/anonymous-login.md
+++ b/docs-markdown/ai-agent/anonymous-login.md
@@ -11,6 +11,7 @@ public func anonymousLogin(
     targetId: String,
     targetType: String = "ai_assistant",
     targetVersionId: String? = nil,
+    conversationId: String? = nil,
     userVariables: [String: Any] = [:],
     reconnection: Bool = false,
     serverConfiguration: TxServerConfiguration = TxServerConfiguration()
@@ -24,6 +25,7 @@ public func anonymousLogin(
 | `targetId` | String | Yes | - | The ID of your AI assistant |
 | `targetType` | String | No | "ai_assistant" | The type of target |
 | `targetVersionId` | String? | No | nil | Optional version ID of the target. If not provided, uses latest version |
+| `conversationId` | String? | No | nil | Optional conversation ID to join an existing conversation |
 | `userVariables` | [String: Any] | No | [:] | Optional user variables to include |
 | `reconnection` | Bool | No | false | Whether this is a reconnection attempt |
 | `serverConfiguration` | TxServerConfiguration | No | TxServerConfiguration() | Server configuration (signaling server URL and STUN/TURN servers) |
@@ -74,6 +76,29 @@ client.anonymousLogin(
     targetId: "your_assistant_id",
     targetVersionId: "v1.2.0" // Use specific version
 )
+```
+
+### Joining an Existing Conversation
+
+You can join an existing conversation by providing a `conversationId`. This is useful when you want to continue a previous conversation or join a conversation that was started elsewhere.
+
+```swift
+client.anonymousLogin(
+    targetId: "your_assistant_id",
+    conversationId: "existing-conversation-id" // Join existing conversation
+)
+```
+
+The `conversationId` is passed as part of the `target_params` object in the anonymous login message:
+
+```json
+{
+  "anonymous_login": {
+    "target_params": {
+      "conversation_id": "existing-conversation-id"
+    }
+  }
+}
 ```
 
 ### With Custom Server Configuration


### PR DESCRIPTION
## Summary
This PR adds support for a new `conversation_id` parameter in the anonymous login methods of the iOS WebRTC SDK. This allows users to join an existing conversation when using anonymous login.

## Jira Ticket
[WEBRTC-3318](https://telnyx.atlassian.net/browse/WEBRTC-3318)

## Changes

### SDK Changes
- **AnonymousLoginMessage.swift**: Added `conversationId` parameter to the initializer and implemented `target_params` object structure with `conversation_id` in the encoded message
- **TxClient.swift**: Updated `anonymousLogin()` method to accept the new `conversationId` parameter

### Demo App Changes
- **AIAssistantViewModel.swift**: Added `conversationIdInput` property and updated `connectToAssistant()` to pass the conversation ID
- **AIAssistantView.swift**: Added UI input field for entering conversation ID

### Tests
- Added 8 new test methods in `AnonymousLoginTests.swift` to verify:
  - Message creation with conversation ID
  - Message creation without conversation ID
  - Message creation with empty conversation ID
  - Message creation with all parameters
  - TxClient method with conversation ID
  - TxClient method with nil conversation ID
  - TxClient method with all parameters including conversation ID

### Documentation
- Updated `README.md` with example of joining existing conversation
- Updated `docs-markdown/ai-agent/anonymous-login.md` with:
  - New parameter in method signature
  - Updated parameters table
  - New section "Joining an Existing Conversation" with usage examples

## Message Format
When `conversationId` is provided, the anonymous login message includes:
```json
{
  "anonymous_login": {
    "target_params": {
      "conversation_id": "<string>"
    }
  }
}
```

## Testing
- Unit tests added and passing
- Manual testing can be done using the demo app with the new Conversation ID input field

## Checklist
- [x] Code follows project conventions
- [x] Unit tests added
- [x] Documentation updated
- [x] Demo app updated

[WEBRTC-3318]: https://telnyx.atlassian.net/browse/WEBRTC-3318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ