### PR TITLE
docs: update changelog for 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [4.0.1](https://github.com/team-telnyx/telnyx-webrtc-ios/releases/tag/4.0.1) (2026-05-25)
+
+### Bug Fixes
+- **Push Reattach Trickle ICE**: Fixed push notification reattach flow so it respects the configured `useTrickleIce` setting when reconnecting from a VoIP push ([#343](https://github.com/team-telnyx/telnyx-webrtc-ios/pull/343)).
+- **Push Answer Login Race**: Fixed duplicate push login handling by waiting for the CallKit answer path before sending push login, improving reliability when answering incoming VoIP push calls ([#345](https://github.com/team-telnyx/telnyx-webrtc-ios/pull/345)).
+
 ## [4.0.0](https://github.com/team-telnyx/telnyx-webrtc-ios/releases/tag/4.0.0) (2026-05-05)
 
 ### ⚠️ Breaking Changes


### PR DESCRIPTION
<!-- Ticket details and link -->
N/A - release changelog documentation
---
<!-- Describe your change here -->
Updates `CHANGELOG.md` with the planned `4.0.1` release notes for the two fixes merged after `4.0.0`.

## :older_man: :baby: Behaviors
### Before changes
- `CHANGELOG.md` did not include the upcoming `4.0.1` release notes.

### After changes
- `CHANGELOG.md` includes `4.0.1` bug fix notes for:
  - Push reattach respecting `useTrickleIce`
  - Push answer login race / duplicate push login handling

## TODO
- Merge this PR before running the `release-01-create-pull-request` workflow for `4.0.1`.

## ✋ Manual testing
1. Not run; documentation-only change.

## Known Issues
None.

## Screenshots
N/A.

## 🔄 iOS Regression Process

Documentation-only changelog update. Full release regression should be tracked on the generated `release/4.0.1` PR.

- [ ] Full release E2E/regression to be completed on `release/4.0.1`
