### PR TITLE
Add stable accessibility identifiers for E2E automation

### DIFF
--- a/TelnyxWebRTCDemo/Accessibility/AccessibilityIdentifiers.swift
+++ b/TelnyxWebRTCDemo/Accessibility/AccessibilityIdentifiers.swift
@@ -15,6 +15,8 @@ enum AccessibilityIdentifiers {
     static let createUserButton = "createUserButton"
     static let addProfileButton = "addProfileButton"
     static let signInButton = "signInButton"
+    static let tokenTextField = "tokenTextField"
+    static let togglePasswordVisibilityButton = "togglePasswordVisibilityButton"
     
     // User Selection
     static let userSelectionBottomSheet = "userSelectionBottomSheet"
@@ -42,6 +44,7 @@ enum AccessibilityIdentifiers {
     static let speakerButton = "speakerButton"
     static let holdButton = "holdButton"
     static let dtmfButton = "dtmfButton"
+    static let callMetricsButton = "callMetricsButton"
     
     // DTMF Pad
     static let dtmfPad = "dtmfPad"

--- a/TelnyxWebRTCDemo/Views/CallView.swift
+++ b/TelnyxWebRTCDemo/Views/CallView.swift
@@ -249,7 +249,7 @@ struct CallView: View {
                                 .background(Color(hex: "#F5F3E4"))
                                 .clipShape(Circle())
                         }
-                        .accessibilityIdentifier("callMetricsButton")
+                        .accessibilityIdentifier(AccessibilityIdentifiers.callMetricsButton)
                         
                         Button(action: {
                             onIceRestart()

--- a/TelnyxWebRTCDemo/Views/HomeView.swift
+++ b/TelnyxWebRTCDemo/Views/HomeView.swift
@@ -255,6 +255,7 @@ struct HomeView: View {
                 Text(socketStateText(for: viewModel.socketState))
                     .font(.system(size: 15, weight: .regular))
                     .foregroundColor(Color(hex: "1D1D1D"))
+                    .accessibilityIdentifier(AccessibilityIdentifiers.connectionStatusLabel)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.top, 5)
@@ -384,4 +385,3 @@ struct HomeView_Previews: PreviewProvider {
         )
     }
 }
-

--- a/TelnyxWebRTCDemo/Views/SipInputCredentialsView.swift
+++ b/TelnyxWebRTCDemo/Views/SipInputCredentialsView.swift
@@ -62,6 +62,7 @@ struct SipInputCredentialsView: View {
                     TextField("Enter token", text: $tokenCallerId)
                         .padding(.horizontal, 10)
                         .frame(height: 40)
+                        .accessibilityIdentifier(AccessibilityIdentifiers.tokenTextField)
                 }
                 .background(RoundedRectangle(cornerRadius: 4)
                     .stroke(hasError ? Color(hex: "#D40000") : Color(hex: "#525252"), lineWidth: 2))
@@ -73,6 +74,7 @@ struct SipInputCredentialsView: View {
                     TextField("Enter caller number", text: $callerIdNumber)
                         .padding(.horizontal, 10)
                         .frame(height: 40)
+                        .accessibilityIdentifier(AccessibilityIdentifiers.callerNumberTextField)
                 }
                 .background(RoundedRectangle(cornerRadius: 4)
                     .stroke(hasError ? Color(hex: "#D40000") : Color(hex: "#525252"), lineWidth: 2))
@@ -84,6 +86,7 @@ struct SipInputCredentialsView: View {
                     TextField("Enter caller name", text: $callerName)
                         .padding(.horizontal, 10)
                         .frame(height: 40)
+                        .accessibilityIdentifier(AccessibilityIdentifiers.callerNameTextField)
                 }
                 .background(RoundedRectangle(cornerRadius: 4)
                     .stroke(hasError ? Color(hex: "#D40000") : Color(hex: "#525252"), lineWidth: 2))
@@ -135,6 +138,7 @@ struct SipInputCredentialsView: View {
                             .foregroundColor(Color(hex: "#525252"))
                             .padding(.trailing, 10)
                     }
+                    .accessibilityIdentifier(AccessibilityIdentifiers.togglePasswordVisibilityButton)
                 }
                 .background(RoundedRectangle(cornerRadius: 4)
                     .stroke(hasError ? Color(hex: "#D40000") : Color(hex: "#525252"), lineWidth: 2))
@@ -235,5 +239,4 @@ struct SipInputCredentialsView: View {
         }
     }
 }
-
 


### PR DESCRIPTION
[WEBRTC-XXX - Add stable demo app accessibility identifiers](https://telnyx.atlassian.net/browse/WEBRTC-XXX)
---
Add the missing stable accessibility identifiers needed by the external WebRTC E2E Maestro workflows.

## :older_man: :baby: Behaviors
### Before changes
- Token login fields and the connection status label required text or coordinate fallbacks in automation.
- The call metrics button used a hardcoded accessibility identifier string instead of the shared identifiers enum.

### After changes
- Token login fields, token-mode caller fields, password visibility toggle, and connection status label expose stable identifiers.
- The call metrics button uses `AccessibilityIdentifiers.callMetricsButton`.

## TODO
- Replace `WEBRTC-XXX` with the tracking ticket if one exists.

## ✋ Manual testing
1. Build the demo app with `xcodebuild -workspace TelnyxRTC.xcworkspace -scheme TelnyxWebRTCDemo -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath build-pr CODE_SIGNING_ALLOWED=NO build`.
2. Run the external `webrtc-ios-e2e` skill flows from the `webrtc-skills` repository.

## Known Issues
- This PR only adds stable UI hooks. Real-device-only cases such as VoIP push, lock-screen handling, and WiFi/cellular transitions are covered by the external skill workflow.

## Screenshots
N/A

## 🔄 iOS Regression Process
Only demo-app automation hooks changed. Relevant validation: demo app build plus external E2E automation flow smoke checks.