### PR TITLE
feat: add TURNS 443 fallback to default ICE servers (VSDK-283 parity)

### DIFF
--- a/TelnyxRTC/Telnyx/InternalConfig.swift
+++ b/TelnyxRTC/Telnyx/InternalConfig.swift
@@ -14,6 +14,7 @@ private let prodHost = "wss://rtc.telnyx.com"
 // UDP preferred for lower latency, TCP as fallback for restrictive firewalls
 private let prodTurnServerUdp = "turn:turn.telnyx.com:3478?transport=udp"
 private let prodTurnTcpUrl = "turn:turn.telnyx.com:3478?transport=tcp"
+private let prodTurns443Url = "turns:turn.telnyx.com:443?transport=tcp"
 private let prodStunUrl = "stun:stun.telnyx.com:3478"
 // UDP TURN server (primary - lower latency)
 private let prodTurnUdp = RTCIceServer(urlStrings: [prodTurnServerUdp],
@@ -23,16 +24,21 @@ private let prodTurnUdp = RTCIceServer(urlStrings: [prodTurnServerUdp],
 private let prodTurnTcp = RTCIceServer(urlStrings: [prodTurnTcpUrl],
                                         username: "testuser",
                                         credential: "testpassword")
+// TURNS 443 server (last-resort fallback for highly restrictive firewalls that only allow outbound HTTPS)
+private let prodTurns443 = RTCIceServer(urlStrings: [prodTurns443Url],
+                                          username: "testuser",
+                                          credential: "testpassword")
 private let prodStun = RTCIceServer(urlStrings: [prodStunUrl])
 // Google STUN server for additional STUN redundancy (aligned with JS WebRTC SDK)
 private let googleStun = RTCIceServer(urlStrings: ["stun:stun.l.google.com:19302"])
-private let prodIceServers = [prodStun, googleStun, prodTurnUdp, prodTurnTcp]
+private let prodIceServers = [prodStun, googleStun, prodTurnUdp, prodTurnTcp, prodTurns443]
 
 // MARK: - Development Servers
 private let developmentHost = "wss://rtcdev.telnyx.com"
 // UDP preferred for lower latency, TCP as fallback for restrictive firewalls
 private let devTurnServerUdp = "turn:turndev.telnyx.com:3478?transport=udp"
 private let devTurnTcpUrl = "turn:turndev.telnyx.com:3478?transport=tcp"
+private let devTurns443Url = "turns:turndev.telnyx.com:443?transport=tcp"
 private let devStunUrl = "stun:stundev.telnyx.com:3478"
 // UDP TURN server (primary - lower latency)
 private let devTurnUdp = RTCIceServer(urlStrings: [devTurnServerUdp],
@@ -42,8 +48,12 @@ private let devTurnUdp = RTCIceServer(urlStrings: [devTurnServerUdp],
 private let devTurnTcp = RTCIceServer(urlStrings: [devTurnTcpUrl],
                                        username: "testuser",
                                        credential: "testpassword")
+// TURNS 443 server (last-resort fallback for highly restrictive firewalls that only allow outbound HTTPS)
+private let devTurns443 = RTCIceServer(urlStrings: [devTurns443Url],
+                                          username: "testuser",
+                                          credential: "testpassword")
 private let devStun = RTCIceServer(urlStrings: [devStunUrl])
-private let devIceServers = [devStun, googleStun, devTurnUdp, devTurnTcp]
+private let devIceServers = [devStun, googleStun, devTurnUdp, devTurnTcp, devTurns443]
 
 // Set this to the machine's address which runs the signaling server
 private let defaultSignalingServerUrl = URL(string: prodHost)!

--- a/TelnyxRTC/Telnyx/InternalConfig.swift
+++ b/TelnyxRTC/Telnyx/InternalConfig.swift
@@ -14,7 +14,8 @@ private let prodHost = "wss://rtc.telnyx.com"
 // UDP preferred for lower latency, TCP as fallback for restrictive firewalls
 private let prodTurnServerUdp = "turn:turn.telnyx.com:3478?transport=udp"
 private let prodTurnTcpUrl = "turn:turn.telnyx.com:3478?transport=tcp"
-private let prodTurns443Url = "turns:turn.telnyx.com:443?transport=tcp"
+private let prodTurns443Url = "turns:turn.telnyx.com:443"
+private let prodTurns443SecondaryUrl = "turns:turn2.telnyx.com:443"
 private let prodStunUrl = "stun:stun.telnyx.com:3478"
 // UDP TURN server (primary - lower latency)
 private let prodTurnUdp = RTCIceServer(urlStrings: [prodTurnServerUdp],
@@ -28,17 +29,20 @@ private let prodTurnTcp = RTCIceServer(urlStrings: [prodTurnTcpUrl],
 private let prodTurns443 = RTCIceServer(urlStrings: [prodTurns443Url],
                                           username: "testuser",
                                           credential: "testpassword")
+private let prodTurns443Secondary = RTCIceServer(urlStrings: [prodTurns443SecondaryUrl],
+                                                 username: "testuser",
+                                                 credential: "testpassword")
 private let prodStun = RTCIceServer(urlStrings: [prodStunUrl])
 // Google STUN server for additional STUN redundancy (aligned with JS WebRTC SDK)
 private let googleStun = RTCIceServer(urlStrings: ["stun:stun.l.google.com:19302"])
-private let prodIceServers = [prodStun, googleStun, prodTurnUdp, prodTurnTcp, prodTurns443]
+private let prodIceServers = [prodStun, googleStun, prodTurnUdp, prodTurnTcp, prodTurns443, prodTurns443Secondary]
 
 // MARK: - Development Servers
 private let developmentHost = "wss://rtcdev.telnyx.com"
 // UDP preferred for lower latency, TCP as fallback for restrictive firewalls
 private let devTurnServerUdp = "turn:turndev.telnyx.com:3478?transport=udp"
 private let devTurnTcpUrl = "turn:turndev.telnyx.com:3478?transport=tcp"
-private let devTurns443Url = "turns:turndev.telnyx.com:443?transport=tcp"
+private let devTurns443Url = "turns:turndev.telnyx.com:443"
 private let devStunUrl = "stun:stundev.telnyx.com:3478"
 // UDP TURN server (primary - lower latency)
 private let devTurnUdp = RTCIceServer(urlStrings: [devTurnServerUdp],

--- a/TelnyxRTCTests/TurnServerConfigurationTests.swift
+++ b/TelnyxRTCTests/TurnServerConfigurationTests.swift
@@ -133,7 +133,147 @@ class TurnServerConfigurationTests: XCTestCase {
         XCTAssertTrue(InternalConfig.devTurnServer.contains("transport=udp"), "Development primary TURN server should use UDP transport")
         XCTAssertTrue(InternalConfig.devTurnServerTcp.contains("transport=tcp"), "Development fallback TURN server should use TCP transport")
     }
-    
+
+    // MARK: - TURNS 443 Server Tests (VSDK-503)
+
+    /// Test that production ICE servers contain exactly 5 servers including TURNS 443
+    func testProdIceServersCountIsFive() {
+        let config = InternalConfig.default
+        let iceServers = config.prodWebRTCIceServers
+
+        XCTAssertEqual(iceServers.count, 5, "Production should have exactly 5 ICE servers: STUN, Google STUN, TURN UDP, TURN TCP, TURNS 443")
+    }
+
+    /// Test that development ICE servers contain exactly 5 servers including TURNS 443
+    func testDevIceServersCountIsFive() {
+        let config = InternalConfig.default
+        let iceServers = config.devWebRTCIceServers
+
+        XCTAssertEqual(iceServers.count, 5, "Development should have exactly 5 ICE servers: STUN, Google STUN, TURN UDP, TURN TCP, TURNS 443")
+    }
+
+    /// Test that the 5th production ICE server is TURNS 443
+    func testProdTurns443IsPresent() {
+        let config = InternalConfig.default
+        let iceServers = config.prodWebRTCIceServers
+
+        guard iceServers.count >= 5 else {
+            XCTFail("Production should have at least 5 ICE servers")
+            return
+        }
+
+        let turns443 = iceServers[4]
+        let urls = turns443.urlStrings
+
+        XCTAssertTrue(urls.contains("turns:turn.telnyx.com:443?transport=tcp"),
+                      "5th production ICE server should be TURNS 443 with turns:turn.telnyx.com:443?transport=tcp")
+        XCTAssertEqual(turns443.username, "testuser", "TURNS 443 server should have username 'testuser'")
+        XCTAssertNotNil(turns443.credential, "TURNS 443 server should have a credential set")
+        XCTAssertEqual(turns443.credential, "testpassword", "TURNS 443 server should have credential 'testpassword'")
+    }
+
+    /// Test that the 5th development ICE server is TURNS 443
+    func testDevTurns443IsPresent() {
+        let config = InternalConfig.default
+        let iceServers = config.devWebRTCIceServers
+
+        guard iceServers.count >= 5 else {
+            XCTFail("Development should have at least 5 ICE servers")
+            return
+        }
+
+        let turns443 = iceServers[4]
+        let urls = turns443.urlStrings
+
+        XCTAssertTrue(urls.contains("turns:turndev.telnyx.com:443?transport=tcp"),
+                      "5th development ICE server should be TURNS 443 with turns:turndev.telnyx.com:443?transport=tcp")
+        XCTAssertEqual(turns443.username, "testuser", "TURNS 443 server should have username 'testuser'")
+        XCTAssertNotNil(turns443.credential, "TURNS 443 server should have a credential set")
+        XCTAssertEqual(turns443.credential, "testpassword", "TURNS 443 server should have credential 'testpassword'")
+    }
+
+    /// Test that TURNS 443 is the last entry in both prod and dev arrays
+    func testTurns443IsLastInBothArrays() {
+        let config = InternalConfig.default
+        let prodServers = config.prodWebRTCIceServers
+        let devServers = config.devWebRTCIceServers
+
+        XCTAssertFalse(prodServers.isEmpty, "Production ICE servers should not be empty")
+        XCTAssertFalse(devServers.isEmpty, "Development ICE servers should not be empty")
+
+        let lastProd = prodServers[prodServers.count - 1]
+        let lastDev = devServers[devServers.count - 1]
+
+        XCTAssertTrue(lastProd.urlStrings.contains { $0.contains("turns:") && $0.contains("443") },
+                      "Last production ICE server should be TURNS 443")
+        XCTAssertTrue(lastDev.urlStrings.contains { $0.contains("turns:") && $0.contains("443") },
+                      "Last development ICE server should be TURNS 443")
+    }
+
+    /// Test that the full production ICE server ordering is preserved:
+    /// STUN → Google STUN → TURN UDP → TURN TCP → TURNS 443
+    func testProdIceServerOrdering() {
+        let config = InternalConfig.default
+        let iceServers = config.prodWebRTCIceServers
+
+        guard iceServers.count == 5 else {
+            XCTFail("Production should have exactly 5 ICE servers")
+            return
+        }
+
+        // Index 0: Telnyx STUN
+        XCTAssertTrue(iceServers[0].urlStrings.contains { $0.contains("stun:stun.telnyx.com") },
+                      "Index 0 should be Telnyx STUN server")
+
+        // Index 1: Google STUN
+        XCTAssertTrue(iceServers[1].urlStrings.contains { $0.contains("stun:stun.l.google.com") },
+                      "Index 1 should be Google STUN server")
+
+        // Index 2: TURN UDP
+        XCTAssertTrue(iceServers[2].urlStrings.contains { $0.contains("turn:") && $0.contains("transport=udp") },
+                      "Index 2 should be TURN UDP server")
+
+        // Index 3: TURN TCP (not TURNS)
+        XCTAssertTrue(iceServers[3].urlStrings.contains { $0.contains("turn:") && $0.contains("transport=tcp") && !$0.contains("turns:") },
+                      "Index 3 should be TURN TCP server")
+
+        // Index 4: TURNS 443
+        XCTAssertTrue(iceServers[4].urlStrings.contains { $0.contains("turns:") && $0.contains("443") },
+                      "Index 4 should be TURNS 443 server")
+    }
+
+    /// Test that the full development ICE server ordering is preserved:
+    /// STUN → Google STUN → TURN UDP → TURN TCP → TURNS 443
+    func testDevIceServerOrdering() {
+        let config = InternalConfig.default
+        let iceServers = config.devWebRTCIceServers
+
+        guard iceServers.count == 5 else {
+            XCTFail("Development should have exactly 5 ICE servers")
+            return
+        }
+
+        // Index 0: Telnyx STUN
+        XCTAssertTrue(iceServers[0].urlStrings.contains { $0.contains("stun:stundev.telnyx.com") },
+                      "Index 0 should be Telnyx dev STUN server")
+
+        // Index 1: Google STUN
+        XCTAssertTrue(iceServers[1].urlStrings.contains { $0.contains("stun:stun.l.google.com") },
+                      "Index 1 should be Google STUN server")
+
+        // Index 2: TURN UDP
+        XCTAssertTrue(iceServers[2].urlStrings.contains { $0.contains("turn:") && $0.contains("transport=udp") },
+                      "Index 2 should be TURN UDP server")
+
+        // Index 3: TURN TCP (not TURNS)
+        XCTAssertTrue(iceServers[3].urlStrings.contains { $0.contains("turn:") && $0.contains("transport=tcp") && !$0.contains("turns:") },
+                      "Index 3 should be TURN TCP server")
+
+        // Index 4: TURNS 443
+        XCTAssertTrue(iceServers[4].urlStrings.contains { $0.contains("turns:") && $0.contains("443") },
+                      "Index 4 should be TURNS 443 server")
+    }
+
     // MARK: - STUN Server Tests
     
     /// Test that STUN servers are correctly configured

--- a/TelnyxRTCTests/TurnServerConfigurationTests.swift
+++ b/TelnyxRTCTests/TurnServerConfigurationTests.swift
@@ -136,12 +136,12 @@ class TurnServerConfigurationTests: XCTestCase {
 
     // MARK: - TURNS 443 Server Tests (VSDK-503)
 
-    /// Test that production ICE servers contain exactly 5 servers including TURNS 443
-    func testProdIceServersCountIsFive() {
+    /// Test that production includes both primary and secondary TURNS endpoints
+    func testProdIceServersCountIsSix() {
         let config = InternalConfig.default
         let iceServers = config.prodWebRTCIceServers
 
-        XCTAssertEqual(iceServers.count, 5, "Production should have exactly 5 ICE servers: STUN, Google STUN, TURN UDP, TURN TCP, TURNS 443")
+        XCTAssertEqual(iceServers.count, 6, "Production should have 6 ICE servers including both TURNS endpoints")
     }
 
     /// Test that development ICE servers contain exactly 5 servers including TURNS 443
@@ -165,8 +165,8 @@ class TurnServerConfigurationTests: XCTestCase {
         let turns443 = iceServers[4]
         let urls = turns443.urlStrings
 
-        XCTAssertTrue(urls.contains("turns:turn.telnyx.com:443?transport=tcp"),
-                      "5th production ICE server should be TURNS 443 with turns:turn.telnyx.com:443?transport=tcp")
+        XCTAssertTrue(urls.contains("turns:turn.telnyx.com:443"),
+                      "5th production ICE server should be the primary TURNS endpoint")
         XCTAssertEqual(turns443.username, "testuser", "TURNS 443 server should have username 'testuser'")
         XCTAssertNotNil(turns443.credential, "TURNS 443 server should have a credential set")
         XCTAssertEqual(turns443.credential, "testpassword", "TURNS 443 server should have credential 'testpassword'")
@@ -185,15 +185,15 @@ class TurnServerConfigurationTests: XCTestCase {
         let turns443 = iceServers[4]
         let urls = turns443.urlStrings
 
-        XCTAssertTrue(urls.contains("turns:turndev.telnyx.com:443?transport=tcp"),
-                      "5th development ICE server should be TURNS 443 with turns:turndev.telnyx.com:443?transport=tcp")
+        XCTAssertTrue(urls.contains("turns:turndev.telnyx.com:443"),
+                      "5th development ICE server should be TURNS 443")
         XCTAssertEqual(turns443.username, "testuser", "TURNS 443 server should have username 'testuser'")
         XCTAssertNotNil(turns443.credential, "TURNS 443 server should have a credential set")
         XCTAssertEqual(turns443.credential, "testpassword", "TURNS 443 server should have credential 'testpassword'")
     }
 
-    /// Test that TURNS 443 is the last entry in both prod and dev arrays
-    func testTurns443IsLastInBothArrays() {
+    /// Test that the final fallback entries are last in prod and dev arrays
+    func testTurns443FallbacksAreLast() {
         let config = InternalConfig.default
         let prodServers = config.prodWebRTCIceServers
         let devServers = config.devWebRTCIceServers
@@ -206,18 +206,20 @@ class TurnServerConfigurationTests: XCTestCase {
 
         XCTAssertTrue(lastProd.urlStrings.contains { $0.contains("turns:") && $0.contains("443") },
                       "Last production ICE server should be TURNS 443")
+        XCTAssertTrue(lastProd.urlStrings.contains("turns:turn2.telnyx.com:443"),
+                      "Last production ICE server should be the secondary turn2 endpoint")
         XCTAssertTrue(lastDev.urlStrings.contains { $0.contains("turns:") && $0.contains("443") },
                       "Last development ICE server should be TURNS 443")
     }
 
     /// Test that the full production ICE server ordering is preserved:
-    /// STUN → Google STUN → TURN UDP → TURN TCP → TURNS 443
+    /// STUN → Google STUN → TURN UDP → TURN TCP → primary TURNS → secondary TURNS
     func testProdIceServerOrdering() {
         let config = InternalConfig.default
         let iceServers = config.prodWebRTCIceServers
 
-        guard iceServers.count == 5 else {
-            XCTFail("Production should have exactly 5 ICE servers")
+        guard iceServers.count == 6 else {
+            XCTFail("Production should have exactly 6 ICE servers")
             return
         }
 
@@ -240,6 +242,9 @@ class TurnServerConfigurationTests: XCTestCase {
         // Index 4: TURNS 443
         XCTAssertTrue(iceServers[4].urlStrings.contains { $0.contains("turns:") && $0.contains("443") },
                       "Index 4 should be TURNS 443 server")
+
+        XCTAssertTrue(iceServers[5].urlStrings.contains("turns:turn2.telnyx.com:443"),
+                      "Index 5 should be the secondary TURNS endpoint")
     }
 
     /// Test that the full development ICE server ordering is preserved:


### PR DESCRIPTION
## Summary

Add complete production TURNS 443 fallback parity and tests. The production ICE catalog now matches the JavaScript SDK exactly:

1. Telnyx STUN
2. Google STUN
3. TURN UDP
4. TURN TCP
5. turns:turn.telnyx.com:443
6. turns:turn2.telnyx.com:443

Both production TURNS URLs intentionally omit a transport query. Development retains its single turndev TURNS endpoint.

## Validation

Tests assert production and development counts, exact ordering, URLs, and credentials. All GitHub checks passed, including ios_fastlane_tests.

## Tracking

VSDK-502 cross-SDK parity; supersedes the earlier five-server VSDK-283 description.