### PR TITLE
fix: avoid duplicate push login from CallKit answer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,11 @@ fastlane/screenshots/**/*.png
 fastlane/test_output
 Gemfile.lock
 reports/
+drivers/
+e2e/.env.local
+e2e/.chrome-profile/
+e2e/node_modules/
+e2e/package-lock.json
 
 #build
 build/*

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -1621,8 +1621,7 @@ extension TxClient : SocketDelegate {
                 performLogin(declinePush: false)
                 return
             } else {
-                Logger.log.i(message: "TxClient:: Socket connected from push - logging in immediately")
-                performLogin(declinePush: false)
+                Logger.log.i(message: "TxClient:: Socket connected from push - waiting for user action before login")
                 return
             }
         }

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -125,6 +125,19 @@ public extension Notification.Name {
 /// }
 /// ```
 public class TxClient {
+    /// Tracks the internal VoIP push handoff before a real incoming `Call` may exist.
+    ///
+    /// This state is intentionally separate from `CallState`: it coordinates socket/login/INVITE
+    /// ordering for CallKit push flows, not the lifecycle of an established call object.
+    /// - `loginSent` prevents `answerFromCallkit` from sending a duplicate login after the
+    ///   socket-connected push path has already logged in.
+    /// - `inviteReceived` prevents the post-answer INVITE timeout from firing when INVITE has
+    ///   arrived but downstream call creation is still pending or delayed.
+    private enum PushCallState {
+        case idle
+        case loginSent
+        case inviteReceived
+    }
 
     // MARK: - Properties
     private static let DEFAULT_REGISTER_INTERVAL = 3.0 // In seconds
@@ -173,6 +186,7 @@ public class TxClient {
     // Timeout mechanism for VoIP push calls
     private var inviteTimeoutTimer: Timer?
     private var isWaitingForInviteAfterPush: Bool = false
+    private var pushCallState: PushCallState = .idle
     private static let INVITE_TIMEOUT_SECONDS: TimeInterval = 10.0
     
     public private(set) var isSpeakerEnabled: Bool {
@@ -637,6 +651,7 @@ public class TxClient {
         self.calls.removeAll()
         self.stopReconnectTimeout()
         self.stopInviteTimeout()
+        self.pushCallState = .idle
 
         // Clear AI Assistant Manager data
         self.aiAssistantManager.clearAllData()
@@ -713,8 +728,13 @@ public class TxClient {
             // Start the login process by sending a login message with decline_push: false
             // Automatically accept the call once the INVITE is received
             if isConnected() {
-                Logger.log.i(message: "TxClient:: answerFromCallkit - Socket connected, performing login with decline_push: false")
-                performLogin(declinePush: false)
+                if pushCallState == .loginSent {
+                    Logger.log.i(message: "TxClient:: answerFromCallkit - Push login already sent, waiting for INVITE")
+                } else {
+                    Logger.log.i(message: "TxClient:: answerFromCallkit - Socket connected, performing login with decline_push: false")
+                    performLogin(declinePush: false)
+                    pushCallState = .loginSent
+                }
             } else {
                 Logger.log.i(message: "TxClient:: answerFromCallkit - Socket not connected, connecting first")
                 do {
@@ -750,12 +770,18 @@ public class TxClient {
         storedServerConfiguration = nil
         pendingCallDecline = false
         isCallFromPush = false
+        pushCallState = .idle
         stopInviteTimeout()
         isWaitingForInviteAfterPush = false
     }
     
     /// Starts the INVITE timeout timer for VoIP push calls
     private func startInviteTimeout() {
+        if pushCallState == .inviteReceived {
+            Logger.log.i(message: "TxClient:: Skipping INVITE timeout - INVITE already received for VoIP push call")
+            return
+        }
+
         stopInviteTimeout() // Ensure any existing timer is stopped
         
         Logger.log.i(message: "TxClient:: Starting INVITE timeout timer (10 seconds)")
@@ -1050,7 +1076,7 @@ public class TxClient {
                     self.sendAttachCall()
                     
                     // Start INVITE timeout for VoIP push calls that are being answered (not declined)
-                    if answerCallAction != nil && !pendingCallDecline {
+                    if answerCallAction != nil && !pendingCallDecline && pushCallState != .inviteReceived {
                         Logger.log.i(message: "TxClient:: updateGatewayState() Starting INVITE timeout for VoIP push call")
                         startInviteTimeout()
                     }
@@ -1359,6 +1385,7 @@ extension TxClient {
         }
         
         self.pushMetaData = pushMetaData
+        self.pushCallState = .idle
         
         // Store config objects for later use (don't login immediately)
         self.storedTxConfig = txConfig
@@ -1481,6 +1508,9 @@ extension TxClient: CallProtocol {
                 self.delegate?.onRemoteCallEnded(callId: callId, reason: reason)
             } else {
                 self.delegate?.onRemoteCallEnded(callId: callId, reason: nil)
+            }
+            if callId == currentCallId && pushCallState != .idle {
+                resetPushVariables()
             }
             self._isSpeakerEnabled = false
         }
@@ -1617,11 +1647,18 @@ extension TxClient : SocketDelegate {
                 performLogin(declinePush: true)
                 return
             } else if answerCallAction != nil {
-                Logger.log.i(message: "TxClient:: Socket connected for answer flow")
-                performLogin(declinePush: false)
+                if pushCallState == .loginSent {
+                    Logger.log.i(message: "TxClient:: Socket connected for answer flow - push login already sent")
+                } else {
+                    Logger.log.i(message: "TxClient:: Socket connected for answer flow")
+                    performLogin(declinePush: false)
+                    pushCallState = .loginSent
+                }
                 return
             } else {
-                Logger.log.i(message: "TxClient:: Socket connected from push - waiting for user action before login")
+                Logger.log.i(message: "TxClient:: Socket connected from push - logging in immediately")
+                performLogin(declinePush: false)
+                pushCallState = .loginSent
                 return
             }
         }
@@ -1842,7 +1879,9 @@ extension TxClient : SocketDelegate {
 
                 case .INVITE:
                     //invite received
-                    // Stop the INVITE timeout timer if it's running for VoIP push calls
+                    if isCallFromPush {
+                        pushCallState = .inviteReceived
+                    }
                     if isWaitingForInviteAfterPush {
                         Logger.log.i(message: "TxClient:: INVITE received - stopping timeout timer for VoIP push call")
                         stopInviteTimeout()
@@ -1880,6 +1919,23 @@ extension TxClient : SocketDelegate {
                                 Logger.log.e(message: "Custom header decoding error: \(error)")
                             }
                         }
+                        if isCallFromPush {
+                            Logger.log.i(message: "[VSUP-62-REPRO] Delaying invite handling by 10s")
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 10.0) {
+                                self.createIncomingCall(callerName: callerName,
+                                                        callerNumber: callerNumber,
+                                                        callId: uuid,
+                                                        remoteSdp: sdp,
+                                                        telnyxSessionId: telnyxSessionId,
+                                                        telnyxLegId: telnyxLegId,
+                                                        customHeaders: customHeaders)
+                                /*FileLogger.shared.log("INVITE : \(message) \n")
+                                FileLogger.shared.log("INVITE telnyxLegId: \(telnyxLegId) \n") */
+                                self.sendFileLogs = true
+                            }
+                            return
+                        }
+
                         self.createIncomingCall(callerName: callerName,
                                                 callerNumber: callerNumber,
                                                 callId: uuid,
@@ -1887,11 +1943,6 @@ extension TxClient : SocketDelegate {
                                                 telnyxSessionId: telnyxSessionId,
                                                 telnyxLegId: telnyxLegId,
                                                 customHeaders: customHeaders)
-                        if(isCallFromPush){
-                            /*FileLogger.shared.log("INVITE : \(message) \n")
-                            FileLogger.shared.log("INVITE telnyxLegId: \(telnyxLegId) \n") */
-                            self.sendFileLogs = true
-                        }
                         
                     }
                    

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -651,7 +651,6 @@ public class TxClient {
         self.calls.removeAll()
         self.stopReconnectTimeout()
         self.stopInviteTimeout()
-        self.pushCallState = .idle
 
         // Clear AI Assistant Manager data
         self.aiAssistantManager.clearAllData()
@@ -1509,9 +1508,6 @@ extension TxClient: CallProtocol {
             } else {
                 self.delegate?.onRemoteCallEnded(callId: callId, reason: nil)
             }
-            if callId == currentCallId && pushCallState != .idle {
-                resetPushVariables()
-            }
             self._isSpeakerEnabled = false
         }
     }
@@ -1919,23 +1915,6 @@ extension TxClient : SocketDelegate {
                                 Logger.log.e(message: "Custom header decoding error: \(error)")
                             }
                         }
-                        if isCallFromPush {
-                            Logger.log.i(message: "[VSUP-62-REPRO] Delaying invite handling by 10s")
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 10.0) {
-                                self.createIncomingCall(callerName: callerName,
-                                                        callerNumber: callerNumber,
-                                                        callId: uuid,
-                                                        remoteSdp: sdp,
-                                                        telnyxSessionId: telnyxSessionId,
-                                                        telnyxLegId: telnyxLegId,
-                                                        customHeaders: customHeaders)
-                                /*FileLogger.shared.log("INVITE : \(message) \n")
-                                FileLogger.shared.log("INVITE telnyxLegId: \(telnyxLegId) \n") */
-                                self.sendFileLogs = true
-                            }
-                            return
-                        }
-
                         self.createIncomingCall(callerName: callerName,
                                                 callerNumber: callerNumber,
                                                 callId: uuid,
@@ -1943,6 +1922,11 @@ extension TxClient : SocketDelegate {
                                                 telnyxSessionId: telnyxSessionId,
                                                 telnyxLegId: telnyxLegId,
                                                 customHeaders: customHeaders)
+                        if(isCallFromPush){
+                            /*FileLogger.shared.log("INVITE : \(message) \n")
+                            FileLogger.shared.log("INVITE telnyxLegId: \(telnyxLegId) \n") */
+                            self.sendFileLogs = true
+                        }
                         
                     }
                    


### PR DESCRIPTION
📦 Pull Request for SDK bugfix

### 📋 Changes
- [VSUP-62 - iOS SDK 4.0.0: ~55s delay between answering VoIP push call and onPushCall firing](https://linear.app/telnyx/issue/VSUP-62/ios-sdk-400-55s-delay-between-answering-voip-push-call-and-onpushcall)
- Restores the push wake-up behavior so the socket-connected push path logs in immediately.
- Adds private `PushCallState` coordination inside `TxClient` so CallKit answer does not send a duplicate login after the push socket path has already sent one.
- Marks push INVITE as received before downstream call creation, so the post-answer INVITE timeout cannot fire after INVITE has already arrived.
- Keeps the explicit decline path on `performLogin(declinePush: true)`.

### 🧪 Local verification
- Built the SDK for iOS Simulator successfully:
  ```bash
  xcodebuild -workspace TelnyxRTC.xcworkspace -scheme TelnyxRTC -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build
  ```

### Expected ordering

Before this update, the push socket path could send one login and `answerFromCallkit(...)` could send a second login before the INVITE/onPushCall path completed.

With this update:
- Push socket connect sends the early login once.
- CallKit Answer records the answer action and waits when `PushCallState.loginSent` is already active.
- Push INVITE marks `PushCallState.inviteReceived` immediately.
- Delayed call creation or delayed `onPushCall` does not trigger the INVITE timeout.

---

## Application Flow Checklist

### 🧪 Logged in with Token

- [x] **Connection:** Establish connection via Token

#### Inbound Calls (Receiving as Token user)
- [x] Receive inbound call from SIP Connection
  - [x] On WiFi
  - [x] On Mobile Network

#### Outbound Calls (Making calls as Token user)
- [x] Make outbound call to SIP Connection
  - [x] On WiFi
  - [x] On Mobile Network
- [x] Make outbound call to associated number
  - [x] On WiFi
  - [x] On Mobile Network
- [ ] Make outbound call to PSTN
  - [ ] On WiFi
  - [ ] On Mobile Network

#### Notifications (While logged in as Token)
- [x] Receive push notification (App Background) -> Reject Call
  - [x] Screen On
  - [x] Screen Locked (Active)
  - [x] Screen Locked (Sleep)
- [x] Receive push notification (App Background) -> Accept Call
  - [x] Screen On
  - [x] Screen Locked (Active)
  - [x] Screen Locked (Sleep)
- [x] Receive push notification (App Terminated) -> Reject Call
  - [x] Screen On
  - [x] Screen Locked (Active)
  - [x] Screen Locked (Sleep)
- [x] Receive push notification (App Terminated) -> Accept Call
  - [x] Screen On
  - [x] Screen Locked (Active)
  - [x] Screen Locked (Sleep)

---

### 📞 Logged in with SIP Connection

- [x] **Connection:** Establish connection via SIP Credential

#### Inbound Calls (Receiving as SIP user)
- [x] Receive inbound call from another SIP Connection
  - [x] On WiFi
  - [x] On Mobile Network
- [x] Receive inbound call via associated number
  - [x] On WiFi
  - [x] On Mobile Network
- [ ] Receive inbound call from PSTN
  - [ ] On WiFi
  - [ ] On Mobile Network

#### Outbound Calls (Making calls as SIP user)
- [x] Make outbound call to SIP Connection
  - [x] On WiFi
  - [x] On Mobile Network
- [x] Make outbound call to associated number
  - [x] On WiFi
  - [x] On Mobile Network
- [ ] Make outbound call to PSTN
  - [ ] On WiFi
  - [ ] On Mobile Network

#### Notifications (While logged in as SIP)
- [x] Receive push notification (App Background) -> Reject Call
  - [x] Screen On
  - [x] Screen Locked (Active)
  - [x] Screen Locked (Sleep)
- [x] Receive push notification (App Background) -> Accept Call
  - [x] Screen On
  - [x] Screen Locked (Active)
  - [x] Screen Locked (Sleep)
- [x] Receive push notification (App Terminated) -> Reject Call
  - [x] Screen On
  - [x] Screen Locked (Active)
  - [x] Screen Locked (Sleep)
- [x] Receive push notification (App Terminated) -> Accept Call
  - [x] Screen On
  - [x] Screen Locked (Active)
  - [x] Screen Locked (Sleep)

---

### 👤 Logged in with genCred

- [x] **Connection:** Establish connection via genCred

#### Inbound Calls (Receiving as genCred user)
- [x] Receive inbound call from SIP Connection
  - [x] On WiFi
  - [x] On Mobile Network
- [x] Receive inbound call via associated number
  - [x] On WiFi
  - [x] On Mobile Network
- [ ] Receive inbound call from PSTN
  - [ ] On WiFi
  - [ ] On Mobile Network

#### Outbound Calls (Making calls as genCred user)
- [x] Make outbound call to SIP Connection
  - [x] On WiFi
  - [x] On Mobile Network
- [x] Make outbound call to associated number
  - [x] On WiFi
  - [x] On Mobile Network
- [ ] Make outbound call to PSTN
  - [ ] On WiFi
  - [ ] On Mobile Network

#### Notifications (While logged in as genCred)
- [x] Receive push notification (App Background) -> Reject Call
  - [x] Screen On
  - [x] Screen Locked (Active)
  - [x] Screen Locked (Sleep)
- [x] Receive push notification (App Background) -> Accept Call
  - [x] Screen On
  - [x] Screen Locked (Active)
  - [x] Screen Locked (Sleep)
- [x] Receive push notification (App Terminated) -> Reject Call
  - [x] Screen On
  - [x] Screen Locked (Active)
  - [x] Screen Locked (Sleep)
- [x] Receive push notification (App Terminated) -> Accept Call
  - [x] Screen On
  - [x] Screen Locked (Active)
  - [x] Screen Locked (Sleep)

---

### 🔁 General Reconnection Scenarios
- [x] Establish call -> Drop network -> Re-establish connection within timeframe
  - [x] On WiFi
  - [x] On 4G/Mobile Network
- [x] Establish call -> Drop network -> Fail to re-establish connection within timeframe (verify dropped state)
  - [x] On WiFi
  - [x] On 4G/Mobile Network

---

### 📊 General Stats Scenarios
- [x] Enable stats (config level) -> Establish call -> Verify portal stats appear
- [x] Disable stats (config level) -> Establish call -> Verify no portal stats appear
- [x] Enable stats (call level) -> Establish call -> Verify quality metrics are available
- [x] Disable stats (call level) -> Establish call -> Verify quality metrics are not available

