### PR TITLE
fix: arm 5s socket connection timeout + redial unconditionally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## [Unreleased]
+
+### Bug Fixes
+- **Socket Connection Timeout / Redial**: The signaling socket now always arms a 5s connection-timeout watchdog and redials on a stalled handshake, instead of only doing so when a region fallback was possible. Previously, on the default `wss://rtc.telnyx.com` URL the watchdog never started (the host has no valid region prefix) and the underlying request timeout was overridden to 120s, so a lost SYN after a VoIP push left the dial hanging on TCP retransmit backoff with no recovery — causing answer-from-push failures on cold start. The watchdog now falls back to the auto region when on a specific region, and otherwise redials the same server. The request timeout is aligned with the (configurable, min 5s) watchdog interval rather than a hardcoded 120s.
+
 ## [4.0.1](https://github.com/team-telnyx/telnyx-webrtc-ios/releases/tag/4.0.1) (2026-05-25)
 
 ### Bug Fixes

--- a/TelnyxRTC.xcodeproj/project.pbxproj
+++ b/TelnyxRTC.xcodeproj/project.pbxproj
@@ -149,6 +149,7 @@
 		B39121AF25FFCE680051E076 /* TxError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39121AE25FFCE680051E076 /* TxError.swift */; };
 		B39121E72600F7B10051E076 /* VertoMessagesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39121E62600F7B10051E076 /* VertoMessagesTests.swift */; };
 		B39121ED2602F22F0051E076 /* SocketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39121EC2602F22F0051E076 /* SocketTests.swift */; };
+		AAB1000000000000000000A1 /* SocketConnectionTimeoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB1000000000000000000A2 /* SocketConnectionTimeoutTests.swift */; };
 		B391220C2604D9C50051E076 /* PeerConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B391220B2604D9C50051E076 /* PeerConnectionTests.swift */; };
 		B39122122604FBC00051E076 /* TestConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39122112604FBC00051E076 /* TestConstants.swift */; };
 		B3912220260502650051E076 /* CallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B391221F260502650051E076 /* CallTests.swift */; };
@@ -370,6 +371,7 @@
 		B39121AE25FFCE680051E076 /* TxError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TxError.swift; sourceTree = "<group>"; };
 		B39121E62600F7B10051E076 /* VertoMessagesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VertoMessagesTests.swift; sourceTree = "<group>"; };
 		B39121EC2602F22F0051E076 /* SocketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketTests.swift; sourceTree = "<group>"; };
+		AAB1000000000000000000A2 /* SocketConnectionTimeoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketConnectionTimeoutTests.swift; sourceTree = "<group>"; };
 		B391220B2604D9C50051E076 /* PeerConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerConnectionTests.swift; sourceTree = "<group>"; };
 		B39122112604FBC00051E076 /* TestConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConstants.swift; sourceTree = "<group>"; };
 		B391221F260502650051E076 /* CallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallTests.swift; sourceTree = "<group>"; };
@@ -787,6 +789,7 @@
 			isa = PBXGroup;
 			children = (
 				B39121EC2602F22F0051E076 /* SocketTests.swift */,
+				AAB1000000000000000000A2 /* SocketConnectionTimeoutTests.swift */,
 			);
 			path = Socket;
 			sourceTree = "<group>";
@@ -1248,6 +1251,7 @@
 				B39121E72600F7B10051E076 /* VertoMessagesTests.swift in Sources */,
 				99D717762D6E229800471D44 /* TelnyxRTCLoggerTests.swift in Sources */,
 				B39121ED2602F22F0051E076 /* SocketTests.swift in Sources */,
+				AAB1000000000000000000A1 /* SocketConnectionTimeoutTests.swift in Sources */,
 				B39122122604FBC00051E076 /* TestConstants.swift in Sources */,
 				9906F63B2E391F5C00A02FE7 /* TxClientReconnectTimeoutTests.swift in Sources */,
 					AA0002012F0F0A0100000001 /* TxClientSocketErrorTests.swift in Sources */,

--- a/TelnyxRTC/Telnyx/Services/Socket.swift
+++ b/TelnyxRTC/Telnyx/Services/Socket.swift
@@ -38,19 +38,23 @@ class Socket {
         cancelConnectionTimeout()
         
         var request = URLRequest(url: signalingServer)
+        // Keep the underlying URLRequest timeout aligned with the watchdog interval
+        // (configurable via setConnectionTimeout, minimum 5s). Previously this was
+        // overwritten to 120s, which let a stalled handshake hang on the kernel's TCP
+        // retransmit backoff with no recovery.
         request.timeoutInterval = connectionTimeout
         let pinner = FoundationSecurity(allowSelfSigned: true) // don't validate SSL certificates
         self.signalingServer = signalingServer
-        
+
         self.socket = WebSocket(request: request, certPinner: pinner)
         self.socket?.delegate = self
-        self.socket?.request.timeoutInterval = TimeInterval(120)
-        
-        // Only start timeout timer if we can fallback to auto (i.e., not already on auto)
-        if shouldFallbackToAuto(signalingServer: signalingServer) {
-            startConnectionTimeout()
-        }
-        
+
+        // Always start the connection-timeout watchdog. If the handshake stalls (e.g. a
+        // lost SYN on cellular after a VoIP push), the timer fires and triggers a redial:
+        // falling back to the auto region when on a specific region, otherwise redialing
+        // the same signaling server.
+        startConnectionTimeout()
+
         self.socket?.connect()
     }
     
@@ -173,30 +177,41 @@ extension Socket : WebSocketDelegate {
         connectionTimeout = max(5.0, timeout)
     }
     
-    /// Starts the connection timeout timer (only when not on auto region)
+    /// Indicates whether the connection-timeout watchdog is currently armed.
+    var isConnectionTimeoutActive: Bool {
+        return connectionTimeoutTimer != nil
+    }
+
+    /// Starts the connection timeout watchdog timer.
     private func startConnectionTimeout() {
         connectionTimeoutTimer = Timer.scheduledTimer(withTimeInterval: connectionTimeout, repeats: false) { [weak self] _ in
             self?.handleConnectionTimeout()
         }
     }
-    
+
     /// Cancels the connection timeout timer
     private func cancelConnectionTimeout() {
         connectionTimeoutTimer?.invalidate()
         connectionTimeoutTimer = nil
     }
-    
-    /// Handles connection timeout by triggering fallback mechanism
-    private func handleConnectionTimeout() {
+
+    /// Handles connection timeout by redialing.
+    ///
+    /// When the socket is on a specific region that can fall back, the redial targets
+    /// the auto region. Otherwise (e.g. the default `wss://rtc.telnyx.com` URL) it
+    /// redials the same signaling server.
+    func handleConnectionTimeout() {
         Logger.log.e(message: "Socket:: Connection timeout after \(connectionTimeout) seconds")
-        
+
         // Mark as not connected and disconnect socket
         isConnected = false
         socket?.disconnect()
-        
-        // Trigger fallback to auto region (we know we can fallback since timer only starts when shouldFallbackToAuto is true)
-        Logger.log.i(message: "Socket:: Triggering fallback to auto region due to timeout")
-        delegate?.onSocketDisconnected(reconnect: true, region: .auto)
+
+        // Fall back to the auto region only when we're on a fallback-able region;
+        // otherwise redial the same server (region: nil).
+        let redialRegion: Region? = shouldFallbackToAuto(signalingServer: signalingServer) ? .auto : nil
+        Logger.log.i(message: "Socket:: Triggering redial due to timeout (region: \(String(describing: redialRegion)))")
+        delegate?.onSocketDisconnected(reconnect: true, region: redialRegion)
     }
     
     

--- a/TelnyxRTCTests/Socket/SocketConnectionTimeoutTests.swift
+++ b/TelnyxRTCTests/Socket/SocketConnectionTimeoutTests.swift
@@ -1,0 +1,72 @@
+//
+//  SocketConnectionTimeoutTests.swift
+//  TelnyxRTCTests
+//
+//  Created by Claude on 10/06/2026.
+//  Copyright © 2026 Telnyx LLC. All rights reserved.
+//
+
+import XCTest
+@testable import TelnyxRTC
+
+/// Tests for the unconditional connection-timeout watchdog and redial behavior.
+///
+/// Regression coverage for the bug where `Socket.connect()` never timed out on the
+/// default prod URL (`wss://rtc.telnyx.com`): the 5s watchdog only started when a
+/// region fallback was possible, and `"rtc"` is not a valid region, so a stalled
+/// handshake (e.g. a lost SYN on cellular after a VoIP push) sat on the kernel's TCP
+/// retransmit backoff with no redial.
+class SocketConnectionTimeoutTests: XCTestCase {
+
+    private var delegate: MockRegionSocketDelegate!
+
+    override func setUpWithError() throws {
+        delegate = MockRegionSocketDelegate()
+    }
+
+    override func tearDownWithError() throws {
+        delegate = nil
+    }
+
+    /// On the default prod URL the watchdog must still fire and redial the same
+    /// server (no region override), since there is no region to fall back from.
+    func testConnectionTimeoutRedialsOnDefaultProdURL() {
+        let socket = Socket()
+        socket.delegate = delegate
+        socket.signalingServer = InternalConfig.default.prodSignalingServer
+
+        socket.handleConnectionTimeout()
+
+        XCTAssertTrue(delegate.onSocketDisconnectedCalled, "Timeout should trigger a disconnect/redial")
+        XCTAssertEqual(delegate.lastReconnectValue, true, "Timeout should request a reconnect")
+        XCTAssertNil(delegate.lastRegionValue, "Default prod URL has no region to fall back from; should redial the same server (region nil)")
+    }
+
+    /// On a specific regional URL the watchdog must redial with a fallback to the
+    /// auto region (preserving the original fallback behavior).
+    func testConnectionTimeoutFallsBackToAutoForRegionalURL() {
+        let socket = Socket()
+        socket.delegate = delegate
+        socket.signalingServer = URL(string: "wss://eu.rtc.telnyx.com")!
+
+        socket.handleConnectionTimeout()
+
+        XCTAssertTrue(delegate.onSocketDisconnectedCalled, "Timeout should trigger a disconnect/redial")
+        XCTAssertEqual(delegate.lastReconnectValue, true, "Timeout should request a reconnect")
+        XCTAssertEqual(delegate.lastRegionValue, .auto, "Regional URL should fall back to the auto region")
+    }
+
+    /// The watchdog timer must start for every connect, including the default prod
+    /// URL where no region fallback is possible.
+    func testConnectionTimeoutStartsOnDefaultProdURL() {
+        let socket = Socket()
+        socket.delegate = delegate
+        socket.connect(signalingServer: InternalConfig.default.prodSignalingServer)
+
+        // The timer is scheduled synchronously inside connect(), before the network
+        // can respond, so it must be active immediately on return.
+        XCTAssertTrue(socket.isConnectionTimeoutActive, "Watchdog timer must start unconditionally, even on the default prod URL")
+
+        socket.disconnect(reconnect: false)
+    }
+}


### PR DESCRIPTION
<!-- Ticket details and link -->
[WEBRTC-XXX - Socket dial never times out on default prod URL, breaks answer-from-push](https://telnyx.atlassian.net/browse/WEBRTC-XXX)

---

`Socket.connect()` set `request.timeoutInterval` to 5s and then immediately overwrote it to 120s, and only armed the 5s connection-timeout watchdog (`startConnectionTimeout()`) when a region fallback was possible. On the default `wss://rtc.telnyx.com` URL, `shouldFallbackToAuto()` returns `false` because the host's first label `"rtc"` is not a valid `Region`, so **no watchdog ran and no retry occurred**.

The result: when the app is woken by a VoIP push on cellular and the first SYN is lost, the dial sits on the kernel's TCP retransmit backoff with no recovery. The user answers, the INVITE can't re-attach in time, and the call dies with `USER_BUSY` while the UI still shows "Connecting…". Reported as >10s to socket-connected in ~29% of cold-start answers, never connecting in ~12%.

## :older_man: :baby: Behaviors

### Before changes
- On the default `wss://rtc.telnyx.com` URL the connection-timeout watchdog never started, and the underlying request timeout was hardcoded to 120s.
- A stalled handshake had no timeout and no redial — the dial hung until the 120s request timeout (or never recovered in time for the push answer window).

### After changes
- The 5s connection-timeout watchdog is **always** armed on connect.
- The underlying request timeout tracks the configurable `connectionTimeout` (minimum 5s) instead of a hardcoded 120s.
- On timeout the socket redials: it falls back to the auto region when on a specific region (preserved behavior), and otherwise redials the same signaling server. This recovers a stalled handshake within ~5s, restoring answer-from-push on cold start.

## TODO
- Replace the placeholder `WEBRTC-XXX` ticket reference with the real ticket.

## ✋ Manual testing
1. Cold-start the demo app and answer an incoming VoIP push call on a cellular connection (ideally a lossy/poor network where SYN loss is likely).
2. Confirm the call connects rather than failing with `USER_BUSY` while showing "Connecting…".
3. Force a stalled handshake (e.g. block the signaling host / drop packets) and verify the logs show `Socket:: Connection timeout after 5.0 seconds` followed by `Socket:: Triggering redial due to timeout (region: nil)` on the default prod URL, and `(region: Optional(...Region.auto))` when on a specific region.
4. Confirm normal connects on the default prod URL are unaffected (watchdog is cancelled on `.connected`).

## Known Issues
- **Unbounded redial on a permanently stalled handshake.** With the watchdog now always on, a server that never completes the handshake will be redialed every ~5s + `RECONNECT_BUFFER` indefinitely. This matches the existing region-fallback path's behavior (it was already unbounded there) and is the intended "redial unconditionally" fix, but if a bounded retry count or backoff is preferred, that's a straightforward follow-up.

## Screenshots
N/A — internal reconnection behavior, no UI change.

## 🔄 iOS Regression Process

This is a bugfix; only the reconnection-relevant tests apply.

### 🔁 General Reconnection Scenarios
- [ ] Establish call -> Drop network -> Re-establish connection within timeframe
  - [ ] On WiFi
  - [ ] On 4G/Mobile Network
- [ ] Establish call -> Drop network -> Fail to re-establish connection within timeframe (verify dropped state)
  - [ ] On WiFi
  - [ ] On 4G/Mobile Network

### Notifications (Answer-from-push)
- [ ] Receive push notification (App Terminated) -> Accept Call on Mobile Network (cold start)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
