### PR TITLE
[VSUP-126] Gate SSL certificate validation — only allow self-signed in DEBUG for dev hosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ push-notification-tool/key.pem
 
 # claude
 .claude/
+TelnyxRTC.xcodeproj/project.pbxproj.bak

--- a/TelnyxRTC.xcodeproj/project.pbxproj
+++ b/TelnyxRTC.xcodeproj/project.pbxproj
@@ -174,7 +174,11 @@
 		C14000122F52000000000001 /* PushCallUUIDResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14000142F52000000000001 /* PushCallUUIDResolverTests.swift */; };
 		E7D4728DC54740F9B74EDCF5 /* AnonymousLoginMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DFC6708A0B342C3BF91953C /* AnonymousLoginMessage.swift */; };
 		EAA0358E635D404F9594CDA38CD57A76 /* Peer+IceRestart.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7DA9FEE6464493BA99C53B5930AA3CB /* Peer+IceRestart.swift */; };
-/* End PBXBuildFile section */
+		7530E91BC461EFF5522FF92F /* SSLValidationHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6748DACA21BD5367E2ED10 /* SSLValidationHelperTests.swift */; };
+		C9799A1411FBF7FA5CC8DF9E /* SocketSSLConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C1A1B92CACA63F62AB2095 /* SocketSSLConfigurationTests.swift */; };
+		E646798A1FBBDD9C713778B1 /* CallReportCollectorSSLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D59B37D5C89B9A69EEC3F5 /* CallReportCollectorSSLTests.swift */; };
+		9127260D822A71414048FCB0 /* SSLValidationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500401434F9B22288B10F27 /* SSLValidationHelper.swift */; };
+/* End PBXBuildFile section
 
 /* Begin PBXContainerItemProxy section */
 		994651852D761F7800049EF4 /* PBXContainerItemProxy */ = {
@@ -399,7 +403,11 @@
 		C14000142F52000000000001 /* PushCallUUIDResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushCallUUIDResolverTests.swift; sourceTree = "<group>"; };
 		C90FC92EC97313A541ABEF2D /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig"; path = "Target Support Files/Pods-TelnyxRTC-TelnyxRTCTests/Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig"; sourceTree = "<group>"; };
 		FD61A0D3085C477AB1B14626A82449EA /* ICERestartMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICERestartMessage.swift; sourceTree = "<group>"; };
-/* End PBXFileReference section */
+		7A6748DACA21BD5367E2ED10 /* SSLValidationHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSLValidationHelperTests.swift; sourceTree = "<group>"; };
+		51C1A1B92CACA63F62AB2095 /* SocketSSLConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketSSLConfigurationTests.swift; sourceTree = "<group>"; };
+		36D59B37D5C89B9A69EEC3F5 /* CallReportCollectorSSLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallReportCollectorSSLTests.swift; sourceTree = "<group>"; };
+		A500401434F9B22288B10F27 /* SSLValidationHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSLValidationHelper.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section
 
 /* Begin PBXFrameworksBuildPhase section */
 		9946517C2D761F7800049EF4 /* Frameworks */ = {
@@ -723,6 +731,7 @@
 				B391221C260501C00051E076 /* WebRTC */,
 				B39121F32603AE670051E076 /* Verto */,
 				B39121F22603AD7B0051E076 /* Socket */,
+				C7F26BD617AAB9A2E24E747F /* Security */,
 				B368BED325EDDBC90032AE52 /* TelnyxRTCTests.swift */,
 				99D717752D6E229000471D44 /* TelnyxRTCLoggerTests.swift */,
 				B3912263260F6A050051E076 /* TelnyxRTCMulticallTests.swift */,
@@ -768,6 +777,7 @@
 				B309D1E225F023F400A2AADF /* Models */,
 				B309D1D425F020A300A2AADF /* Verto */,
 				B3AF248925EE7C0D0062EDA9 /* Services */,
+				020E964F3C1F4B612F677321 /* Security */,
 				B368BEE025EDDC7D0032AE52 /* TxClient.swift */,
 				B3AF247F25EE7B1F0062EDA9 /* TxClientDelegate.swift */,
 				B3AF248325EE7B6A0062EDA9 /* InternalConfig.swift */,
@@ -798,6 +808,15 @@
 			path = Socket;
 			sourceTree = "<group>";
 		};
+		C7F26BD617AAB9A2E24E747F /* Security */ = {
+			isa = PBXGroup;
+			children = (
+				7A6748DACA21BD5367E2ED10 /* SSLValidationHelperTests.swift */,
+				51C1A1B92CACA63F62AB2095 /* SocketSSLConfigurationTests.swift */,
+			);
+			path = Security;
+			sourceTree = "<group>";
+		};
 		B39121F32603AE670051E076 /* Verto */ = {
 			isa = PBXGroup;
 			children = (
@@ -812,6 +831,7 @@
 				B391220B2604D9C50051E076 /* PeerConnectionTests.swift */,
 				B391221F260502650051E076 /* CallTests.swift */,
 				AA00FF002F3E000100000001 /* CallReportCollectorTests.swift */,
+				36D59B37D5C89B9A69EEC3F5 /* CallReportCollectorSSLTests.swift */,
 			);
 			path = WebRTC;
 			sourceTree = "<group>";
@@ -824,6 +844,14 @@
 				B3AF249725EE7DC70062EDA9 /* SocketDelegate.swift */,
 			);
 			path = Services;
+			sourceTree = "<group>";
+		};
+		020E964F3C1F4B612F677321 /* Security */ = {
+			isa = PBXGroup;
+			children = (
+				A500401434F9B22288B10F27 /* SSLValidationHelper.swift */,
+			);
+			path = Security;
 			sourceTree = "<group>";
 		};
 		B3AF24A825EE84410062EDA9 /* Extensions */ = {
@@ -1235,6 +1263,7 @@
 				99CC5BAC2CF804A500EF43DC /* WebRTCStatsReporter.swift in Sources */,
 				9911247E2CF50092000C23BA /* Dictionary+Extensions.swift in Sources */,
 				996C67BC2CFEA4880056E508 /* RTCIceServer+Extension.swift in Sources */,
+				9127260D822A71414048FCB0 /* SSLValidationHelper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1259,6 +1288,9 @@
 				B3912264260F6A050051E076 /* TelnyxRTCMulticallTests.swift in Sources */,
 				B3912220260502650051E076 /* CallTests.swift in Sources */,
 				B3A1555928767E2D00C70528 /* RTCTestDelegate.swift in Sources */,
+				7530E91BC461EFF5522FF92F /* SSLValidationHelperTests.swift in Sources */,
+				C9799A1411FBF7FA5CC8DF9E /* SocketSSLConfigurationTests.swift in Sources */,
+				E646798A1FBBDD9C713778B1 /* CallReportCollectorSSLTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TelnyxRTC.xcodeproj/project.pbxproj
+++ b/TelnyxRTC.xcodeproj/project.pbxproj
@@ -1399,14 +1399,14 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = YKUVNPU9FS;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 4.0.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.webrtcapp.TelnyxWebRTCDemoUITests.gp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.webrtcapp.TelnyxWebRTCDemoUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -1423,14 +1423,14 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = YKUVNPU9FS;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 4.0.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.webrtcapp.TelnyxWebRTCDemoUITests.gp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.webrtcapp.TelnyxWebRTCDemoUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
@@ -1569,7 +1569,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1591,7 +1591,7 @@
 					"$(BUILT_PRODUCTS_DIR)/Starscream",
 				);
 				MARKETING_VERSION = 4.0.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.WebRTCSDK.gp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.WebRTCSDK;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -1627,7 +1627,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 4.0.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.WebRTCSDK.gp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.WebRTCSDK;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
@@ -1642,7 +1642,7 @@
 			baseConfigurationReference = C90FC92EC97313A541ABEF2D /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = TelnyxRTCTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1650,7 +1650,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.TelnyxRTCTests.gp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.TelnyxRTCTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -1663,7 +1663,7 @@
 			baseConfigurationReference = 095B627B36C455D921694757 /* Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = TelnyxRTCTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1671,7 +1671,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.TelnyxRTCTests.gp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.TelnyxRTCTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -1689,7 +1689,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 2;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = YKUVNPU9FS;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = TelnyxWebRTCDemo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
@@ -1698,7 +1698,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 4.0.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.webrtcapp.gp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.webrtcapp;
 				PRODUCT_NAME = "Telnyx WebRTC";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -1716,7 +1716,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 2;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = YKUVNPU9FS;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = TelnyxWebRTCDemo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
@@ -1725,7 +1725,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 4.0.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.webrtcapp.gp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.webrtcapp;
 				PRODUCT_NAME = "Telnyx WebRTC";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;

--- a/TelnyxRTC.xcodeproj/project.pbxproj
+++ b/TelnyxRTC.xcodeproj/project.pbxproj
@@ -1399,14 +1399,14 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = YKUVNPU9FS;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 4.0.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.webrtcapp.TelnyxWebRTCDemoUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.webrtcapp.TelnyxWebRTCDemoUITests.gp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -1423,14 +1423,14 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = YKUVNPU9FS;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 4.0.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.webrtcapp.TelnyxWebRTCDemoUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.webrtcapp.TelnyxWebRTCDemoUITests.gp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
@@ -1569,7 +1569,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1591,7 +1591,7 @@
 					"$(BUILT_PRODUCTS_DIR)/Starscream",
 				);
 				MARKETING_VERSION = 4.0.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.WebRTCSDK;
+				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.WebRTCSDK.gp;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -1627,7 +1627,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 4.0.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.WebRTCSDK;
+				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.WebRTCSDK.gp;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = NO;
@@ -1642,7 +1642,7 @@
 			baseConfigurationReference = C90FC92EC97313A541ABEF2D /* Pods-TelnyxRTC-TelnyxRTCTests.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = TelnyxRTCTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1650,7 +1650,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.TelnyxRTCTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.TelnyxRTCTests.gp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -1663,7 +1663,7 @@
 			baseConfigurationReference = 095B627B36C455D921694757 /* Pods-TelnyxRTC-TelnyxRTCTests.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = TelnyxRTCTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1671,7 +1671,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.TelnyxRTCTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.TelnyxRTCTests.gp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -1689,7 +1689,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 2;
-				DEVELOPMENT_TEAM = YKUVNPU9FS;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = TelnyxWebRTCDemo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
@@ -1698,7 +1698,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 4.0.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.webrtcapp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.webrtcapp.gp;
 				PRODUCT_NAME = "Telnyx WebRTC";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -1716,7 +1716,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 2;
-				DEVELOPMENT_TEAM = YKUVNPU9FS;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = TelnyxWebRTCDemo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
@@ -1725,7 +1725,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 4.0.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.webrtcapp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.telnyx.webrtcapp.gp;
 				PRODUCT_NAME = "Telnyx WebRTC";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;

--- a/TelnyxRTC/Telnyx/Security/SSLValidationHelper.swift
+++ b/TelnyxRTC/Telnyx/Security/SSLValidationHelper.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Darwin
 
 enum SSLValidationHelper {
 
@@ -57,34 +58,19 @@ enum SSLValidationHelper {
     }
 
     private static func isPrivateOrLoopbackIPv6(_ host: String) -> Bool {
-        // Handle IPv6 loopback and unique-local addresses
-        // ::1 → loopback
+        // First validate this is actually an IPv6 literal
+        var addr = in6_addr()
+        guard inet_pton(AF_INET6, host, &addr) == 1 else { return false }
+
+        // Now safe to do prefix checks — host is confirmed IPv6
         if host == "::1" { return true }
 
-        // fc00::/7 → unique-local addresses (fc00:: – fdff::)
-        if host.hasPrefix("fc") || host.hasPrefix("fd") {
-            // Validate it's a valid IPv6 address by attempting to parse components
-            let fullForm = expandIPv6(host)
-            guard !fullForm.isEmpty else { return false }
-            return true
-        }
+        // fc00::/7 → unique-local (fc00:: – fdff::)
+        if host.hasPrefix("fc") || host.hasPrefix("fd") { return true }
 
-        // fe80::/10 → link-local (also private, but typically not used for dev servers)
-        if host.hasPrefix("fe80") {
-            return true
-        }
+        // fe80::/10 → link-local
+        if host.hasPrefix("fe80") { return true }
 
         return false
-    }
-
-    /// Expand a compressed IPv6 address to its full 8-group form for validation.
-    private static func expandIPv6(_ addr: String) -> String {
-        // Basic validation: must contain at least one "::" or 8 groups
-        let parts = addr.split(separator: ":", omittingEmptySubsequences: true)
-        guard parts.count >= 2 && parts.count <= 8 else { return "" }
-
-        // Rejoin to normalize — full validation would require inet_pton
-        // but this is sufficient for our prefix-based checks
-        return parts.joined(separator: ":")
     }
 }

--- a/TelnyxRTC/Telnyx/Security/SSLValidationHelper.swift
+++ b/TelnyxRTC/Telnyx/Security/SSLValidationHelper.swift
@@ -1,0 +1,51 @@
+//
+//  SSLValidationHelper.swift
+//  TelnyxRTC
+//
+//  Copyright © 2026 Telnyx LLC. All rights reserved.
+//
+
+import Foundation
+
+enum SSLValidationHelper {
+
+    static let localHosts: [String] = [
+        "localhost",
+        "127.0.0.1"
+    ]
+
+    static func shouldAllowSelfSigned(for url: URL) -> Bool {
+        guard let host = url.host?.lowercased() else { return false }
+
+        if localHosts.contains(host) {
+            return true
+        }
+
+        if isPrivateOrLoopbackIP(host) {
+            return true
+        }
+
+        return false
+    }
+
+    private static func isPrivateOrLoopbackIP(_ host: String) -> Bool {
+        let octets = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard octets.count == 4 else { return false }
+
+        var bytes: [UInt8] = []
+        for octetStr in octets {
+            guard let value = UInt8(octetStr) else { return false }
+            bytes.append(value)
+        }
+
+        let first = bytes[0]
+        let second = bytes[1]
+
+        if first == 127 { return true }
+        if first == 10 { return true }
+        if first == 192 && second == 168 { return true }
+        if first == 172 && (16...31).contains(second) { return true }
+
+        return false
+    }
+}

--- a/TelnyxRTC/Telnyx/Security/SSLValidationHelper.swift
+++ b/TelnyxRTC/Telnyx/Security/SSLValidationHelper.swift
@@ -21,15 +21,22 @@ enum SSLValidationHelper {
             return true
         }
 
-        if isPrivateOrLoopbackIP(host) {
+        if isPrivateOrLoopbackIPv4(host) {
+            return true
+        }
+
+        if isPrivateOrLoopbackIPv6(host) {
             return true
         }
 
         return false
     }
 
-    private static func isPrivateOrLoopbackIP(_ host: String) -> Bool {
-        let octets = host.split(separator: ".", omittingEmptySubsequences: false)
+    private static func isPrivateOrLoopbackIPv4(_ host: String) -> Bool {
+        // Strip IPv4-in-IPv6 wrapper if present (e.g. ::ffff:127.0.0.1)
+        let ipv4Part = host.hasPrefix("::ffff:") ? String(host.dropFirst(7)) : host
+
+        let octets = ipv4Part.split(separator: ".", omittingEmptySubsequences: false)
         guard octets.count == 4 else { return false }
 
         var bytes: [UInt8] = []
@@ -47,5 +54,37 @@ enum SSLValidationHelper {
         if first == 172 && (16...31).contains(second) { return true }
 
         return false
+    }
+
+    private static func isPrivateOrLoopbackIPv6(_ host: String) -> Bool {
+        // Handle IPv6 loopback and unique-local addresses
+        // ::1 → loopback
+        if host == "::1" { return true }
+
+        // fc00::/7 → unique-local addresses (fc00:: – fdff::)
+        if host.hasPrefix("fc") || host.hasPrefix("fd") {
+            // Validate it's a valid IPv6 address by attempting to parse components
+            let fullForm = expandIPv6(host)
+            guard !fullForm.isEmpty else { return false }
+            return true
+        }
+
+        // fe80::/10 → link-local (also private, but typically not used for dev servers)
+        if host.hasPrefix("fe80") {
+            return true
+        }
+
+        return false
+    }
+
+    /// Expand a compressed IPv6 address to its full 8-group form for validation.
+    private static func expandIPv6(_ addr: String) -> String {
+        // Basic validation: must contain at least one "::" or 8 groups
+        let parts = addr.split(separator: ":", omittingEmptySubsequences: true)
+        guard parts.count >= 2 && parts.count <= 8 else { return "" }
+
+        // Rejoin to normalize — full validation would require inet_pton
+        // but this is sufficient for our prefix-based checks
+        return parts.joined(separator: ":")
     }
 }

--- a/TelnyxRTC/Telnyx/Services/Socket.swift
+++ b/TelnyxRTC/Telnyx/Services/Socket.swift
@@ -47,7 +47,18 @@ class Socket {
         
         var request = URLRequest(url: signalingServer)
         request.timeoutInterval = connectionTimeout
-        let pinner = FoundationSecurity(allowSelfSigned: true) // don't validate SSL certificates
+
+        let pinner: FoundationSecurity
+        #if DEBUG
+        if SSLValidationHelper.shouldAllowSelfSigned(for: signalingServer) {
+            pinner = FoundationSecurity(allowSelfSigned: true)
+        } else {
+            pinner = FoundationSecurity(allowSelfSigned: false)
+        }
+        #else
+        pinner = FoundationSecurity(allowSelfSigned: false)
+        #endif
+
         self.signalingServer = signalingServer
         
         self.socket = WebSocket(request: request, certPinner: pinner)

--- a/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
@@ -282,7 +282,7 @@ public class TelnyxCallReportCollector {
     #endif
 
     #if DEBUG
-    private lazy var localSession: URLSession = {
+    private static let localSession: URLSession = {
         let delegate = AllowSelfSignedDelegate()
         return URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
     }()
@@ -291,7 +291,7 @@ public class TelnyxCallReportCollector {
     private func urlSession(for url: URL) -> URLSession {
         #if DEBUG
         if SSLValidationHelper.shouldAllowSelfSigned(for: url) {
-            return localSession
+            return Self.localSession
         }
         return URLSession.shared
         #else
@@ -300,7 +300,11 @@ public class TelnyxCallReportCollector {
     }
 
     private func executeUpload(request: URLRequest, attempt: Int) {
-        let session = urlSession(for: request.url!)
+        guard let requestUrl = request.url else {
+            Logger.log.e(message: "TelnyxCallReportCollector: Request has no URL, skipping upload")
+            return
+        }
+        let session = urlSession(for: requestUrl)
         let task = session.dataTask(with: request) { [weak self] data, response, error in
             guard let self = self else { return }
 

--- a/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
@@ -262,14 +262,16 @@ public class TelnyxCallReportCollector {
         executeUpload(request: request, attempt: 1)
     }
 
-    /// URLSession delegate that accepts self-signed certificates (matches WebSocket behavior)
-    ///
-    /// ⚠️ Security Note: This accepts ALL self-signed certificates for dev/staging parity.
-    /// In production, this enables MITM attacks on call reports. Consider production-gating
-    /// this behavior or restricting to known dev/staging hostnames only.
+    #if DEBUG
     private class AllowSelfSignedDelegate: NSObject, URLSessionDelegate {
         func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge,
                         completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+            let host = challenge.protectionSpace.host
+            guard let checkUrl = URL(string: "https://\(host)"),
+                  SSLValidationHelper.shouldAllowSelfSigned(for: checkUrl) else {
+                completionHandler(.performDefaultHandling, nil)
+                return
+            }
             if let serverTrust = challenge.protectionSpace.serverTrust {
                 completionHandler(.useCredential, URLCredential(trust: serverTrust))
             } else {
@@ -277,14 +279,29 @@ public class TelnyxCallReportCollector {
             }
         }
     }
+    #endif
 
-    private lazy var urlSession: URLSession = {
+    #if DEBUG
+    private lazy var localSession: URLSession = {
         let delegate = AllowSelfSignedDelegate()
         return URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
     }()
+    #endif
+
+    private func urlSession(for url: URL) -> URLSession {
+        #if DEBUG
+        if SSLValidationHelper.shouldAllowSelfSigned(for: url) {
+            return localSession
+        }
+        return URLSession.shared
+        #else
+        return URLSession.shared
+        #endif
+    }
 
     private func executeUpload(request: URLRequest, attempt: Int) {
-        let task = urlSession.dataTask(with: request) { [weak self] data, response, error in
+        let session = urlSession(for: request.url!)
+        let task = session.dataTask(with: request) { [weak self] data, response, error in
             guard let self = self else { return }
 
             if let error = error {

--- a/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
@@ -222,7 +222,10 @@ public class TelnyxCallReportCollector {
         }
 
         let scheme = wsUrl.scheme?.replacingOccurrences(of: "ws", with: "http") ?? "https"
-        let endpoint = "\(scheme)://\(wsUrl.host ?? "rtc.telnyx.com")\(wsUrl.port.map { ":\($0)" } ?? "")/call_report"
+        let rawHost = wsUrl.host ?? "rtc.telnyx.com"
+        // IPv6 literals must be bracketed in URLs
+        let urlHost = rawHost.contains(":") ? "[\(rawHost)]" : rawHost
+        let endpoint = "\(scheme)://\(urlHost)\(wsUrl.port.map { ":\($0)" } ?? "")/call_report"
 
         guard let endpointUrl = URL(string: endpoint) else {
             Logger.log.e(message: "TelnyxCallReportCollector: Failed to construct endpoint URL from: \(endpoint)")
@@ -267,7 +270,13 @@ public class TelnyxCallReportCollector {
         func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge,
                         completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
             let host = challenge.protectionSpace.host
-            guard let checkUrl = URL(string: "https://\(host)"),
+            let urlHost: String
+            if host.contains(":") {
+                urlHost = "[\(host)]"  // IPv6 literal — needs bracketing
+            } else {
+                urlHost = host
+            }
+            guard let checkUrl = URL(string: "https://\(urlHost)"),
                   SSLValidationHelper.shouldAllowSelfSigned(for: checkUrl) else {
                 completionHandler(.performDefaultHandling, nil)
                 return

--- a/TelnyxRTCTests/Security/SSLValidationHelperTests.swift
+++ b/TelnyxRTCTests/Security/SSLValidationHelperTests.swift
@@ -1,0 +1,127 @@
+//
+//  SSLValidationHelperTests.swift
+//  TelnyxRTCTests
+//
+//  Copyright © 2026 Telnyx LLC. All rights reserved.
+//
+
+import XCTest
+@testable import TelnyxRTC
+
+class SSLValidationHelperTests: XCTestCase {
+
+    // MARK: - Local/Loopback
+
+    func testAllowsLocalhost() {
+        let url = URL(string: "wss://localhost:8080")!
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testAllowsLocalhostNoPort() {
+        let url = URL(string: "wss://localhost")!
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testAllowsLoopback127_0_0_1() {
+        let url = URL(string: "wss://127.0.0.1:8080")!
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testAllowsLoopback127_255_255_255() {
+        let url = URL(string: "wss://127.255.255.255:443")!
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    // MARK: - Private Networks
+
+    func testAllowsPrivateNetwork10_x() {
+        let url = URL(string: "wss://10.0.0.5:8080")!
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testAllowsPrivateNetwork192_168_x() {
+        let url = URL(string: "wss://192.168.1.100:8080")!
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testAllowsPrivateNetwork10_255_255_255() {
+        let url = URL(string: "wss://10.255.255.255:443")!
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testAllowsPrivateNetwork192_168_0_0() {
+        let url = URL(string: "wss://192.168.0.0:443")!
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testAllowsPrivateNetwork172_16_x() {
+        let url = URL(string: "wss://172.16.0.1:443")!
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testAllowsPrivateNetwork172_31_x() {
+        let url = URL(string: "wss://172.31.255.255:443")!
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testRejectsPrivateNetwork172_32_x() {
+        let url = URL(string: "wss://172.32.0.1:443")!
+        XCTAssertFalse(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testRejectsPrivateNetwork172_15_x() {
+        let url = URL(string: "wss://172.15.0.1:443")!
+        XCTAssertFalse(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    // MARK: - Non-Local Hosts
+
+    func testRejectsUnknownHost() {
+        let url = URL(string: "wss://evil.example.com")!
+        XCTAssertFalse(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testRejectsArbitraryPublicIP() {
+        let url = URL(string: "wss://93.184.216.34:443")!
+        XCTAssertFalse(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testRejectsNonTelnyxDomain() {
+        let url = URL(string: "wss://example.org:8080")!
+        XCTAssertFalse(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    // MARK: - Edge Cases
+
+    func testRejectsMalformedURL() {
+        let url = URL(string: "wss://")!
+        XCTAssertFalse(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testRejectsURLWithNoHost() {
+        let url = URL(string: "wss:///path")!
+        XCTAssertFalse(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    // MARK: - Hostname Spoofing Prevention
+
+    func testRejectsHostnameSpoof10Prefix() {
+        let url = URL(string: "wss://10.evil.com:443")!
+        XCTAssertFalse(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testRejectsHostnameSpoof192_168Prefix() {
+        let url = URL(string: "wss://192.168.attacker.com:443")!
+        XCTAssertFalse(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testRejectsHostnameSpoof127Prefix() {
+        let url = URL(string: "wss://127.0.0.1.attacker.com:443")!
+        XCTAssertFalse(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testRejectsHostnameSpoof172Prefix() {
+        let url = URL(string: "wss://172.16.evil.com:443")!
+        XCTAssertFalse(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+}

--- a/TelnyxRTCTests/Security/SocketSSLConfigurationTests.swift
+++ b/TelnyxRTCTests/Security/SocketSSLConfigurationTests.swift
@@ -11,21 +11,116 @@ import Starscream
 
 class SocketSSLConfigurationTests: XCTestCase {
 
-    // MARK: - SSLValidationHelper gating
+    // MARK: - SSLValidationHelper — IPv4 private/loopback ranges
 
-    func testSocketHelperRejectsUnknownHost() {
+    func testRejectsUnknownHost() {
         let url = URL(string: "wss://evil.example.com")!
         XCTAssertFalse(SSLValidationHelper.shouldAllowSelfSigned(for: url))
     }
 
-    func testSocketHelperAllowsLocalhost() {
+    func testAllowsLocalhost() {
         let url = URL(string: "wss://localhost:8080")!
         XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
     }
 
-    func testSocketHelperAllowsLoopback() {
+    func testAllowsLoopback127_0_0_1() {
         let url = URL(string: "wss://127.0.0.1:8080")!
         XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testAllowsLoopback127_255_255_254() {
+        let url = URL(string: "wss://127.255.255.254")!
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testAllowsPrivate10_x() {
+        let url = URL(string: "wss://10.0.0.1:443")!
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testAllowsPrivate192_168_x() {
+        let url = URL(string: "wss://192.168.1.100")!
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testAllowsPrivate172_16_31() {
+        let url16 = URL(string: "wss://172.16.0.1")!
+        let url31 = URL(string: "wss://172.31.255.255")!
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url16))
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url31))
+    }
+
+    // MARK: - IPv4 boundary — addresses that should NOT match
+
+    func testRejects172_15() {
+        let url = URL(string: "wss://172.15.0.1")!
+        XCTAssertFalse(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testRejects172_32() {
+        let url = URL(string: "wss://172.32.0.1")!
+        XCTAssertFalse(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testRejectsPublicIP() {
+        let url = URL(string: "wss://8.8.8.8")!
+        XCTAssertFalse(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testRejectsPublicDomain() {
+        let url = URL(string: "wss://rtc.telnyx.com")!
+        XCTAssertFalse(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    // MARK: - IPv6 loopback and ULA
+
+    func testAllowsIPv6Loopback() {
+        let url = URL(string: "wss://[::1]:8080")!
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testAllowsIPv6UniqueLocalFC() {
+        let url = URL(string: "wss://[fc00::1]:8080")!
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testAllowsIPv6UniqueLocalFD() {
+        let url = URL(string: "wss://[fd12:3456:7890::1]")!
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testRejectsIPv6Public() {
+        let url = URL(string: "wss://[2606:4700::1]")!
+        XCTAssertFalse(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    // MARK: - IPv4-in-IPv6 mapping
+
+    func testAllowsIPv4MappedIPv6Loopback() {
+        let url = URL(string: "wss://[::ffff:127.0.0.1]:8080")!
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testAllowsIPv4MappedIPv6Private() {
+        let url = URL(string: "wss://[::ffff:10.0.0.1]")!
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testRejectsIPv4MappedIPv6Public() {
+        let url = URL(string: "wss://[::ffff:8.8.8.8]")!
+        XCTAssertFalse(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    // MARK: - Edge cases
+
+    func testRejectsEmptyHost() {
+        let url = URL(string: "wss://:8080")!
+        XCTAssertFalse(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testRejectsInvalidIP() {
+        let url = URL(string: "wss://999.999.999.999")!
+        XCTAssertFalse(SSLValidationHelper.shouldAllowSelfSigned(for: url))
     }
 
     // MARK: - Socket integration
@@ -49,17 +144,5 @@ class SocketSSLConfigurationTests: XCTestCase {
 
         let url = URL(string: "wss://localhost")!
         XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
-    }
-
-    // MARK: - API surface
-
-    func testSSLValidationHelperHasStaticMethod() {
-        let url = URL(string: "wss://localhost")!
-        let result: Bool = SSLValidationHelper.shouldAllowSelfSigned(for: url)
-        XCTAssertNotNil(result as Any?)
-    }
-
-    func testDevHostsContainsLocalhost() {
-        XCTAssertTrue(SSLValidationHelper.localHosts.contains("localhost"))
     }
 }

--- a/TelnyxRTCTests/Security/SocketSSLConfigurationTests.swift
+++ b/TelnyxRTCTests/Security/SocketSSLConfigurationTests.swift
@@ -1,0 +1,65 @@
+//
+//  SocketSSLConfigurationTests.swift
+//  TelnyxRTCTests
+//
+//  Copyright © 2026 Telnyx LLC. All rights reserved.
+//
+
+import XCTest
+import Starscream
+@testable import TelnyxRTC
+
+class SocketSSLConfigurationTests: XCTestCase {
+
+    // MARK: - SSLValidationHelper gating
+
+    func testSocketHelperRejectsUnknownHost() {
+        let url = URL(string: "wss://evil.example.com")!
+        XCTAssertFalse(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testSocketHelperAllowsLocalhost() {
+        let url = URL(string: "wss://localhost:8080")!
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testSocketHelperAllowsLoopback() {
+        let url = URL(string: "wss://127.0.0.1:8080")!
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    // MARK: - Socket integration
+
+    func testSocketClassExistsAndCanInstantiate() {
+        let socket = Socket()
+        XCTAssertNotNil(socket)
+    }
+
+    func testSocketConnectToNonLocalHostUsesStrictValidation() {
+        let socket = Socket()
+        socket.automaticallyConnectWebSocket = false
+
+        let url = URL(string: "wss://rtc.telnyx.com")!
+        XCTAssertFalse(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testSocketConnectToLocalHostAllowsBypassInDebug() {
+        let socket = Socket()
+        socket.automaticallyConnectWebSocket = false
+
+        let url = URL(string: "wss://localhost")!
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    // MARK: - API surface
+
+    func testSSLValidationHelperHasStaticMethod() {
+        let url = URL(string: "wss://localhost")!
+        let result: Bool = SSLValidationHelper.shouldAllowSelfSigned(for: url)
+        XCTAssertNotNil(result as Any?)
+    }
+
+    func testDevHostsContainsLocalhost() {
+        XCTAssertTrue(SSLValidationHelper.localHosts.contains("localhost"))
+    }
+}

--- a/TelnyxRTCTests/WebRTC/CallReportCollectorSSLTests.swift
+++ b/TelnyxRTCTests/WebRTC/CallReportCollectorSSLTests.swift
@@ -36,7 +36,7 @@ class CallReportCollectorSSLTests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    // MARK: - Integration
+    // MARK: - SSLValidationHelper integration with CallReportCollector
 
     func testCallReportHelperRejectsNonLocalHost() {
         let url = URL(string: "wss://rtc.telnyx.com")!
@@ -48,9 +48,9 @@ class CallReportCollectorSSLTests: XCTestCase {
         XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
     }
 
-    // MARK: - Post report
+    // MARK: - Post report — verifies the non-local → URLSession.shared path doesn't crash
 
-    func testPostReportDoesNotCrash() {
+    func testPostReportToNonLocalHostDoesNotCrash() {
         collector.start(peerConnection: mockPeerConnection)
 
         let statsExpectation = expectation(description: "Stats accumulation")
@@ -82,6 +82,41 @@ class CallReportCollectorSSLTests: XCTestCase {
         XCTAssertNotNil(collector.callEndTime)
     }
 
+    // MARK: - Post report to localhost — verifies the local → localSession path doesn't crash
+
+    func testPostReportToLocalHostDoesNotCrash() {
+        collector.start(peerConnection: mockPeerConnection)
+
+        let statsExpectation = expectation(description: "Stats accumulation")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            statsExpectation.fulfill()
+        }
+        wait(for: [statsExpectation], timeout: 1.0)
+
+        collector.stop()
+
+        let summary = CallReportSummary(
+            callId: "test-call-local",
+            state: "done",
+            durationSeconds: 5.0,
+            telnyxSessionId: "session",
+            telnyxLegId: "leg",
+            voiceSdkSessionId: "test-session",
+            startTimestamp: ISO8601DateFormatter().string(from: collector.callStartTime),
+            endTimestamp: ISO8601DateFormatter().string(from: collector.callEndTime ?? Date())
+        )
+
+        // Posting to localhost should use the self-signed session in DEBUG — verify it doesn't crash
+        collector.postReport(
+            summary: summary,
+            callReportId: "report-local",
+            host: "wss://localhost:8080",
+            voiceSdkId: "ios-sdk-test"
+        )
+
+        XCTAssertNotNil(collector.callEndTime)
+    }
+
     // MARK: - HTTP URL derivation
 
     func testHTTPURLDerivedFromWebSocket() {
@@ -96,6 +131,15 @@ class CallReportCollectorSSLTests: XCTestCase {
         let httpUrl = URL(string: "https://rtc.telnyx.com/report")!
         XCTAssertFalse(SSLValidationHelper.shouldAllowSelfSigned(for: httpUrl))
     }
+
+    // MARK: - IPv6 support for call report endpoints
+
+    func testIPv6LoopbackAllowedForCallReport() {
+        let url = URL(string: "wss://[::1]:8080")!
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    // MARK: - DEBUG-only delegate exists
 
     #if DEBUG
     func testAllowSelfSignedDelegateExistsInDebugBuild() {

--- a/TelnyxRTCTests/WebRTC/CallReportCollectorSSLTests.swift
+++ b/TelnyxRTCTests/WebRTC/CallReportCollectorSSLTests.swift
@@ -1,0 +1,105 @@
+//
+//  CallReportCollectorSSLTests.swift
+//  TelnyxRTCTests
+//
+//  Copyright © 2026 Telnyx LLC. All rights reserved.
+//
+
+import XCTest
+import WebRTC
+@testable import TelnyxRTC
+
+class CallReportCollectorSSLTests: XCTestCase {
+
+    var collector: TelnyxCallReportCollector!
+    var mockPeerConnection: RTCPeerConnection!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        let configuration = RTCConfiguration()
+        configuration.iceServers = []
+        let constraints = RTCMediaConstraints(mandatoryConstraints: nil, optionalConstraints: nil)
+        let factory = RTCPeerConnectionFactory()
+        mockPeerConnection = factory.peerConnection(with: configuration, constraints: constraints, delegate: nil)
+
+        let config = CallReportConfig(enabled: true, interval: 0.1)
+        let logConfig = LogCollectorConfig(enabled: true, level: "debug", maxEntries: 100)
+        collector = TelnyxCallReportCollector(config: config, logCollectorConfig: logConfig)
+    }
+
+    override func tearDownWithError() throws {
+        collector?.stop()
+        collector = nil
+        mockPeerConnection?.close()
+        mockPeerConnection = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Integration
+
+    func testCallReportHelperRejectsNonLocalHost() {
+        let url = URL(string: "wss://rtc.telnyx.com")!
+        XCTAssertFalse(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    func testCallReportHelperAllowsLocalhost() {
+        let url = URL(string: "wss://localhost")!
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: url))
+    }
+
+    // MARK: - Post report
+
+    func testPostReportDoesNotCrash() {
+        collector.start(peerConnection: mockPeerConnection)
+
+        let statsExpectation = expectation(description: "Stats accumulation")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            statsExpectation.fulfill()
+        }
+        wait(for: [statsExpectation], timeout: 1.0)
+
+        collector.stop()
+
+        let summary = CallReportSummary(
+            callId: "test-call-ssl",
+            state: "done",
+            durationSeconds: 5.0,
+            telnyxSessionId: "session",
+            telnyxLegId: "leg",
+            voiceSdkSessionId: "test-session",
+            startTimestamp: ISO8601DateFormatter().string(from: collector.callStartTime),
+            endTimestamp: ISO8601DateFormatter().string(from: collector.callEndTime ?? Date())
+        )
+
+        collector.postReport(
+            summary: summary,
+            callReportId: "report-ssl",
+            host: "wss://rtc.telnyx.com",
+            voiceSdkId: "ios-sdk-test"
+        )
+
+        XCTAssertNotNil(collector.callEndTime)
+    }
+
+    // MARK: - HTTP URL derivation
+
+    func testHTTPURLDerivedFromWebSocket() {
+        let wsUrl = URL(string: "wss://localhost")!
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: wsUrl))
+
+        let httpUrl = URL(string: "https://localhost/report")!
+        XCTAssertTrue(SSLValidationHelper.shouldAllowSelfSigned(for: httpUrl))
+    }
+
+    func testHTTPURLNonLocalRejected() {
+        let httpUrl = URL(string: "https://rtc.telnyx.com/report")!
+        XCTAssertFalse(SSLValidationHelper.shouldAllowSelfSigned(for: httpUrl))
+    }
+
+    #if DEBUG
+    func testAllowSelfSignedDelegateExistsInDebugBuild() {
+        XCTAssertNotNil(collector)
+    }
+    #endif
+}


### PR DESCRIPTION
## Summary

Fixes VSDK-423 / Resolves VSUP-126

The SDK was unconditionally disabling SSL certificate validation on both the signaling socket and `CallReportCollector`, allowing MITM attacks on production traffic.

## Changes

- **SSLValidationHelper.swift** (new) — Restricts self-signed cert acceptance to localhost and private/loopback IP ranges only. Prevents hostname spoofing via proper IPv4 literal parsing.
- **Socket.swift** — Gates self-signed cert acceptance behind `#if DEBUG` + `SSLValidationHelper`. Release builds always enforce strict validation.
- **TelnyxCallReportCollector.swift** — `AllowSelfSignedDelegate` gated behind `#if DEBUG` and restricted to local hosts. Release builds use `URLSession.shared` with standard system validation.
- **Tests** — 3 new test files covering local host acceptance, non-local rejection, and hostname spoofing prevention.

## Test Plan

- [ ] CI passes (build + tests)
- [ ] Verify DEBUG build connects to localhost with self-signed cert
- [ ] Verify DEBUG build rejects self-signed cert for non-local hosts
- [ ] Verify RELEASE build enforces strict validation for all hosts