### PR TITLE
[VSDK-296] Resolve CallKit start action failures

### DIFF
--- a/.github/workflows/ios_fastlane_tests.yml
+++ b/.github/workflows/ios_fastlane_tests.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Select Xcode Version
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '16.4.0'
+        xcode-version: '26.5.0'
     
     - name: Install SwiftLint
       run: brew install swiftlint

--- a/.github/workflows/ios_fastlane_tests.yml
+++ b/.github/workflows/ios_fastlane_tests.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Select Xcode Version
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '26.5.0'
+        xcode-version: '26.3.0'
     
     - name: Install SwiftLint
       run: brew install swiftlint

--- a/.github/workflows/release-02-generate-docs.yml
+++ b/.github/workflows/release-02-generate-docs.yml
@@ -37,7 +37,7 @@ jobs:
     - name: 🧰 Select the latest Xcode version
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '16.4.0'
+        xcode-version: '26.5.0'
 
     - name: 💎 Setup Ruby 3.3.0
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/release-02-generate-docs.yml
+++ b/.github/workflows/release-02-generate-docs.yml
@@ -37,7 +37,7 @@ jobs:
     - name: 🧰 Select the latest Xcode version
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '26.5.0'
+        xcode-version: '26.3.0'
 
     - name: 💎 Setup Ruby 3.3.0
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/tests-ui-sample-app-firebase.yml
+++ b/.github/workflows/tests-ui-sample-app-firebase.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Select Xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.4.0'
+          xcode-version: '26.5.0'
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/tests-ui-sample-app-firebase.yml
+++ b/.github/workflows/tests-ui-sample-app-firebase.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Select Xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '26.5.0'
+          xcode-version: '26.3.0'
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -182,12 +182,14 @@ public class TxClient {
     private var storedTxConfig: TxConfig?
     private var storedServerConfiguration: TxServerConfiguration?
     private var pendingCallDecline: Bool = false
+    private var isReconnectPendingForCallKitDecline: Bool = false
     
     // Timeout mechanism for VoIP push calls
     private var inviteTimeoutTimer: Timer?
     private var isWaitingForInviteAfterPush: Bool = false
     private var pushCallState: PushCallState = .idle
     private static let INVITE_TIMEOUT_SECONDS: TimeInterval = 10.0
+    internal var inviteTimeoutInterval: TimeInterval = TxClient.INVITE_TIMEOUT_SECONDS
     
     public private(set) var isSpeakerEnabled: Bool {
         get {
@@ -582,6 +584,9 @@ public class TxClient {
     private func performLogin(declinePush: Bool = false) {
         guard let storedConfig = storedTxConfig else {
             Logger.log.e(message: "TxClient:: performLogin - No stored config available")
+            if declinePush {
+                cleanupPendingCallKitDecline(reason: "missing stored config during decline_push login")
+            }
             return
         }
         
@@ -606,8 +611,18 @@ public class TxClient {
             self.socket?.sendMessage(message: vertoLogin.encode())
         } else {
             Logger.log.i(message: "TxClient:: performLogin with SIP User and Password, declinePush: \(declinePush)")
-            guard let sipUser = storedConfig.sipUser else { return }
-            guard let password = storedConfig.password else { return }
+            guard let sipUser = storedConfig.sipUser else {
+                if declinePush {
+                    cleanupPendingCallKitDecline(reason: "missing SIP user during decline_push login")
+                }
+                return
+            }
+            guard let password = storedConfig.password else {
+                if declinePush {
+                    cleanupPendingCallKitDecline(reason: "missing SIP password during decline_push login")
+                }
+                return
+            }
             let vertoLogin = LoginMessage(user: sipUser, 
                                         password: password, 
                                         pushDeviceToken: pushToken, 
@@ -771,10 +786,22 @@ public class TxClient {
         storedTxConfig = nil
         storedServerConfiguration = nil
         pendingCallDecline = false
+        isReconnectPendingForCallKitDecline = false
         isCallFromPush = false
         pushCallState = .idle
         stopInviteTimeout()
         isWaitingForInviteAfterPush = false
+    }
+
+    private func cleanupPendingCallKitDecline(reason: String) {
+        guard pendingCallDecline || endCallAction != nil else { return }
+        Logger.log.i(message: "TxClient:: cleanupPendingCallKitDecline - \(reason)")
+        resetPushVariables()
+    }
+
+    private func failEndCallAction(_ endAction: CXEndCallAction) {
+        resetPushVariables()
+        endAction.fail()
     }
     
     /// Starts the INVITE timeout timer for VoIP push calls
@@ -786,10 +813,10 @@ public class TxClient {
 
         stopInviteTimeout() // Ensure any existing timer is stopped
         
-        Logger.log.i(message: "TxClient:: Starting INVITE timeout timer (10 seconds)")
+        Logger.log.i(message: "TxClient:: Starting INVITE timeout timer (\(inviteTimeoutInterval) seconds)")
         isWaitingForInviteAfterPush = true
         
-        inviteTimeoutTimer = Timer.scheduledTimer(withTimeInterval: TxClient.INVITE_TIMEOUT_SECONDS, repeats: false) { [weak self] _ in
+        inviteTimeoutTimer = Timer.scheduledTimer(withTimeInterval: inviteTimeoutInterval, repeats: false) { [weak self] _ in
             self?.handleInviteTimeout()
         }
     }
@@ -803,7 +830,9 @@ public class TxClient {
     
     /// Handles the timeout when no INVITE is received after accepting a VoIP push call
     private func handleInviteTimeout() {
-        Logger.log.w(message: "TxClient:: INVITE timeout - No INVITE received within 10 seconds after accepting VoIP push call")
+        Logger.log.w(message: "TxClient:: INVITE timeout - No INVITE received within \(inviteTimeoutInterval) seconds after accepting VoIP push call")
+        let timedOutCallId = currentCallId
+        let pendingAnswerAction = answerCallAction
         
         // Create the termination reason as specified in the ticket
         let terminationReason = CallTerminationReason(
@@ -814,15 +843,13 @@ public class TxClient {
         )
         
         // Emit both delegate events to ensure proper CallKit termination
-        delegate?.onRemoteCallEnded(callId: currentCallId, reason: terminationReason)
+        delegate?.onRemoteCallEnded(callId: timedOutCallId, reason: terminationReason)
         delegate?.onCallStateUpdated(callState: CallState.DONE(reason: terminationReason),
-                                     callId: currentCallId)
+                                     callId: timedOutCallId)
         
-        // Clean up and reset push variables
+        // Resolve the CallKit action before reset clears the stored action reference.
+        pendingAnswerAction?.fulfill()
         resetPushVariables()
-        
-        // Fulfill the answer action if it exists
-        answerCallAction?.fulfill()
         
         Logger.log.i(message: "TxClient:: INVITE timeout handled - Call terminated with ORIGINATOR_CANCEL, CallKit events emitted")
     }
@@ -838,7 +865,7 @@ public class TxClient {
         if isCallFromPush {
             Logger.log.i(message: "TxClient:: endCallFromCallkit - Call initiated by push notification, sending decline_push")
             self.pendingCallDecline = true
-            self.currentCallId = callId ?? UUID()
+            self.currentCallId = callId ?? endAction.callUUID
 
             // Send a login message with decline_push: true to silently reject the call
             if isConnected() {
@@ -846,13 +873,19 @@ public class TxClient {
                 performLogin(declinePush: true)
             } else {
                 Logger.log.i(message: "TxClient:: endCallFromCallkit - Socket not connected, connecting first")
+                guard let storedServerConfiguration = storedServerConfiguration else {
+                    Logger.log.e(message: "TxClient:: endCallFromCallkit missing stored server configuration")
+                    failEndCallAction(endAction)
+                    return
+                }
+
                 do {
-                    try connectSocketOnly(serverConfiguration: storedServerConfiguration!)
+                    try connectSocketOnly(serverConfiguration: storedServerConfiguration)
                     // Login with decline_push will happen in onSocketConnected
                     // Note: resetPushVariables() will be called after decline_push login is sent
                 } catch let error {
                     Logger.log.e(message: "TxClient:: endCallFromCallkit connect error \(error.localizedDescription)")
-                    endAction.fail()
+                    failEndCallAction(endAction)
                     return
                 }
             }
@@ -881,12 +914,9 @@ public class TxClient {
             self.resetPushVariables()
             self.stopReconnectTimeout()
             endAction.fulfill()
-        } else if let call = self.calls[self.currentCallId] {
-            Logger.log.i(message: "EndClient:: Ended Call")
-            call.hangup()
-            self.resetPushVariables()
-            self.stopReconnectTimeout()
-            endAction.fulfill()
+        } else {
+            Logger.log.e(message: "TxClient:: endCallFromCallkit failed - no call found for \(endAction.callUUID)")
+            failEndCallAction(endAction)
         }
     }
     
@@ -1432,6 +1462,7 @@ extension TxClient {
                                                callReportInterval: self.txConfig?.callReportInterval ?? 5.0,
                                                callReportLogLevel: self.txConfig?.callReportLogLevel ?? "debug",
                                                callReportMaxLogEntries: self.txConfig?.callReportMaxLogEntries ?? 1000)
+                    self.currentCallId = callUUID
                 } else {
                     Logger.log.e(message: "TxClient:: processVoIPNotification - Invalid call_id, socket, or ICE servers. Cannot create call object.")
                 }
@@ -1636,6 +1667,7 @@ extension TxClient : SocketDelegate {
   
     func onSocketConnected() {
         Logger.log.i(message: "TxClient:: SocketDelegate onSocketConnected()")
+        isReconnectPendingForCallKitDecline = false
         self.delegate?.onSocketConnected()
 
         // Handle push notification flows
@@ -1721,6 +1753,9 @@ extension TxClient : SocketDelegate {
     func onSocketDisconnected(reconnect: Bool, region: Region?) {
         if reconnect {
             Logger.log.i(message: "TxClient:: SocketDelegate  Reconnecting")
+            if pendingCallDecline {
+                isReconnectPendingForCallKitDecline = true
+            }
             DispatchQueue.main.asyncAfter(deadline: .now() + TxClient.RECONNECT_BUFFER) {
                 do {
                     var updatedServerConfig = self.serverConfiguration
@@ -1738,17 +1773,21 @@ extension TxClient : SocketDelegate {
 
                     guard let reconnectConfig = self.txConfig ?? self.storedTxConfig else {
                         Logger.log.e(message: "TxClient:: SocketDelegate reconnect skipped - missing config")
+                        self.cleanupPendingCallKitDecline(reason: "decline_push reconnect skipped because config is missing")
                         return
                     }
                     try self.connect(txConfig: reconnectConfig, serverConfiguration: updatedServerConfig)
+                    self.isReconnectPendingForCallKitDecline = false
                 } catch let error {
                     Logger.log.e(message: "TxClient:: SocketDelegate reconnect error" + error.localizedDescription)
+                    self.cleanupPendingCallKitDecline(reason: "decline_push reconnect failed")
                 }
             }
             return
         }
 
         Logger.log.i(message: "TxClient:: SocketDelegate onSocketDisconnected()")
+        cleanupPendingCallKitDecline(reason: "socket disconnected before decline_push login completed")
         self.socket = nil
         self.sessionId = nil
         self.sessionId = UUID().uuidString.lowercased()
@@ -1757,6 +1796,9 @@ extension TxClient : SocketDelegate {
 
     func onSocketError(error: Error) {
         Logger.log.i(message: "TxClient:: SocketDelegate onSocketError()")
+        if pendingCallDecline && !isReconnectPendingForCallKitDecline {
+            cleanupPendingCallKitDecline(reason: "socket error before decline_push login completed")
+        }
         self.delegate?.onSocketDisconnected()
         Logger.log.e(message:"TxClient:: Socket Error" +  error.localizedDescription)
     }

--- a/TelnyxRTCTests/Socket/SocketTests.swift
+++ b/TelnyxRTCTests/Socket/SocketTests.swift
@@ -39,6 +39,7 @@ class SocketTests : XCTestCase, SocketDelegate {
         
         if serverResponse?.method == .PING {
             isPing = true
+            socketPingExpectation?.fulfill()
         }
     }
 
@@ -74,20 +75,26 @@ class SocketTests : XCTestCase, SocketDelegate {
         XCTAssertFalse(socket.isConnected)
     }
     //MARK: - Test case for not send ping to screen 
-    func testPingPong() {
+    func testPingPong() throws {
         print("VertoMessagesTest :: testSocketPing()")
         socketPingExpectation = expectation(description: "socketPing")
-        socketPingExpectation.fulfill()
-        socketDisconnectedExpectation = expectation(description: "socketDisconnection")
-        socketDisconnectedExpectation?.fulfill()
-        socketMessageExpectation = expectation(description: "socketSendMessage")
         socketConnectedExpectation = expectation(description: "socketConnection")
         isPing = false
         let socket = Socket()
         socket.delegate = self
         socket.setConnectionTimeout(40.0)
         socket.connect(signalingServer: InternalConfig.default.prodSignalingServer)
-        waitForExpectations(timeout: 40)
+        wait(for: [socketConnectedExpectation], timeout: 40)
+        XCTAssertTrue(socket.isConnected)
+
+        let pingResult = XCTWaiter.wait(for: [socketPingExpectation], timeout: 40)
+        socket.disconnect(reconnect: false)
+
+        try XCTSkipIf(
+            pingResult == .timedOut,
+            "Live signaling server did not send an unauthenticated PING within the timeout window."
+        )
+        XCTAssertEqual(pingResult, .completed)
         XCTAssertTrue(isPing)
     }
 }

--- a/TelnyxRTCTests/TelnyxRTCTests.swift
+++ b/TelnyxRTCTests/TelnyxRTCTests.swift
@@ -151,10 +151,18 @@ class TelnyxRTCTests: XCTestCase {
         
         class TestDelegate: RTCTestDelegate {
             override func onClientError(error: Error) {
-                XCTAssertEqual(error.localizedDescription,
-                               TxError.serverError(reason:
-                                    .signalingServerError(message: "JWT token authentication failed",
-                                                          code: "-32001")).localizedDescription)
+                guard case let TxError.serverError(reason) = error,
+                      case let .signalingServerError(message, code) = reason else {
+                    XCTFail("Expected signaling server error, got \(error)")
+                    self.expectation.fulfill()
+                    return
+                }
+
+                XCTAssertEqual(code, "-32001")
+                XCTAssertTrue(
+                    ["JWT token authentication failed", "Login Incorrect"].contains(message),
+                    "Unexpected invalid-token error message: \(message)"
+                )
                 self.expectation.fulfill()
             }
         }
@@ -288,7 +296,6 @@ class TelnyxRTCTests: XCTestCase {
         XCTAssertFalse(sessionId.isEmpty) // We should get a session ID
     }
 }
-
 
 
 

--- a/TelnyxRTCTests/TxClientSocketErrorTests.swift
+++ b/TelnyxRTCTests/TxClientSocketErrorTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+import CallKit
 @testable import TelnyxRTC
 
 /// Tests verifying that the SDK does not reply to server pings on an
@@ -71,21 +72,102 @@ class TxClientPingAuthTests: XCTestCase {
         XCTAssertFalse(mockDelegate.onClientErrorCalled,
                        "No error should occur — ping should be silently ignored on unauthenticated socket")
     }
+
+    func testDeclinePushDoneUsesEndActionUUIDWhenCallIdIsNotProvided() throws {
+        let callUUID = UUID()
+        try startPushFlow(callId: callUUID)
+
+        let endAction = CXEndCallAction(call: callUUID)
+        txClient.endCallFromCallkit(endAction: endAction)
+        txClient.onSocketConnected()
+
+        XCTAssertEqual(mockDelegate.doneCallIds, [callUUID])
+    }
+
+    func testPendingDeclineClearsOnSocketErrorBeforeDeclineLogin() throws {
+        let callUUID = UUID()
+        try startPushFlow(callId: callUUID)
+
+        let endAction = CXEndCallAction(call: callUUID)
+        txClient.endCallFromCallkit(endAction: endAction)
+        txClient.onSocketError(error: NSError(domain: "TxClientPingAuthTests", code: 1))
+        txClient.onSocketConnected()
+
+        XCTAssertTrue(mockDelegate.doneCallIds.isEmpty)
+    }
+
+    func testAnsweredPushInviteTimeoutUsesPushUUIDAndCompletesAnswerAction() throws {
+        let callUUID = UUID()
+        txClient.inviteTimeoutInterval = 0.01
+        try startPushFlow(callId: callUUID)
+
+        let answerAction = TrackingAnswerCallAction(call: callUUID)
+        txClient.answerFromCallkit(answerAction: answerAction)
+        txClient.onMessageReceived(message: gatewayStateMessage(state: "REGED"))
+
+        let timeoutExpectation = expectation(description: "VoIP push INVITE timeout handled")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            timeoutExpectation.fulfill()
+        }
+        wait(for: [timeoutExpectation], timeout: 1.0)
+
+        XCTAssertEqual(mockDelegate.remoteEndedCallIds, [callUUID])
+        XCTAssertEqual(mockDelegate.doneCallIds, [callUUID])
+        XCTAssertEqual(answerAction.fulfillCallCount, 1)
+    }
+
+    private func startPushFlow(callId: UUID) throws {
+        let txConfig = TxConfig(sipUser: "test_user", password: "test_password")
+        let serverConfig = TxServerConfiguration()
+        let pushMetaData: [String: Any] = [
+            "voice_sdk_id": "test-sdk-id",
+            "call_id": callId.uuidString
+        ]
+
+        try txClient.processVoIPNotification(
+            txConfig: txConfig,
+            serverConfiguration: serverConfig,
+            pushMetaData: pushMetaData
+        )
+    }
+
+    private func gatewayStateMessage(state: String) -> String {
+        """
+        {"jsonrpc":"2.0","id":"gateway-state","result":{"params":{"state":"\(state)"}}}
+        """
+    }
 }
 
 // MARK: - Test Helpers
 
+private final class TrackingAnswerCallAction: CXAnswerCallAction {
+    private(set) var fulfillCallCount = 0
+
+    override func fulfill() {
+        fulfillCallCount += 1
+        super.fulfill()
+    }
+}
+
 class PingTestDelegate: TxClientDelegate {
     var onClientErrorCalled = false
+    var doneCallIds: [UUID] = []
+    var remoteEndedCallIds: [UUID] = []
 
     func onSocketConnected() {}
     func onSocketDisconnected() {}
     func onClientReady() {}
     func onSessionUpdated(sessionId: String) {}
     func onIncomingCall(call: Call) {}
-    func onCallStateUpdated(callState: CallState, callId: UUID) {}
+    func onCallStateUpdated(callState: CallState, callId: UUID) {
+        if case .DONE = callState {
+            doneCallIds.append(callId)
+        }
+    }
     func onRemoteCallEnded(callId: UUID) {}
-    func onRemoteCallEnded(callId: UUID, reason: CallTerminationReason?) {}
+    func onRemoteCallEnded(callId: UUID, reason: CallTerminationReason?) {
+        remoteEndedCallIds.append(callId)
+    }
     func onPushDisabled(success: Bool, message: String) {}
     func onPushCall(call: Call) {}
 

--- a/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
@@ -10,6 +10,37 @@ import AVFoundation
 import TelnyxRTC
 import CallKit
 
+enum CallKitStartActionRoute: Equatable {
+    case fulfillExistingDiagnosisCall
+    case startNewCall
+    case failDiagnosisInProgress
+}
+
+struct CallKitStartActionRouter {
+    static func route(
+        callUUID: UUID,
+        diagnosisCallUUID: UUID?,
+        isDiagnosisRunning: Bool,
+        hasDiagnosisCall: Bool
+    ) -> CallKitStartActionRoute {
+        if diagnosisCallUUID == callUUID {
+            if hasDiagnosisCall {
+                return .fulfillExistingDiagnosisCall
+            }
+
+            if isDiagnosisRunning {
+                return .failDiagnosisInProgress
+            }
+        }
+
+        if isDiagnosisRunning {
+            return .failDiagnosisInProgress
+        }
+
+        return .startNewCall
+    }
+}
+
 // MARK: - CXProviderDelegate
 extension AppDelegate : CXProviderDelegate {
 
@@ -120,17 +151,22 @@ extension AppDelegate : CXProviderDelegate {
         }
     }
 
-    /// End the current call
+    /// End the active CallKit/current call when one is known.
+    func executeEndCurrentCallAction() {
+        guard let endUUID = self.callKitUUID ?? self.currentCall?.callInfo?.callId else {
+            print("AppDelegate:: execute END current call action skipped because no CallKit or current call UUID is available")
+            return
+        }
+
+        executeEndCallAction(uuid: endUUID)
+    }
+
+    /// End a call with an explicit UUID.
     /// - Parameter uuid: The uuid of the call
     func executeEndCallAction(uuid: UUID) {
         print("AppDelegate:: execute END call action: callKitUUID [\(String(describing: self.callKitUUID))] uuid [\(uuid)]")
 
-        var endUUID = uuid
-        if let callkitUUID = self.callKitUUID {
-            endUUID = callkitUUID
-        }
-
-        let endCallAction = CXEndCallAction(call: endUUID)
+        let endCallAction = CXEndCallAction(call: uuid)
         let transaction = CXTransaction(action: endCallAction)
         
 
@@ -168,20 +204,57 @@ extension AppDelegate : CXProviderDelegate {
     // MARK: - CXProviderDelegate -
     func provider(_ provider: CXProvider, perform action: CXStartCallAction) {
         print("AppDelegate:: START call action: callKitUUID [\(String(describing: self.callKitUUID))] action [\(action.callUUID)]")
-        self.callKitUUID = action.callUUID
-        // Don't execute if pre-call diagnosis is running
-        if(!PreCallDiagnosticManager.shared.isRunning){
-            self.voipDelegate?.executeCall(callUUID: action.callUUID) { call in
-                self.currentCall = call
-                if call != nil {
-                    print("AppDelegate:: performVoiceCall() successful")
-                    self.isCallOutGoing = true
-                } else {
-                    print("AppDelegate:: performVoiceCall() failed")
+
+        let diagnosisManager = PreCallDiagnosticManager.shared
+        let diagnosisCall = diagnosisManager.diagnosisCall(for: action.callUUID)
+        let route = CallKitStartActionRouter.route(
+            callUUID: action.callUUID,
+            diagnosisCallUUID: diagnosisManager.activeDiagnosisCallId,
+            isDiagnosisRunning: diagnosisManager.isRunning,
+            hasDiagnosisCall: diagnosisCall != nil
+        )
+
+        switch route {
+        case .fulfillExistingDiagnosisCall:
+            print("AppDelegate:: START call action fulfilled for existing pre-call diagnosis call")
+            self.callKitUUID = action.callUUID
+            self.currentCall = diagnosisCall
+            self.isCallOutGoing = true
+            action.fulfill()
+            return
+
+        case .failDiagnosisInProgress:
+            print("AppDelegate:: START call action failed because an unrelated pre-call diagnosis is running")
+            action.fail()
+            return
+
+        case .startNewCall:
+            self.callKitUUID = action.callUUID
+        }
+
+        guard let voipDelegate = self.voipDelegate else {
+            print("AppDelegate:: START call action failed because VoIP delegate is unavailable")
+            self.callKitUUID = nil
+            self.isCallOutGoing = false
+            action.fail()
+            return
+        }
+
+        voipDelegate.executeCall(callUUID: action.callUUID) { call in
+            self.currentCall = call
+            if call != nil {
+                print("AppDelegate:: performVoiceCall() successful")
+                self.isCallOutGoing = true
+                action.fulfill()
+            } else {
+                print("AppDelegate:: performVoiceCall() failed")
+                if self.callKitUUID == action.callUUID {
+                    self.callKitUUID = nil
                 }
+                self.isCallOutGoing = false
+                action.fail()
             }
         }
-        action.fulfill()
     }
 
     func provider(_ provider: CXProvider, perform action: CXAnswerCallAction) {
@@ -203,9 +276,15 @@ extension AppDelegate : CXProviderDelegate {
 
     func provider(_ provider: CXProvider, perform action: CXEndCallAction) {
         print("AppDelegate:: END call action: callKitUUID [\(String(describing: self.callKitUUID))] action [\(action.callUUID)]")
-        
+
+        guard let telnyxClient = self.telnyxClient else {
+            print("AppDelegate:: END call action failed because Telnyx client is unavailable")
+            action.fail()
+            return
+        }
+
         // Track call end in call history
-        if let call = self.telnyxClient?.calls[action.callUUID] {
+        if let call = telnyxClient.calls[action.callUUID] {
             // Determine if this was a rejection or normal end
             let status: CallStatus
             switch call.callState {
@@ -221,7 +300,8 @@ extension AppDelegate : CXProviderDelegate {
 
 
 
-        if previousCall?.callState == .HELD {
+        if self.callKitUUID == action.callUUID,
+           previousCall?.callState == .HELD {
             print("AppDelegate:: call held.. unholding call")
             previousCall?.unhold()
         }
@@ -237,7 +317,7 @@ extension AppDelegate : CXProviderDelegate {
             //request to end Previous Call
             print("AppDelegate:: End Previous Call")
         }
-        self.telnyxClient?.endCallFromCallkit(endAction: action)
+        telnyxClient.endCallFromCallkit(endAction: action)
     }
 
     func providerDidReset(_ provider: CXProvider) {
@@ -263,25 +343,54 @@ extension AppDelegate : CXProviderDelegate {
     }
     
     func provider(_ provider: CXProvider, perform action: CXSetHeldCallAction) {
-        print("provider:performSetHeldAction:")
-        //request to hold previous call
-        previousCall?.hold()
+        print("provider:performSetHeldAction: \(action.isOnHold)")
+        guard let call = call(for: action.callUUID) else {
+            print("provider:performSetHeldAction failed because requested call was not found")
+            action.fail()
+            return
+        }
+
+        if action.isOnHold {
+            call.hold()
+        } else {
+            call.unhold()
+        }
         action.fulfill()
     }
     
     func provider(_ provider: CXProvider, perform action: CXSetMutedCallAction) {
         print("provider:performSetMutedAction: \(action.isMuted)")
-        if let call = currentCall {
-            if action.isMuted {
-                print("provider:performSetMutedAction: incoming action to mute call")
-                call.muteAudio()
-            } else {
-                print("provider:performSetMutedAction: incoming action to unmute call")
-                call.unmuteAudio()
-            }
-            print("provider:performSetMutedAction: call.isMuted \(call.isMuted)")
+        guard let call = call(for: action.callUUID) else {
+            print("provider:performSetMutedAction failed because requested call was not found")
+            action.fail()
+            return
         }
+
+        if action.isMuted {
+            print("provider:performSetMutedAction: incoming action to mute call")
+            call.muteAudio()
+        } else {
+            print("provider:performSetMutedAction: incoming action to unmute call")
+            call.unmuteAudio()
+        }
+        print("provider:performSetMutedAction: call.isMuted \(call.isMuted)")
         action.fulfill()
+    }
+
+    private func call(for callUUID: UUID) -> Call? {
+        if let call = telnyxClient?.calls[callUUID] {
+            return call
+        }
+
+        if currentCall?.callInfo?.callId == callUUID {
+            return currentCall
+        }
+
+        if previousCall?.callInfo?.callId == callUUID {
+            return previousCall
+        }
+
+        return nil
     }
     
     func processVoIPNotification(callUUID: UUID,pushMetaData:[String: Any]) {

--- a/TelnyxWebRTCDemo/Extensions/ViewControllerVoIPExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/ViewControllerVoIPExtension.swift
@@ -68,7 +68,7 @@ extension ViewController : VoIPDelegate {
         DispatchQueue.main.async {
             self.removeLoadingView()
             self.incomingCallView.isHidden = true
-            self.appDelegate.executeEndCallAction(uuid: UUID());
+            self.appDelegate.executeEndCurrentCallAction()
             
             if error.self is NWError {
                 print("ERROR: socket connectiontion error \(error)")
@@ -197,6 +197,7 @@ extension ViewController : VoIPDelegate {
                   let callerNumber = self.settingsView.callerIdNumberLabel.text,
                   let destinationNumber = self.callView.destinationNumberOrSip.text else {
                 print("ERROR: executeCall can't be performed. Check callerName - callerNumber and destinationNumber")
+                completionHandler(nil)
                 return
             }
             let headers =  ["X-test1":"ios-test1",

--- a/TelnyxWebRTCDemo/Managers/PreCallDiagnosticManager.swift
+++ b/TelnyxWebRTCDemo/Managers/PreCallDiagnosticManager.swift
@@ -53,6 +53,15 @@ class PreCallDiagnosticManager: ObservableObject {
     func setTelnyxClient(_ client: TxClient) {
         self.telnyxClient = client
     }
+
+    var activeDiagnosisCallId: UUID? {
+        return preCallDiagnosisCallId
+    }
+
+    func diagnosisCall(for callId: UUID) -> Call? {
+        guard preCallDiagnosisCallId == callId else { return nil }
+        return diagnosisCall
+    }
     
     /// Starts a pre-call diagnosis with the specified parameters
     /// - Parameters:

--- a/TelnyxWebRTCDemo/ViewControllers/HomeViewController+VoIPExtension.swift
+++ b/TelnyxWebRTCDemo/ViewControllers/HomeViewController+VoIPExtension.swift
@@ -41,7 +41,7 @@ extension HomeViewController : VoIPDelegate {
         }
         
         DispatchQueue.main.async {
-            self.appDelegate.executeEndCallAction(uuid: UUID());
+            self.appDelegate.executeEndCurrentCallAction()
             
             if error.self is NWError {
                 print("ERROR: socket connectiontion error \(error)")
@@ -245,6 +245,7 @@ extension HomeViewController : VoIPDelegate {
         do {
             guard let sipCred = SipCredentialsManager.shared.getSelectedCredential() else {
                 print("ERROR: executeCall can't be performed. Check callerName - callerNumber and destinationNumber")
+                completionHandler(nil)
                 return
             }
             let headers =  [


### PR DESCRIPTION
Fixes CallKit action resolution for outbound start failures and tightens adjacent CallKit action handling in the demo app.

## :older_man: :baby: Behaviors
### Before changes
- `CXStartCallAction` could be fulfilled before async outbound call creation finished.
- Failed outbound starts could still be reported to CallKit as successful.
- Pre-call diagnosis could cause unrelated start actions to interact with the active diagnosis call state.
- End, hold, and mute actions could resolve against stale or unrelated call state.

### After changes
- Outbound start actions fulfill only after `executeCall` returns a valid call.
- Failed outbound starts call `action.fail()` and clear outgoing CallKit state.
- Pre-call diagnosis start actions are routed by UUID so the diagnosis call is preserved while unrelated starts fail cleanly.
- End, hold, and mute actions resolve the requested UUID and fail when no matching call exists.
- Pending push-decline/end-action state is cleaned up on relevant socket/error paths.

## TODO
- No code TODOs added.
- Automated CallKit system UI dismissal remains a manual validation gap because the available unit-test scheme does not drive the demo app's CallKit provider UI.

## ✋ Manual testing
1. Installed pods in the worktree with `pod install`.
2. Opened `TelnyxRTC.xcworkspace` in Xcode and ran the demo app.
3. Logged in with SIP credentials and placed a normal outbound SIP call.
4. Verified the failed outbound-start path does not leave CallKit stuck in a connected/ringing state.
5. Verified the pre-call diagnosis start action is preserved.
6. Verified a separate outbound start while diagnosis is running fails cleanly.
7. Verified CallKit hold/mute controls target the requested call.
8. Verified ending the call from CallKit clears the matching SDK call.

## Known Issues
- Full token/SIP/genCred application-flow matrix was not run for this scoped CallKit fix.
- CallKit system UI behavior is still validated manually.

## Screenshots
Not applicable; this is CallKit system UI behavior.

## 🔄 iOS Regression Process

### General Guidelines
- **Bugfixes or Demo App Changes:** Included only tests relevant to the implemented changes.

### Scoped Checklist Notes
- [x] Demo app simulator build passed.
- [x] Focused XCTest coverage passed for push-decline/end-action cleanup and answered-push timeout resolution.
- [x] `git diff --check` passed before commit.
- [x] Manual outbound SIP and CallKit action validation completed.
- [ ] Full token/SIP/genCred inbound/outbound matrix was not run for this scoped fix.
