### PR TITLE
fix: redial socket after default URL timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [Unreleased]
+
+### Bug Fixes
+- **Socket Connection Timeout / Redial**: The signaling socket now always arms a 5s connection-timeout watchdog and redials on a stalled handshake, instead of only doing so when a region fallback was possible. Previously, on the default `wss://rtc.telnyx.com` URL the watchdog never started (the host has no valid region prefix) and the underlying request timeout was overridden to 120s, so a lost SYN after a VoIP push left the dial hanging on TCP retransmit backoff with no recovery — causing answer-from-push failures on cold start. On timeout the socket now falls back to the auto region only for genuine Telnyx regional hosts (`*.rtc.telnyx.com` / `*.rtcdev.telnyx.com`) and otherwise redials the same server, the duplicate disconnect callback from the timed-out socket is suppressed so it does not surface a spurious disconnect mid-redial, and the push socket-only reconnect path no longer force-unwraps a possibly-nil `TxConfig` ([#348](https://github.com/team-telnyx/telnyx-webrtc-ios/pull/348)).
+
 ## [4.0.1](https://github.com/team-telnyx/telnyx-webrtc-ios/releases/tag/4.0.1) (2026-05-25)
 
 ### Bug Fixes

--- a/TelnyxRTC/Telnyx/Services/Socket.swift
+++ b/TelnyxRTC/Telnyx/Services/Socket.swift
@@ -17,9 +17,16 @@ class Socket {
     private var reconnect : Bool = false
     internal var signalingServer:URL? = nil
     
-    /// Timer for manual connection timeout (only used when not on auto region)
+    /// Timer for manual connection timeout.
     private var connectionTimeoutTimer: Timer?
     
+    /// Prevents the socket's disconnect callback from sending a second non-timeout disconnect
+    /// after a connection timeout has already requested a reconnect.
+    private var suppressDisconnectCallbackAfterConnectionTimeout = false
+
+    /// Test seam that allows unit tests to validate request/timer setup without opening a network connection.
+    internal var automaticallyConnectWebSocket = true
+
     /// Connection timeout interval in seconds
     private var connectionTimeout: TimeInterval = 5.0
     
@@ -36,6 +43,7 @@ class Socket {
         
         // Cancel any existing timeout timer
         cancelConnectionTimeout()
+        suppressDisconnectCallbackAfterConnectionTimeout = false
         
         var request = URLRequest(url: signalingServer)
         request.timeoutInterval = connectionTimeout
@@ -44,14 +52,13 @@ class Socket {
         
         self.socket = WebSocket(request: request, certPinner: pinner)
         self.socket?.delegate = self
-        self.socket?.request.timeoutInterval = TimeInterval(120)
         
-        // Only start timeout timer if we can fallback to auto (i.e., not already on auto)
-        if shouldFallbackToAuto(signalingServer: signalingServer) {
-            startConnectionTimeout()
+        // Apply the SDK dial timeout to every signaling server, including the default auto URL.
+        startConnectionTimeout()
+        
+        if automaticallyConnectWebSocket {
+            self.socket?.connect()
         }
-        
-        self.socket?.connect()
     }
     
     func disconnect(reconnect:Bool) {
@@ -85,6 +92,8 @@ extension Socket : WebSocketDelegate {
     // Fallback to .auto Region
     func shouldFallbackToAuto(signalingServer: URL?) -> Bool {
         guard let url = signalingServer,
+              let host = url.host,
+              isTelnyxRTCRegionalHost(host),
               let regionPrefix = extractRegionPrefix(from: url),
               let region = Region(rawValue: regionPrefix) else {
             return false
@@ -92,6 +101,10 @@ extension Socket : WebSocketDelegate {
         return region != .auto
     }
     
+    private func isTelnyxRTCRegionalHost(_ host: String) -> Bool {
+        host.hasSuffix(".rtc.telnyx.com") || host.hasSuffix(".rtcdev.telnyx.com")
+    }
+
     func extractRegionPrefix(from url: URL) -> String? {
         let host = url.host ?? ""
         let components = host.components(separatedBy: ".")
@@ -116,6 +129,11 @@ extension Socket : WebSocketDelegate {
             //This are server side disconnections
             cancelConnectionTimeout()
             isConnected = false
+            if suppressDisconnectCallbackAfterConnectionTimeout {
+                suppressDisconnectCallbackAfterConnectionTimeout = false
+                Logger.log.i(message: "Socket:: websocket disconnected after connection timeout: \(reason) with code: \(code)")
+                break
+            }
             self.delegate?.onSocketDisconnected(reconnect: self.reconnect,region: nil)
             Logger.log.i(message: "Socket:: websocket is disconnected: \(reason) with code: \(code)")
             break;
@@ -128,6 +146,11 @@ extension Socket : WebSocketDelegate {
         case .cancelled:
             cancelConnectionTimeout()
             isConnected = false
+            if suppressDisconnectCallbackAfterConnectionTimeout {
+                suppressDisconnectCallbackAfterConnectionTimeout = false
+                Logger.log.i(message: "Socket:: WebSocketDelegate .cancelled after connection timeout")
+                break
+            }
             self.delegate?.onSocketDisconnected(reconnect: self.reconnect,region: nil)
             self.reconnect = false
             Logger.log.i(message: "Socket:: WebSocketDelegate .cancelled")
@@ -136,6 +159,11 @@ extension Socket : WebSocketDelegate {
         case .error(let error):
             cancelConnectionTimeout()
             isConnected = false
+            if suppressDisconnectCallbackAfterConnectionTimeout {
+                suppressDisconnectCallbackAfterConnectionTimeout = false
+                Logger.log.i(message: "Socket:: WebSocketDelegate .error after connection timeout")
+                break
+            }
             guard let error = error else {
                 Logger.log.e(message: "Socket:: WebSocketDelegate .error UNKNOWN")
                 return
@@ -173,7 +201,17 @@ extension Socket : WebSocketDelegate {
         connectionTimeout = max(5.0, timeout)
     }
     
-    /// Starts the connection timeout timer (only when not on auto region)
+    /// The currently configured WebSocket request timeout interval.
+    internal var currentRequestTimeoutInterval: TimeInterval? {
+        socket?.request.timeoutInterval
+    }
+
+    /// Whether the manual connection timeout timer is currently scheduled.
+    internal var hasConnectionTimeoutTimer: Bool {
+        connectionTimeoutTimer != nil
+    }
+
+    /// Starts the connection timeout timer.
     private func startConnectionTimeout() {
         connectionTimeoutTimer = Timer.scheduledTimer(withTimeInterval: connectionTimeout, repeats: false) { [weak self] _ in
             self?.handleConnectionTimeout()
@@ -186,17 +224,29 @@ extension Socket : WebSocketDelegate {
         connectionTimeoutTimer = nil
     }
     
-    /// Handles connection timeout by triggering fallback mechanism
-    private func handleConnectionTimeout() {
+    /// Handles connection timeout by triggering the reconnect mechanism.
+    internal func handleConnectionTimeout() {
         Logger.log.e(message: "Socket:: Connection timeout after \(connectionTimeout) seconds")
+        cancelConnectionTimeout()
         
         // Mark as not connected and disconnect socket
         isConnected = false
+        let shouldSuppressDisconnectCallback = socket != nil
+        suppressDisconnectCallbackAfterConnectionTimeout = shouldSuppressDisconnectCallback
         socket?.disconnect()
+        if !shouldSuppressDisconnectCallback {
+            suppressDisconnectCallbackAfterConnectionTimeout = false
+        }
         
-        // Trigger fallback to auto region (we know we can fallback since timer only starts when shouldFallbackToAuto is true)
-        Logger.log.i(message: "Socket:: Triggering fallback to auto region due to timeout")
-        delegate?.onSocketDisconnected(reconnect: true, region: .auto)
+        let reconnectRegion = connectionTimeoutReconnectRegion(signalingServer: signalingServer)
+        Logger.log.i(message: "Socket:: Triggering reconnect due to timeout with region: \(String(describing: reconnectRegion))")
+        delegate?.onSocketDisconnected(reconnect: true, region: reconnectRegion)
+    }
+
+    /// Region override to pass to TxClient after a connection timeout.
+    /// Region URLs fall back to `.auto`; default/auto URLs keep `nil` so TxClient redials the same URL.
+    internal func connectionTimeoutReconnectRegion(signalingServer: URL?) -> Region? {
+        shouldFallbackToAuto(signalingServer: signalingServer) ? .auto : nil
     }
     
     

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -567,6 +567,9 @@ public class TxClient {
         Logger.log.i(message: "TxClient:: connectSocketOnly - connecting socket without login")
         self.registerRetryCount = TxClient.MAX_REGISTER_RETRY
         self.gatewayState = .NOREG
+        if self.txConfig == nil {
+            self.txConfig = storedTxConfig
+        }
         self.serverConfiguration = serverConfiguration
 
         Logger.log.i(message: "TxClient:: serverConfiguration server: [\(self.serverConfiguration.signalingServer)] ICE Servers [\(self.serverConfiguration.webRTCIceServers)]")
@@ -1733,7 +1736,11 @@ extension TxClient : SocketDelegate {
                         )
                     }
 
-                    try self.connect(txConfig: self.txConfig!, serverConfiguration: updatedServerConfig)
+                    guard let reconnectConfig = self.txConfig ?? self.storedTxConfig else {
+                        Logger.log.e(message: "TxClient:: SocketDelegate reconnect skipped - missing config")
+                        return
+                    }
+                    try self.connect(txConfig: reconnectConfig, serverConfiguration: updatedServerConfig)
                 } catch let error {
                     Logger.log.e(message: "TxClient:: SocketDelegate reconnect error" + error.localizedDescription)
                 }

--- a/TelnyxRTCTests/RegionTests.swift
+++ b/TelnyxRTCTests/RegionTests.swift
@@ -333,6 +333,76 @@ class RegionTests: XCTestCase {
         // Test with invalid region URL
         let invalidURL = URL(string: "wss://invalid.domain.com")!
         XCTAssertFalse(socket.shouldFallbackToAuto(signalingServer: invalidURL))
+
+        // Test with custom URL that uses a region-like prefix - should NOT fallback
+        let customURL = URL(string: "wss://eu.example.com")!
+        XCTAssertFalse(socket.shouldFallbackToAuto(signalingServer: customURL))
+    }
+
+    /**
+     Test that Socket.connect preserves the configured dial timeout for the default auto URL
+     and starts the manual timeout timer even when no regional fallback is available.
+     */
+    func testSocketConnectAppliesConnectionTimeoutForDefaultAutoServer() {
+        let socket = Socket()
+        socket.automaticallyConnectWebSocket = false
+        socket.setConnectionTimeout(5.0)
+
+        let autoURL = URL(string: "wss://rtc.telnyx.com")!
+        socket.connect(signalingServer: autoURL)
+
+        XCTAssertEqual(socket.currentRequestTimeoutInterval, 5.0)
+        XCTAssertTrue(socket.hasConnectionTimeoutTimer)
+
+        socket.disconnect(reconnect: false)
+    }
+
+    /**
+     Test that a timeout on the default auto URL asks TxClient to reconnect without changing region.
+     */
+    func testSocketConnectionTimeoutRedialsDefaultAutoServerWithNilRegion() {
+        let socket = Socket()
+        let mockDelegate = MockSocketDelegateForRegionTesting()
+        socket.delegate = mockDelegate
+        socket.signalingServer = URL(string: "wss://rtc.telnyx.com")!
+
+        socket.handleConnectionTimeout()
+
+        XCTAssertTrue(mockDelegate.onSocketDisconnectedCalled)
+        XCTAssertEqual(mockDelegate.lastReconnectValue, true)
+        XCTAssertNil(mockDelegate.lastRegionValue)
+    }
+
+    /**
+     Test that a timeout on a custom URL redials the same server instead of falling back to Telnyx auto.
+     */
+    func testSocketConnectionTimeoutRedialsCustomServerWithNilRegion() {
+        let socket = Socket()
+        let mockDelegate = MockSocketDelegateForRegionTesting()
+        socket.delegate = mockDelegate
+        socket.signalingServer = URL(string: "wss://eu.example.com")!
+
+        socket.handleConnectionTimeout()
+
+        XCTAssertTrue(mockDelegate.onSocketDisconnectedCalled)
+        XCTAssertEqual(mockDelegate.lastReconnectValue, true)
+        XCTAssertNil(mockDelegate.lastRegionValue)
+    }
+
+    /**
+     Test that a timeout on an explicit region URL falls back to auto region.
+     */
+    func testSocketConnectionTimeoutFallsBackToAutoForRegionServer() {
+        let socket = Socket()
+        let mockDelegate = MockSocketDelegateForRegionTesting()
+        socket.delegate = mockDelegate
+        socket.signalingServer = URL(string: "wss://eu.rtc.telnyx.com")!
+
+        socket.handleConnectionTimeout()
+
+        XCTAssertTrue(mockDelegate.onSocketDisconnectedCalled)
+        XCTAssertEqual(mockDelegate.lastReconnectValue, true)
+        XCTAssertEqual(mockDelegate.lastRegionValue, .auto)
     }
 }
 

--- a/TelnyxRTCTests/Socket/SocketTests.swift
+++ b/TelnyxRTCTests/Socket/SocketTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class SocketTests : XCTestCase, SocketDelegate {
     func onSocketDisconnected(reconnect: Bool, region: TelnyxRTC.Region?) {
         //Handle socket disconnected
-        socketDisconnectedExpectation.fulfill()
+        socketDisconnectedExpectation?.fulfill()
     }
 
     private weak var socketConnectedExpectation: XCTestExpectation!
@@ -24,7 +24,7 @@ class SocketTests : XCTestCase, SocketDelegate {
     var isPing = false
 
     func onSocketConnected() {
-        socketConnectedExpectation.fulfill()
+        socketConnectedExpectation?.fulfill()
     }
 
     func onSocketError(error: Error) {
@@ -35,7 +35,7 @@ class SocketTests : XCTestCase, SocketDelegate {
         //For now we are not checking the response, just if we get any response.
         let serverResponse = Message().decode(message: message)
         errorResponse = serverResponse?.serverError
-        socketMessageExpectation.fulfill()
+        socketMessageExpectation?.fulfill()
         
         if serverResponse?.method == .PING {
             isPing = true
@@ -50,6 +50,7 @@ class SocketTests : XCTestCase, SocketDelegate {
         socketConnectedExpectation = expectation(description: "socketConnection")
         let socket = Socket()
         socket.delegate = self
+        socket.setConnectionTimeout(40.0)
         socket.connect(signalingServer: InternalConfig.default.prodSignalingServer)
         waitForExpectations(timeout: 5)
         XCTAssertTrue(socket.isConnected)
@@ -78,12 +79,13 @@ class SocketTests : XCTestCase, SocketDelegate {
         socketPingExpectation = expectation(description: "socketPing")
         socketPingExpectation.fulfill()
         socketDisconnectedExpectation = expectation(description: "socketDisconnection")
-        socketDisconnectedExpectation.fulfill()
+        socketDisconnectedExpectation?.fulfill()
         socketMessageExpectation = expectation(description: "socketSendMessage")
         socketConnectedExpectation = expectation(description: "socketConnection")
         isPing = false
         let socket = Socket()
         socket.delegate = self
+        socket.setConnectionTimeout(40.0)
         socket.connect(signalingServer: InternalConfig.default.prodSignalingServer)
         waitForExpectations(timeout: 40)
         XCTAssertTrue(isPing)


### PR DESCRIPTION
<!-- Ticket details and link -->
Socket dial never times out on default prod URL, breaks answer-from-push
---
<!-- Describe your change here -->
Fixes the default production WebSocket dial path so stalled iOS cold-start push answers do not wait on the TCP backoff path indefinitely.

## :older_man: :baby: Behaviors
### Before changes
- `Socket.connect()` set `URLRequest.timeoutInterval` to the SDK connection timeout, then overwrote the Starscream request timeout to 120s.
- The manual 5s connection watchdog only started when regional fallback was available.
- Default `wss://rtc.telnyx.com` dials therefore had no 5s watchdog and no reconnect/redial path when the initial handshake stalled.
- Push socket-only reconnects could hit `txConfig!` during redial if the timeout happened before login established the current config.

### After changes
- The hardcoded 120s WebSocket request timeout override is removed.
- The configured SDK connection timeout (minimum 5s) is applied to the Starscream request and the watchdog starts for every socket dial, including `wss://rtc.telnyx.com`.
- Timeout now requests reconnect unconditionally:
  - Telnyx regional hosts like `eu.rtc.telnyx.com` / `eu.rtcdev.telnyx.com` fall back to `.auto`.
  - Default/auto and custom hosts redial the same server with `region: nil`.
- Timeout-triggered socket cancellation suppresses duplicate non-reconnect disconnect/error callbacks from the old socket.
- Push socket-only redial can reuse the stored push `TxConfig` instead of force-unwrapping a nil current config.

## TODO
- [ ] Manual cold-start VoIP push answer smoke on cellular / lossy network if available.

## ✋ Manual testing
1. CI `ios_fastlane_tests` passed on the latest PR head (`8672fd5f`).
2. CI CodeQL and Markdown lint passed.
3. Added `CHANGELOG.md` `[Unreleased]` entry for the timeout/redial fix.
4. Local `xcodebuild` is unavailable on this host because it only has Command Line Tools (`xcode-select: error: tool 'xcodebuild' requires Xcode`).
5. Local `swift test` stalled while downloading the WebRTC binary artifact and was killed after no progress/output.
6. Local `git diff --check` passed.
7. Local `swift package dump-package` passed.
8. Added unit coverage for:
   - default prod URL preserving 5s request timeout and starting the watchdog,
   - default prod URL timeout redialing with `region: nil`,
   - custom region-like host redialing with `region: nil`,
   - Telnyx regional URL timeout falling back to `.auto`.

## Known Issues
- Manual cold-start VoIP push answer validation on cellular/lossy network is still recommended.

## Screenshots
N/A

## 🔄 iOS Regression Process

Bugfix scope: socket dial timeout and redial behavior only. Relevant checklist items for release validation:

- [ ] Receive push notification (App Terminated) -> Accept Call
  - [ ] On Mobile Network
- [ ] General reconnection: establish connection -> drop/blackhole initial network attempt -> verify reconnect/redial within configured timeout
  - [ ] On 4G/Mobile Network


