### PR TITLE
Skip ping reply on unauthenticated push socket

### DIFF
--- a/TelnyxRTC.xcodeproj/project.pbxproj
+++ b/TelnyxRTC.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		9905E4772EA81D41000AC89D /* CandidateMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9905E4762EA81D41000AC89D /* CandidateMessage.swift */; };
 		9905E4792EA81D50000AC89D /* EndOfCandidatesMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9905E4782EA81D50000AC89D /* EndOfCandidatesMessage.swift */; };
 		9906F63B2E391F5C00A02FE7 /* TxClientReconnectTimeoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9906F63A2E391F5C00A02FE7 /* TxClientReconnectTimeoutTests.swift */; };
+		AA0002012F0F0A0100000001 /* TxClientSocketErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0002002F0F0A0100000001 /* TxClientSocketErrorTests.swift */; };
 		9906F8C52E3C159900A02FE7 /* RingingAckMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9906F8C42E3C159900A02FE7 /* RingingAckMessage.swift */; };
 		9906F8C72E3C15CA00A02FE7 /* AIAssistantManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9906F8C62E3C15CA00A02FE7 /* AIAssistantManager.swift */; };
 		9906F8C92E3CEA4600A02FE7 /* AIAssistantView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9906F8C82E3CEA4600A02FE7 /* AIAssistantView.swift */; };
@@ -264,6 +265,7 @@
 		9905E4762EA81D41000AC89D /* CandidateMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CandidateMessage.swift; sourceTree = "<group>"; };
 		9905E4782EA81D50000AC89D /* EndOfCandidatesMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfCandidatesMessage.swift; sourceTree = "<group>"; };
 		9906F63A2E391F5C00A02FE7 /* TxClientReconnectTimeoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxClientReconnectTimeoutTests.swift; sourceTree = "<group>"; };
+		AA0002002F0F0A0100000001 /* TxClientSocketErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TxClientSocketErrorTests.swift; sourceTree = "<group>"; };
 		9906F8C42E3C159900A02FE7 /* RingingAckMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RingingAckMessage.swift; sourceTree = "<group>"; };
 		9906F8C62E3C15CA00A02FE7 /* AIAssistantManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIAssistantManager.swift; sourceTree = "<group>"; };
 		9906F8C82E3CEA4600A02FE7 /* AIAssistantView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIAssistantView.swift; sourceTree = "<group>"; };
@@ -719,6 +721,7 @@
 				99D717752D6E229000471D44 /* TelnyxRTCLoggerTests.swift */,
 				B3912263260F6A050051E076 /* TelnyxRTCMulticallTests.swift */,
 				9906F63A2E391F5C00A02FE7 /* TxClientReconnectTimeoutTests.swift */,
+				AA0002002F0F0A0100000001 /* TxClientSocketErrorTests.swift */,
 				B39122112604FBC00051E076 /* TestConstants.swift */,
 				B368BED525EDDBC90032AE52 /* Info.plist */,
 			);
@@ -1247,6 +1250,7 @@
 				B39121ED2602F22F0051E076 /* SocketTests.swift in Sources */,
 				B39122122604FBC00051E076 /* TestConstants.swift in Sources */,
 				9906F63B2E391F5C00A02FE7 /* TxClientReconnectTimeoutTests.swift in Sources */,
+					AA0002012F0F0A0100000001 /* TxClientSocketErrorTests.swift in Sources */,
 				B368BED425EDDBC90032AE52 /* TelnyxRTCTests.swift in Sources */,
 				B366D3FB26150D1100156FE1 /* StringExtension.swift in Sources */,
 				B391220C2604D9C50051E076 /* PeerConnectionTests.swift in Sources */,

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -1700,35 +1700,13 @@ extension TxClient : SocketDelegate {
         self.socket = nil
         self.sessionId = nil
         self.sessionId = UUID().uuidString.lowercased()
-
-        // If we were in a push flow with an unauthenticated socket,
-        // reset push state so future connect() calls are not hijacked
-        // by the stale isCallFromPush flag.
-        if isCallFromPush {
-            Logger.log.i(message: "TxClient:: Socket disconnected during push flow - resetting push state")
-            resetPushVariables()
-        }
-
         self.delegate?.onSocketDisconnected()
     }
 
     func onSocketError(error: Error) {
         Logger.log.i(message: "TxClient:: SocketDelegate onSocketError()")
-        Logger.log.e(message: "TxClient:: Socket Error: \(error.localizedDescription)")
-
-        // Clean up the socket to prevent stale references (matching onSocketDisconnected behavior)
-        self.socket = nil
-        self.sessionId = UUID().uuidString.lowercased()
-
-        // If we were in a push flow with an unauthenticated socket,
-        // reset push state so future connect() calls are not hijacked
-        // by the stale isCallFromPush flag.
-        if isCallFromPush {
-            Logger.log.i(message: "TxClient:: Socket error during push flow - resetting push state")
-            resetPushVariables()
-        }
-
         self.delegate?.onSocketDisconnected()
+        Logger.log.e(message:"TxClient:: Socket Error" +  error.localizedDescription)
     }
 
     /**
@@ -1772,18 +1750,6 @@ extension TxClient : SocketDelegate {
             // Use the existing ServerErrorReason.signalingServerError approach
             let err = TxError.serverError(reason: .signalingServerError(message: message, code: code))
             self.delegate?.onClientError(error: err)
-
-            // If we are in a push flow on an unauthenticated socket (not yet registered),
-            // a server error (e.g. 401 from pong) means this session is unrecoverable.
-            // Clean up push state so future connect() calls work correctly.
-            if isCallFromPush && gatewayState == .NOREG {
-                Logger.log.i(message: "TxClient:: Server error on unauthenticated push socket - resetting push state and disconnecting")
-                resetPushVariables()
-                self.socket?.disconnect(reconnect: false)
-                self.socket = nil
-                self.sessionId = UUID().uuidString.lowercased()
-                self.delegate?.onSocketDisconnected()
-            }
         }
 
         //Check if we are getting the new sessionId in response to the "login" message.
@@ -1972,7 +1938,16 @@ extension TxClient : SocketDelegate {
                  break;
                 //Mark: to send meassage to pong
             case .PING:
-                self.socket?.sendMessage(message: message)
+                // Only reply to ping if we are authenticated (registered).
+                // During push flow the socket is unauthenticated until the user
+                // answers and performLogin completes. Sending pong on an
+                // unauthenticated socket triggers a 401 error from the server
+                // which corrupts SDK state and prevents future calls.
+                if self.gatewayState == .REGED {
+                    self.socket?.sendMessage(message: message)
+                } else {
+                    Logger.log.i(message: "TxClient:: Ignoring PING - not yet authenticated (gateway: \(self.gatewayState))")
+                }
                 break;
                 default:
                     Logger.log.i(message: "TxClient:: SocketDelegate Default method")

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -1700,6 +1700,15 @@ extension TxClient : SocketDelegate {
         self.socket = nil
         self.sessionId = nil
         self.sessionId = UUID().uuidString.lowercased()
+
+        // If we were in a push flow with an unauthenticated socket,
+        // reset push state so future connect() calls are not hijacked
+        // by the stale isCallFromPush flag.
+        if isCallFromPush {
+            Logger.log.i(message: "TxClient:: Socket disconnected during push flow - resetting push state")
+            resetPushVariables()
+        }
+
         self.delegate?.onSocketDisconnected()
     }
 
@@ -1759,10 +1768,22 @@ extension TxClient : SocketDelegate {
             let message: String = error["message"] as? String ?? "Unknown"
             let codeInt: Int = error["code"] as? Int ?? 0
             let code: String = String(codeInt)
-            
+
             // Use the existing ServerErrorReason.signalingServerError approach
             let err = TxError.serverError(reason: .signalingServerError(message: message, code: code))
             self.delegate?.onClientError(error: err)
+
+            // If we are in a push flow on an unauthenticated socket (not yet registered),
+            // a server error (e.g. 401 from pong) means this session is unrecoverable.
+            // Clean up push state so future connect() calls work correctly.
+            if isCallFromPush && gatewayState == .NOREG {
+                Logger.log.i(message: "TxClient:: Server error on unauthenticated push socket - resetting push state and disconnecting")
+                resetPushVariables()
+                self.socket?.disconnect(reconnect: false)
+                self.socket = nil
+                self.sessionId = UUID().uuidString.lowercased()
+                self.delegate?.onSocketDisconnected()
+            }
         }
 
         //Check if we are getting the new sessionId in response to the "login" message.

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -1705,8 +1705,21 @@ extension TxClient : SocketDelegate {
 
     func onSocketError(error: Error) {
         Logger.log.i(message: "TxClient:: SocketDelegate onSocketError()")
+        Logger.log.e(message: "TxClient:: Socket Error: \(error.localizedDescription)")
+
+        // Clean up the socket to prevent stale references (matching onSocketDisconnected behavior)
+        self.socket = nil
+        self.sessionId = UUID().uuidString.lowercased()
+
+        // If we were in a push flow with an unauthenticated socket,
+        // reset push state so future connect() calls are not hijacked
+        // by the stale isCallFromPush flag.
+        if isCallFromPush {
+            Logger.log.i(message: "TxClient:: Socket error during push flow - resetting push state")
+            resetPushVariables()
+        }
+
         self.delegate?.onSocketDisconnected()
-        Logger.log.e(message:"TxClient:: Socket Error" +  error.localizedDescription)
     }
 
     /**

--- a/TelnyxRTCTests/TxClientSocketErrorTests.swift
+++ b/TelnyxRTCTests/TxClientSocketErrorTests.swift
@@ -75,7 +75,7 @@ class TxClientPingAuthTests: XCTestCase {
 
 // MARK: - Test Helpers
 
-private class PingTestDelegate: TxClientDelegate {
+class PingTestDelegate: TxClientDelegate {
     var onClientErrorCalled = false
 
     func onSocketConnected() {}

--- a/TelnyxRTCTests/TxClientSocketErrorTests.swift
+++ b/TelnyxRTCTests/TxClientSocketErrorTests.swift
@@ -8,18 +8,18 @@
 import XCTest
 @testable import TelnyxRTC
 
-/// Tests for TxClient socket error handling, specifically verifying that
-/// a 401 error on the unauthenticated push notification websocket properly
-/// cleans up state so future connections are not corrupted.
-class TxClientSocketErrorTests: XCTestCase {
+/// Tests verifying that the SDK does not reply to server pings on an
+/// unauthenticated socket. Sending pong before login triggers a 401
+/// error from the server which corrupts SDK state.
+class TxClientPingAuthTests: XCTestCase {
 
     var txClient: TxClient!
-    var mockDelegate: SocketErrorTestDelegate!
+    var mockDelegate: PingTestDelegate!
 
     override func setUp() {
         super.setUp()
         txClient = TxClient()
-        mockDelegate = SocketErrorTestDelegate()
+        mockDelegate = PingTestDelegate()
         txClient.delegate = mockDelegate
     }
 
@@ -30,33 +30,24 @@ class TxClientSocketErrorTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - Basic socket error cleanup
+    /// When the gateway is not registered (unauthenticated socket),
+    /// receiving a PING message should NOT send a pong reply.
+    /// This prevents the 401 error that corrupts SDK state during push flow.
+    func testPingIgnoredWhenNotAuthenticated() {
+        // Gateway state defaults to NOREG (not registered / unauthenticated).
+        // Simulate receiving a telnyx_rtc.ping message.
+        let pingMessage = "{\"jsonrpc\":\"2.0\",\"method\":\"telnyx_rtc.ping\",\"params\":{}}"
+        txClient.onMessageReceived(message: pingMessage)
 
-    /// Verify that onSocketError notifies the delegate
-    func testSocketErrorNotifiesDelegate() {
-        let expectation = XCTestExpectation(description: "Delegate should receive onSocketDisconnected")
-        mockDelegate.onSocketDisconnectedExpectation = expectation
-
-        txClient.onSocketError(error: TestSocketError(reason: "401 Unauthorized"))
-
-        wait(for: [expectation], timeout: 1.0)
-        XCTAssertTrue(mockDelegate.onSocketDisconnectedCalled)
+        // The client should NOT have crashed or entered a bad state.
+        // Since we can't directly observe whether a message was sent on the socket
+        // (socket is nil in test), we verify the client remains functional.
+        XCTAssertFalse(txClient.isConnected())
     }
 
-    /// Verify that after a socket error, isConnected() returns false
-    func testSocketErrorCleansUpConnection() {
-        txClient.onSocketError(error: TestSocketError(reason: "401 Unauthorized"))
-
-        XCTAssertFalse(txClient.isConnected(), "Client should not be connected after socket error")
-    }
-
-    // MARK: - Push flow socket error cleanup
-
-    /// Verify that a socket error during push flow resets push state
-    /// so that a subsequent connect() goes through the normal login flow
-    /// rather than being hijacked by the stale isCallFromPush flag.
-    func testSocketErrorDuringPushFlowResetsState() throws {
-        // Set up push flow state via processVoIPNotification
+    /// After push flow setup, the gateway is still NOREG (login hasn't happened).
+    /// PING messages should be ignored until the user answers and login completes.
+    func testPingIgnoredDuringPushFlowBeforeAuth() throws {
         let txConfig = TxConfig(sipUser: "test_user", password: "test_password")
         let serverConfig = TxServerConfiguration()
         let pushMetaData: [String: Any] = [
@@ -70,100 +61,35 @@ class TxClientSocketErrorTests: XCTestCase {
             pushMetaData: pushMetaData
         )
 
-        // Now simulate the 401 error on the unauthenticated websocket
-        txClient.onSocketError(error: TestSocketError(reason: "401 Unauthorized"))
+        // At this point: socket is connected but unauthenticated (NOREG).
+        // A ping arrives — SDK should NOT reply.
+        let pingMessage = "{\"jsonrpc\":\"2.0\",\"method\":\"telnyx_rtc.ping\",\"params\":{}}"
+        txClient.onMessageReceived(message: pingMessage)
 
-        // After the error, the client should be in a clean state:
-        // - Not connected
-        XCTAssertFalse(txClient.isConnected(), "Client should not be connected after push socket error")
-
-        // - Delegate should have been notified
-        XCTAssertTrue(mockDelegate.onSocketDisconnectedCalled)
-    }
-
-    /// Verify that after a push flow socket error, a new processVoIPNotification
-    /// can be processed successfully (state is not corrupted)
-    func testNewPushAfterSocketError() throws {
-        // First push flow
-        let txConfig = TxConfig(sipUser: "test_user", password: "test_password")
-        let serverConfig = TxServerConfiguration()
-        let firstCallId = UUID().uuidString
-        let pushMetaData: [String: Any] = [
-            "voice_sdk_id": "test-sdk-id-1",
-            "call_id": firstCallId
-        ]
-
-        try txClient.processVoIPNotification(
-            txConfig: txConfig,
-            serverConfiguration: serverConfig,
-            pushMetaData: pushMetaData
-        )
-
-        // Socket error occurs (simulating 401 on unauthenticated websocket)
-        txClient.onSocketError(error: TestSocketError(reason: "401 Unauthorized"))
-
-        // A new push notification arrives for a different call
-        let secondCallId = UUID().uuidString
-        let newPushMetaData: [String: Any] = [
-            "voice_sdk_id": "test-sdk-id-2",
-            "call_id": secondCallId
-        ]
-
-        // This should NOT throw - the state should be clean enough to process a new push
-        XCTAssertNoThrow(try txClient.processVoIPNotification(
-            txConfig: txConfig,
-            serverConfiguration: serverConfig,
-            pushMetaData: newPushMetaData
-        ))
-    }
-
-    /// Verify that socket error cleanup does not affect non-push flows
-    func testSocketErrorWithoutPushFlow() {
-        // Just trigger a socket error without any push flow active
-        txClient.onSocketError(error: TestSocketError(reason: "Connection reset"))
-
-        XCTAssertFalse(txClient.isConnected())
-        XCTAssertTrue(mockDelegate.onSocketDisconnectedCalled)
-    }
-
-    /// Verify that multiple sequential socket errors don't cause issues
-    func testMultipleSocketErrors() {
-        txClient.onSocketError(error: TestSocketError(reason: "Error 1"))
-        txClient.onSocketError(error: TestSocketError(reason: "Error 2"))
-        txClient.onSocketError(error: TestSocketError(reason: "Error 3"))
-
-        XCTAssertFalse(txClient.isConnected())
-        XCTAssertEqual(mockDelegate.socketDisconnectedCount, 3)
+        // Client should still be in a valid state, no 401 triggered.
+        // The delegate should NOT have received an error.
+        XCTAssertFalse(mockDelegate.onClientErrorCalled,
+                       "No error should occur — ping should be silently ignored on unauthenticated socket")
     }
 }
 
 // MARK: - Test Helpers
 
-private struct TestSocketError: Error, LocalizedError {
-    let reason: String
-    var errorDescription: String? { reason }
-}
-
-private class SocketErrorTestDelegate: TxClientDelegate {
-    var onSocketDisconnectedCalled = false
-    var socketDisconnectedCount = 0
-    var onSocketDisconnectedExpectation: XCTestExpectation?
+private class PingTestDelegate: TxClientDelegate {
+    var onClientErrorCalled = false
 
     func onSocketConnected() {}
-
-    func onSocketDisconnected() {
-        onSocketDisconnectedCalled = true
-        socketDisconnectedCount += 1
-        onSocketDisconnectedExpectation?.fulfill()
-    }
-
+    func onSocketDisconnected() {}
     func onClientReady() {}
     func onSessionUpdated(sessionId: String) {}
     func onIncomingCall(call: Call) {}
     func onCallStateUpdated(callState: CallState, callId: UUID) {}
-    func onClientError(error: Error) {}
     func onRemoteCallEnded(callId: UUID) {}
     func onRemoteCallEnded(callId: UUID, reason: CallTerminationReason?) {}
     func onPushDisabled(success: Bool, message: String) {}
     func onPushCall(call: Call) {}
+
+    func onClientError(error: Error) {
+        onClientErrorCalled = true
+    }
 }

--- a/TelnyxRTCTests/TxClientSocketErrorTests.swift
+++ b/TelnyxRTCTests/TxClientSocketErrorTests.swift
@@ -1,0 +1,169 @@
+//
+//  TxClientSocketErrorTests.swift
+//  TelnyxRTCTests
+//
+//  Copyright © 2025 Telnyx LLC. All rights reserved.
+//
+
+import XCTest
+@testable import TelnyxRTC
+
+/// Tests for TxClient socket error handling, specifically verifying that
+/// a 401 error on the unauthenticated push notification websocket properly
+/// cleans up state so future connections are not corrupted.
+class TxClientSocketErrorTests: XCTestCase {
+
+    var txClient: TxClient!
+    var mockDelegate: SocketErrorTestDelegate!
+
+    override func setUp() {
+        super.setUp()
+        txClient = TxClient()
+        mockDelegate = SocketErrorTestDelegate()
+        txClient.delegate = mockDelegate
+    }
+
+    override func tearDown() {
+        txClient.delegate = nil
+        txClient = nil
+        mockDelegate = nil
+        super.tearDown()
+    }
+
+    // MARK: - Basic socket error cleanup
+
+    /// Verify that onSocketError notifies the delegate
+    func testSocketErrorNotifiesDelegate() {
+        let expectation = XCTestExpectation(description: "Delegate should receive onSocketDisconnected")
+        mockDelegate.onSocketDisconnectedExpectation = expectation
+
+        txClient.onSocketError(error: TestSocketError(reason: "401 Unauthorized"))
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertTrue(mockDelegate.onSocketDisconnectedCalled)
+    }
+
+    /// Verify that after a socket error, isConnected() returns false
+    func testSocketErrorCleansUpConnection() {
+        txClient.onSocketError(error: TestSocketError(reason: "401 Unauthorized"))
+
+        XCTAssertFalse(txClient.isConnected(), "Client should not be connected after socket error")
+    }
+
+    // MARK: - Push flow socket error cleanup
+
+    /// Verify that a socket error during push flow resets push state
+    /// so that a subsequent connect() goes through the normal login flow
+    /// rather than being hijacked by the stale isCallFromPush flag.
+    func testSocketErrorDuringPushFlowResetsState() throws {
+        // Set up push flow state via processVoIPNotification
+        let txConfig = TxConfig(sipUser: "test_user", password: "test_password")
+        let serverConfig = TxServerConfiguration()
+        let pushMetaData: [String: Any] = [
+            "voice_sdk_id": "test-sdk-id",
+            "call_id": UUID().uuidString
+        ]
+
+        try txClient.processVoIPNotification(
+            txConfig: txConfig,
+            serverConfiguration: serverConfig,
+            pushMetaData: pushMetaData
+        )
+
+        // Now simulate the 401 error on the unauthenticated websocket
+        txClient.onSocketError(error: TestSocketError(reason: "401 Unauthorized"))
+
+        // After the error, the client should be in a clean state:
+        // - Not connected
+        XCTAssertFalse(txClient.isConnected(), "Client should not be connected after push socket error")
+
+        // - Delegate should have been notified
+        XCTAssertTrue(mockDelegate.onSocketDisconnectedCalled)
+    }
+
+    /// Verify that after a push flow socket error, a new processVoIPNotification
+    /// can be processed successfully (state is not corrupted)
+    func testNewPushAfterSocketError() throws {
+        // First push flow
+        let txConfig = TxConfig(sipUser: "test_user", password: "test_password")
+        let serverConfig = TxServerConfiguration()
+        let firstCallId = UUID().uuidString
+        let pushMetaData: [String: Any] = [
+            "voice_sdk_id": "test-sdk-id-1",
+            "call_id": firstCallId
+        ]
+
+        try txClient.processVoIPNotification(
+            txConfig: txConfig,
+            serverConfiguration: serverConfig,
+            pushMetaData: pushMetaData
+        )
+
+        // Socket error occurs (simulating 401 on unauthenticated websocket)
+        txClient.onSocketError(error: TestSocketError(reason: "401 Unauthorized"))
+
+        // A new push notification arrives for a different call
+        let secondCallId = UUID().uuidString
+        let newPushMetaData: [String: Any] = [
+            "voice_sdk_id": "test-sdk-id-2",
+            "call_id": secondCallId
+        ]
+
+        // This should NOT throw - the state should be clean enough to process a new push
+        XCTAssertNoThrow(try txClient.processVoIPNotification(
+            txConfig: txConfig,
+            serverConfiguration: serverConfig,
+            pushMetaData: newPushMetaData
+        ))
+    }
+
+    /// Verify that socket error cleanup does not affect non-push flows
+    func testSocketErrorWithoutPushFlow() {
+        // Just trigger a socket error without any push flow active
+        txClient.onSocketError(error: TestSocketError(reason: "Connection reset"))
+
+        XCTAssertFalse(txClient.isConnected())
+        XCTAssertTrue(mockDelegate.onSocketDisconnectedCalled)
+    }
+
+    /// Verify that multiple sequential socket errors don't cause issues
+    func testMultipleSocketErrors() {
+        txClient.onSocketError(error: TestSocketError(reason: "Error 1"))
+        txClient.onSocketError(error: TestSocketError(reason: "Error 2"))
+        txClient.onSocketError(error: TestSocketError(reason: "Error 3"))
+
+        XCTAssertFalse(txClient.isConnected())
+        XCTAssertEqual(mockDelegate.socketDisconnectedCount, 3)
+    }
+}
+
+// MARK: - Test Helpers
+
+private struct TestSocketError: Error, LocalizedError {
+    let reason: String
+    var errorDescription: String? { reason }
+}
+
+private class SocketErrorTestDelegate: TxClientDelegate {
+    var onSocketDisconnectedCalled = false
+    var socketDisconnectedCount = 0
+    var onSocketDisconnectedExpectation: XCTestExpectation?
+
+    func onSocketConnected() {}
+
+    func onSocketDisconnected() {
+        onSocketDisconnectedCalled = true
+        socketDisconnectedCount += 1
+        onSocketDisconnectedExpectation?.fulfill()
+    }
+
+    func onClientReady() {}
+    func onSessionUpdated(sessionId: String) {}
+    func onIncomingCall(call: Call) {}
+    func onCallStateUpdated(callState: CallState, callId: UUID) {}
+    func onClientError(error: Error) {}
+    func onRemoteCallEnded(callId: UUID) {}
+    func onRemoteCallEnded(callId: UUID, reason: CallTerminationReason?) {}
+    func onPushDisabled(success: Bool, message: String) {}
+    func onPushCall(call: Call) {}
+}


### PR DESCRIPTION
[WEBRTC-XXX - Skip ping reply on unauthenticated push socket](https://telnyx.atlassian.net/browse/WEBRTC-XXX)
---
During push flow, `processVoIPNotification` opens a socket but does not authenticate — login only happens when the user answers via `answerFromCallkit` → `performLogin`. The server sends `telnyx_rtc.ping` every 30s, and the SDK was blindly echoing it back as pong. Sending pong on an unauthenticated socket triggers a 401 error from the server which corrupts SDK state and prevents future calls.

## :older_man: :baby: Behaviors
### Before changes
- Push notification arrives, unauthenticated socket opens, SDK waits for user to answer.
- At 30s the server pings, SDK replies with pong on the unauthenticated socket.
- Server returns 401 error, which corrupts SDK state (stale socket, stale `isCallFromPush` flag).
- All subsequent calls fail because `connect()` enters the push flow branch and never sends a login message.

### After changes
- SDK only replies to `telnyx_rtc.ping` when `gatewayState == .REGED` (authenticated).
- On an unauthenticated push socket, pings are silently ignored with a log message.
- The 401 error never occurs, the socket stays healthy, and the user can answer at any time.

## TODO
- Confirm the WEBRTC ticket number and update the PR title link.

## ✋ Manual testing
1. Configure an inbound call with a short timeout (e.g. 15s) that goes to voicemail.
2. Receive the VoIP push on the iOS client — do NOT answer immediately.
3. Wait 30+ seconds (past the first ping interval).
4. Verify the SDK does NOT send a pong and no 401 error occurs.
5. Answer the call (or receive a new call) and verify it works normally.
6. Also test answering a call before 30s to confirm normal flow is unaffected.

## Known Issues
None.

## 🔄 iOS Regression Process

### Bugfixes or Demo App Changes: Only include the tests relevant to the implemented changes.

#### Notifications (relevant to push flow fix)
- [ ] Receive push notification (App Background) -> Accept Call
  - [ ] Screen On
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)
- [ ] Receive push notification (App Terminated) -> Accept Call
  - [ ] Screen On
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)
- [ ] Receive push notification (App Background) -> Reject Call
  - [ ] Screen On
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)
- [ ] Receive push notification (App Terminated) -> Reject Call
  - [ ] Screen On
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)