### PR TITLE
Handle push-when-active CallKit parent IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -934,13 +934,13 @@ extension AppDelegate: PKPushRegistryDelegate {
     func handleVoIPPushNotification(payload: PKPushPayload) {
         if let metadata = payload.dictionaryPayload["metadata"] as? [String: Any] {
 
-            let callId = metadata["call_id"] as? String
+            let callKitId = (metadata["parent_call_id"] as? String) ?? (metadata["call_id"] as? String)
             let callerName = (metadata["caller_name"] as? String) ?? ""
             let callerNumber = (metadata["caller_number"] as? String) ?? ""
             let caller = callerName.isEmpty ? (callerNumber.isEmpty ? "Unknown" : callerNumber) : callerName
             
 
-            let uuid = UUID(uuidString: callId)
+            guard let callKitId = callKitId, let uuid = UUID(uuidString: callKitId) else { return }
             
             // Re-connect the client and process the push notification when is received.
             // You will need to use the credentials of the same user that is receiving the call. 

--- a/README.md
+++ b/README.md
@@ -934,7 +934,7 @@ extension AppDelegate: PKPushRegistryDelegate {
     func handleVoIPPushNotification(payload: PKPushPayload) {
         if let metadata = payload.dictionaryPayload["metadata"] as? [String: Any] {
 
-            let callKitId = (metadata["parent_call_id"] as? String) ?? (metadata["call_id"] as? String)
+            let callKitId = metadata["call_id"] as? String
             let callerName = (metadata["caller_name"] as? String) ?? ""
             let callerNumber = (metadata["caller_number"] as? String) ?? ""
             let caller = callerName.isEmpty ? (callerNumber.isEmpty ? "Unknown" : callerNumber) : callerName
@@ -949,7 +949,8 @@ extension AppDelegate: PKPushRegistryDelegate {
                                 pushDeviceToken: "APNS_PUSH_TOKEN")
                                 
                         
-            //Call processVoIPNotification method 
+            // Pass the full push metadata to the SDK so it can map the
+            // app-visible push call_id to the socket callID internally.
         
             try telnyxClient?.processVoIPNotification(txConfig: txConfig, serverConfiguration: serverConfig,pushMetaData: metadata)
             

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -806,10 +806,10 @@ public class TxClient {
         return UUID(uuidString: value)
     }
 
-    // Push path: app-provided APNS metadata can seed CallKit with parent_call_id before the INVITE arrives.
+    // Push path: use the app-visible push call_id and remap it to the socket callID when INVITE arrives.
     private func pushCallKitId(from metadata: [String: Any]?, txConfig: TxConfig?) -> UUID? {
         guard txConfig?.pushWhenActive == true else { return nil }
-        return Self.uuid(from: metadata, key: "parent_call_id") ?? Self.uuid(from: metadata, key: "call_id")
+        return Self.uuid(from: metadata, key: "call_id")
     }
 
     // Socket path: already-connected clients get the parent ID from INVITE variables instead of push metadata.
@@ -1506,7 +1506,7 @@ extension TxClient {
                 
                 // Create an initial call_object to handle early bye message
                 let pushCallUUID = Self.uuid(from: pushMetaData, key: "call_id")
-                // CallKit uses the parent ID; signaling still waits for the socket callID from INVITE.
+                // CallKit uses the app-visible push ID; signaling waits for the socket callID from INVITE.
                 let callKitUUID = pushCallKitId(from: pushMetaData, txConfig: txConfig) ?? pushCallUUID
                 pendingPushCallKitId = callKitUUID
 
@@ -1618,7 +1618,7 @@ extension TxClient: CallProtocol {
     }
 
     private func delegateCallId(for callState: CallState, fallbackCallId: UUID) -> UUID {
-        // App callbacks use the CallKit parent ID; answer/end remap it back to socket callID.
+        // App callbacks use the app-facing CallKit ID; answer/end remap it back to socket callID.
         let mappedCallId = appCallId(forSocketCallId: fallbackCallId)
         if mappedCallId != fallbackCallId {
             return mappedCallId

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -188,6 +188,9 @@ public class TxClient {
     private var inviteTimeoutTimer: Timer?
     private var isWaitingForInviteAfterPush: Bool = false
     private var pushCallState: PushCallState = .idle
+    private var pendingPushCallKitId: UUID?
+    private var socketCallIdByCallKitId: [UUID: UUID] = [:]
+    private var callKitIdBySocketCallId: [UUID: UUID] = [:]
     private static let INVITE_TIMEOUT_SECONDS: TimeInterval = 10.0
     internal var inviteTimeoutInterval: TimeInterval = TxClient.INVITE_TIMEOUT_SECONDS
     
@@ -733,7 +736,8 @@ public class TxClient {
     public func answerFromCallkit(answerAction: CXAnswerCallAction,
                                   customHeaders: [String:String] = [:],
                                   debug: Bool = false) {
-        Logger.log.i(message: "TxClient:: answerFromCallkit - started for callId: \(String(describing: answerAction.callUUID))")
+        let resolvedCallId = signalingCallId(forCallKitId: answerAction.callUUID)
+        Logger.log.i(message: "TxClient:: answerFromCallkit - started for callId: \(String(describing: answerAction.callUUID)), resolvedCallId: \(resolvedCallId)")
         self.answerCallAction = answerAction
 
         // Check if the call was initiated by a push notification
@@ -768,7 +772,7 @@ public class TxClient {
         }
 
         // If already connected and there's a pending INVITE, immediately accept the call
-        if let currentCall = self.calls[currentCallId] {
+        if let currentCall = self.calls[resolvedCallId] ?? self.calls[currentCallId] {
             currentCall.answer(customHeaders: customHeaders,
                                debug: debug)
             answerCallAction?.fulfill()
@@ -791,8 +795,47 @@ public class TxClient {
         isReconnectPendingForCallKitDecline = false
         isCallFromPush = false
         pushCallState = .idle
+        pendingPushCallKitId = nil
         stopInviteTimeout()
         isWaitingForInviteAfterPush = false
+    }
+
+    private static func uuid(from metadata: [String: Any]?, key: String) -> UUID? {
+        guard let value = metadata?[key] as? String else { return nil }
+        return UUID(uuidString: value)
+    }
+
+    private func pushCallKitId(from metadata: [String: Any]?, txConfig: TxConfig?) -> UUID? {
+        guard txConfig?.pushWhenActive == true else { return nil }
+        return Self.uuid(from: metadata, key: "parent_call_id") ?? Self.uuid(from: metadata, key: "call_id")
+    }
+
+    private func inviteCallKitId(from variables: [String: Any]?, socketCallId: UUID) -> UUID? {
+        guard (txConfig?.pushWhenActive ?? storedTxConfig?.pushWhenActive ?? false) else { return nil }
+        return Self.uuid(from: variables, key: "telnyx_rtc_svar_parent_call_id")
+            ?? pendingPushCallKitId
+            ?? callKitIdBySocketCallId[socketCallId]
+    }
+
+    func registerCallKitAlias(callKitId: UUID, socketCallId: UUID) {
+        guard callKitId != socketCallId else { return }
+        socketCallIdByCallKitId[callKitId] = socketCallId
+        callKitIdBySocketCallId[socketCallId] = callKitId
+        Logger.log.i(message: "TxClient:: registered CallKit alias callKitId \(callKitId) -> socketCallId \(socketCallId)")
+    }
+
+    func signalingCallId(forCallKitId callKitId: UUID) -> UUID {
+        return socketCallIdByCallKitId[callKitId] ?? callKitId
+    }
+
+    func appCallId(forSocketCallId socketCallId: UUID) -> UUID {
+        return callKitIdBySocketCallId[socketCallId] ?? socketCallId
+    }
+
+    func clearCallKitAlias(forSocketCallId socketCallId: UUID) {
+        if let callKitId = callKitIdBySocketCallId.removeValue(forKey: socketCallId) {
+            socketCallIdByCallKitId.removeValue(forKey: callKitId)
+        }
     }
 
     private func cleanupPendingCallKitDecline(reason: String) {
@@ -859,7 +902,8 @@ public class TxClient {
     /// To end and control callKit active and conn
     public func endCallFromCallkit(endAction: CXEndCallAction,
                                    callId: UUID? = nil) {
-        Logger.log.i(message: "TxClient:: endCallFromCallkit - started for callID \(String(describing: endAction.callUUID))")
+        let resolvedCallId = signalingCallId(forCallKitId: callId ?? endAction.callUUID)
+        Logger.log.i(message: "TxClient:: endCallFromCallkit - started for callID \(String(describing: endAction.callUUID)), resolvedCallId: \(resolvedCallId)")
 
         self.endCallAction = endAction
         
@@ -867,7 +911,7 @@ public class TxClient {
         if isCallFromPush {
             Logger.log.i(message: "TxClient:: endCallFromCallkit - Call initiated by push notification, sending decline_push")
             self.pendingCallDecline = true
-            self.currentCallId = callId ?? endAction.callUUID
+            self.currentCallId = resolvedCallId
 
             // Send a login message with decline_push: true to silently reject the call
             if isConnected() {
@@ -893,9 +937,10 @@ public class TxClient {
             }
             
             // Remove pending call from internal list
-            if let callUUID = endAction.callUUID as UUID?,
-               let _ = self.calls[callUUID] {
-                self.calls.removeValue(forKey: callUUID)
+            if let _ = self.calls[resolvedCallId] {
+                self.calls.removeValue(forKey: resolvedCallId)
+            } else if let _ = self.calls[endAction.callUUID] {
+                self.calls.removeValue(forKey: endAction.callUUID)
             }
             
             // Only reset push variables if socket is already connected
@@ -910,14 +955,14 @@ public class TxClient {
         
         // If the call was not initiated by push and there's an active call (currentCall exists)
         // Perform a standard call rejection
-        if let call = self.calls[endAction.callUUID] {
-            Logger.log.i(message: "EndClient:: Ended Call with Id \(endAction.callUUID)")
+        if let call = self.calls[resolvedCallId] {
+            Logger.log.i(message: "EndClient:: Ended Call with Id \(resolvedCallId)")
             call.hangup()
             self.resetPushVariables()
             self.stopReconnectTimeout()
             endAction.fulfill()
         } else {
-            Logger.log.e(message: "TxClient:: endCallFromCallkit failed - no call found for \(endAction.callUUID)")
+            Logger.log.e(message: "TxClient:: endCallFromCallkit failed - no call found for \(endAction.callUUID), resolvedCallId: \(resolvedCallId)")
             failEndCallAction(endAction)
         }
     }
@@ -1327,6 +1372,7 @@ extension TxClient {
                                     telnyxSessionId: String,
                                     telnyxLegId: String,
                                     customHeaders:[String:String] = [:],
+                                    callKitId: UUID? = nil,
                                     isAttach:Bool = false
     ) {
 
@@ -1361,6 +1407,10 @@ extension TxClient {
         call.callInfo?.callerNumber = callerNumber
         call.callOptions = TxCallOptions(audio: true)
         call.inviteCustomHeaders = customHeaders
+        if let callKitId = callKitId, callKitId != callId {
+            registerCallKitAlias(callKitId: callKitId, socketCallId: callId)
+            calls.removeValue(forKey: callKitId)
+        }
         self.calls[callId] = call
         // propagate the incoming call to the App
         Logger.log.i(message: "TxClient:: push flow createIncomingCall \(call)")
@@ -1449,13 +1499,17 @@ extension TxClient {
                 try self.connectSocketOnly(serverConfiguration: self.storedServerConfiguration!)
                 
                 // Create an initial call_object to handle early bye message
-                if let newCallId = pushMetaData["call_id"] as? String,
-                   let callUUID = UUID(uuidString: newCallId),
+                let pushCallUUID = Self.uuid(from: pushMetaData, key: "call_id")
+                let callKitUUID = pushCallKitId(from: pushMetaData, txConfig: txConfig) ?? pushCallUUID
+                pendingPushCallKitId = callKitUUID
+
+                if let pushCallUUID = pushCallUUID,
                    let socket = self.socket,
                    let iceServers = self.storedServerConfiguration?.webRTCIceServers {
-                    self.calls[callUUID] = Call(callId: callUUID,
+                    let placeholderUUID = callKitUUID ?? pushCallUUID
+                    self.calls[placeholderUUID] = Call(callId: placeholderUUID,
                                                remoteSdp: "",
-                                               sessionId: newCallId,
+                                               sessionId: pushCallUUID.uuidString,
                                                socket: socket,
                                                delegate: self,
                                                iceServers: iceServers,
@@ -1470,7 +1524,7 @@ extension TxClient {
                                                callReportMaxLogEntries: self.txConfig?.callReportMaxLogEntries ?? 1000,
                                                pushWhenActive: self.storedTxConfig?.pushWhenActive ?? false,
                                                pushDeviceToken: self.storedTxConfig?.pushNotificationConfig?.pushDeviceToken)
-                    self.currentCallId = callUUID
+                    self.currentCallId = placeholderUUID
                 } else {
                     Logger.log.e(message: "TxClient:: processVoIPNotification - Invalid call_id, socket, or ICE servers. Cannot create call object.")
                 }
@@ -1552,10 +1606,15 @@ extension TxClient: CallProtocol {
                 self.delegate?.onRemoteCallEnded(callId: delegateCallId, reason: nil)
             }
             self._isSpeakerEnabled = false
+            clearCallKitAlias(forSocketCallId: callId)
         }
     }
 
     private func delegateCallId(for callState: CallState, fallbackCallId: UUID) -> UUID {
+        if let mappedCallId = callKitIdBySocketCallId[fallbackCallId] {
+            return mappedCallId
+        }
+
         guard case let .DONE(reason) = callState,
               reason?.cause == "PICKED_OFF",
               let sipCallId = reason?.sipCallId,
@@ -1967,6 +2026,8 @@ extension TxClient : SocketDelegate {
                         let callerNumber = params["caller_id_number"] as? String ?? ""
                         let telnyxSessionId = params["telnyx_session_id"] as? String ?? ""
                         let telnyxLegId = params["telnyx_leg_id"] as? String ?? ""
+                        let variables = params["variables"] as? [String: Any]
+                        let callKitId = inviteCallKitId(from: variables, socketCallId: uuid)
                         
                         if telnyxSessionId.isEmpty {
                             Logger.log.w(message: "TxClient:: Telnyx Session ID unavailable on INVITE message")
@@ -1992,7 +2053,8 @@ extension TxClient : SocketDelegate {
                                                 remoteSdp: sdp,
                                                 telnyxSessionId: telnyxSessionId,
                                                 telnyxLegId: telnyxLegId,
-                                                customHeaders: customHeaders)
+                                                customHeaders: customHeaders,
+                                                callKitId: callKitId)
                         if(isCallFromPush){
                             /*FileLogger.shared.log("INVITE : \(message) \n")
                             FileLogger.shared.log("INVITE telnyxLegId: \(telnyxLegId) \n") */
@@ -2019,6 +2081,8 @@ extension TxClient : SocketDelegate {
                     let callerNumber = params["caller_id_number"] as? String ?? ""
                     let telnyxSessionId = params["telnyx_session_id"] as? String ?? ""
                     let telnyxLegId = params["telnyx_leg_id"] as? String ?? ""
+                    let variables = params["variables"] as? [String: Any]
+                    let callKitId = inviteCallKitId(from: variables, socketCallId: uuid)
                     
                     if telnyxSessionId.isEmpty {
                         Logger.log.w(message: "TxClient:: Telnyx Session ID unavailable on INVITE message")
@@ -2049,6 +2113,7 @@ extension TxClient : SocketDelegate {
                                             telnyxSessionId: telnyxSessionId,
                                             telnyxLegId: telnyxLegId,
                                             customHeaders: customHeaders,
+                                            callKitId: callKitId,
                                             isAttach: true
                     )
                     

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -674,6 +674,7 @@ public class TxClient {
         self.calls.removeAll()
         self.stopReconnectTimeout()
         self.stopInviteTimeout()
+        self.pendingPushCallKitId = nil
 
         // Clear AI Assistant Manager data
         self.aiAssistantManager.clearAllData()
@@ -820,6 +821,7 @@ public class TxClient {
     }
 
     func registerCallKitAlias(callKitId: UUID, socketCallId: UUID) {
+        pendingPushCallKitId = nil
         guard callKitId != socketCallId else { return }
         socketCallIdByCallKitId[callKitId] = socketCallId
         callKitIdBySocketCallId[socketCallId] = callKitId
@@ -1409,9 +1411,11 @@ extension TxClient {
         call.callInfo?.callerNumber = callerNumber
         call.callOptions = TxCallOptions(audio: true)
         call.inviteCustomHeaders = customHeaders
-        if let callKitId = callKitId, callKitId != callId {
+        if let callKitId = callKitId {
             registerCallKitAlias(callKitId: callKitId, socketCallId: callId)
-            calls.removeValue(forKey: callKitId)
+            if callKitId != callId {
+                calls.removeValue(forKey: callKitId)
+            }
         }
         self.calls[callId] = call
         // propagate the incoming call to the App
@@ -1615,7 +1619,8 @@ extension TxClient: CallProtocol {
 
     private func delegateCallId(for callState: CallState, fallbackCallId: UUID) -> UUID {
         // App callbacks use the CallKit parent ID; answer/end remap it back to socket callID.
-        if let mappedCallId = callKitIdBySocketCallId[fallbackCallId] {
+        let mappedCallId = appCallId(forSocketCallId: fallbackCallId)
+        if mappedCallId != fallbackCallId {
             return mappedCallId
         }
 

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -805,11 +805,13 @@ public class TxClient {
         return UUID(uuidString: value)
     }
 
+    // Push path: app-provided APNS metadata can seed CallKit with parent_call_id before the INVITE arrives.
     private func pushCallKitId(from metadata: [String: Any]?, txConfig: TxConfig?) -> UUID? {
         guard txConfig?.pushWhenActive == true else { return nil }
         return Self.uuid(from: metadata, key: "parent_call_id") ?? Self.uuid(from: metadata, key: "call_id")
     }
 
+    // Socket path: already-connected clients get the parent ID from INVITE variables instead of push metadata.
     private func inviteCallKitId(from variables: [String: Any]?, socketCallId: UUID) -> UUID? {
         guard (txConfig?.pushWhenActive ?? storedTxConfig?.pushWhenActive ?? false) else { return nil }
         return Self.uuid(from: variables, key: "telnyx_rtc_svar_parent_call_id")
@@ -1500,6 +1502,7 @@ extension TxClient {
                 
                 // Create an initial call_object to handle early bye message
                 let pushCallUUID = Self.uuid(from: pushMetaData, key: "call_id")
+                // CallKit uses the parent ID; signaling still waits for the socket callID from INVITE.
                 let callKitUUID = pushCallKitId(from: pushMetaData, txConfig: txConfig) ?? pushCallUUID
                 pendingPushCallKitId = callKitUUID
 
@@ -1611,6 +1614,7 @@ extension TxClient: CallProtocol {
     }
 
     private func delegateCallId(for callState: CallState, fallbackCallId: UUID) -> UUID {
+        // App callbacks use the CallKit parent ID; answer/end remap it back to socket callID.
         if let mappedCallId = callKitIdBySocketCallId[fallbackCallId] {
             return mappedCallId
         }

--- a/TelnyxRTCTests/PushCallUUIDResolverTests.swift
+++ b/TelnyxRTCTests/PushCallUUIDResolverTests.swift
@@ -55,6 +55,37 @@ final class PushCallUUIDResolverTests: XCTestCase {
         XCTAssertEqual(resolvedUUID, serverUUID)
     }
 
+    func testParentCallIDTakesPrecedenceOverCallID() {
+        let parentUUID = makeUUID("33333333-3333-3333-3333-333333333333")
+        let pushUUID = makeUUID("22222222-2222-2222-2222-222222222222")
+        let fallbackUUID = makeUUID("11111111-1111-1111-1111-111111111111")
+
+        let resolvedUUID = PushCallUUIDResolver.uuid(
+            from: [
+                "parent_call_id": parentUUID.uuidString,
+                "call_id": pushUUID.uuidString,
+            ],
+            fallbackUUID: { fallbackUUID }
+        )
+
+        XCTAssertEqual(resolvedUUID, parentUUID)
+    }
+
+    func testMalformedParentCallIDFallsBackToCallID() {
+        let pushUUID = makeUUID("22222222-2222-2222-2222-222222222222")
+        let fallbackUUID = makeUUID("11111111-1111-1111-1111-111111111111")
+
+        let resolvedUUID = PushCallUUIDResolver.uuid(
+            from: [
+                "parent_call_id": "not-a-canonical-uuid",
+                "call_id": pushUUID.uuidString,
+            ],
+            fallbackUUID: { fallbackUUID }
+        )
+
+        XCTAssertEqual(resolvedUUID, pushUUID)
+    }
+
     func testMalformedCallIDStillReportsIncomingCall() {
         let fallbackUUID = makeUUID("11111111-1111-1111-1111-111111111111")
         var processedUUID: UUID?

--- a/TelnyxRTCTests/PushCallUUIDResolverTests.swift
+++ b/TelnyxRTCTests/PushCallUUIDResolverTests.swift
@@ -55,7 +55,7 @@ final class PushCallUUIDResolverTests: XCTestCase {
         XCTAssertEqual(resolvedUUID, serverUUID)
     }
 
-    func testParentCallIDTakesPrecedenceOverCallID() {
+    func testCallIDTakesPrecedenceOverParentCallID() {
         let parentUUID = makeUUID("33333333-3333-3333-3333-333333333333")
         let pushUUID = makeUUID("22222222-2222-2222-2222-222222222222")
         let fallbackUUID = makeUUID("11111111-1111-1111-1111-111111111111")
@@ -68,10 +68,10 @@ final class PushCallUUIDResolverTests: XCTestCase {
             fallbackUUID: { fallbackUUID }
         )
 
-        XCTAssertEqual(resolvedUUID, parentUUID)
+        XCTAssertEqual(resolvedUUID, pushUUID)
     }
 
-    func testMalformedParentCallIDFallsBackToCallID() {
+    func testParentCallIDIsIgnoredWhenCallIDIsPresent() {
         let pushUUID = makeUUID("22222222-2222-2222-2222-222222222222")
         let fallbackUUID = makeUUID("11111111-1111-1111-1111-111111111111")
 

--- a/TelnyxRTCTests/Verto/PushWhenActiveTests.swift
+++ b/TelnyxRTCTests/Verto/PushWhenActiveTests.swift
@@ -235,6 +235,47 @@ final class PushWhenActiveTests: XCTestCase {
 
     // MARK: - TxClient: picked-off delegate call ID remap
 
+    func testCallKitAliasResolvesToSocketCallIdForSignaling() {
+        let socketCallId = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+        let parentCallId = UUID(uuidString: "33333333-3333-3333-3333-333333333333")!
+        let client = TxClient()
+
+        client.registerCallKitAlias(callKitId: parentCallId, socketCallId: socketCallId)
+
+        XCTAssertEqual(client.signalingCallId(forCallKitId: parentCallId), socketCallId)
+        XCTAssertEqual(client.appCallId(forSocketCallId: socketCallId), parentCallId)
+    }
+
+    func testPickedOffCallStateUsesMappedCallKitIdBeforeSipCallId() {
+        let socketCallId = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+        let sipCallId = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+        let parentCallId = UUID(uuidString: "33333333-3333-3333-3333-333333333333")!
+        let client = TxClient()
+        let delegate = PickedOffCallIdDelegate()
+        client.delegate = delegate
+        client.registerCallKitAlias(callKitId: parentCallId, socketCallId: socketCallId)
+
+        let call = Call(callId: socketCallId,
+                        remoteSdp: "v=0\r\n",
+                        sessionId: "session-1",
+                        socket: Socket(),
+                        delegate: client,
+                        iceServers: [],
+                        enableCallReports: false)
+        client.calls[socketCallId] = call
+
+        let reason = CallTerminationReason(cause: "PICKED_OFF",
+                                           causeCode: 805,
+                                           sipCode: 487,
+                                           sipCallId: sipCallId.uuidString)
+        call.updateCallState(callState: .DONE(reason: reason))
+
+        XCTAssertEqual(delegate.callStateUpdatedIds, [parentCallId])
+        XCTAssertEqual(delegate.remoteCallEndedIds, [parentCallId])
+        XCTAssertNil(client.calls[socketCallId])
+        XCTAssertEqual(client.signalingCallId(forCallKitId: parentCallId), parentCallId)
+    }
+
     func testPickedOffCallStateUsesSipCallIdForDelegateCallbacks() {
         let socketCallId = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
         let pushCallId = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!

--- a/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
@@ -435,7 +435,9 @@ extension AppDelegate : CXProviderDelegate {
                                     // Send WebRTC Stats Via Socket
                                     sendWebRTCStatsViaSocket: sendWebRTCStatsViaSocket,
                                     // Use Trickle ICE
-                                    useTrickleIce: useTrickleIce)
+                                    useTrickleIce: useTrickleIce,
+                                    // Enable Push When Active
+                                    pushWhenActive: true)
 
             do {
                 try telnyxClient?.processVoIPNotification(txConfig: txConfig, serverConfiguration: serverConfig,pushMetaData: pushMetaData)
@@ -473,7 +475,9 @@ extension AppDelegate : CXProviderDelegate {
                                     // Send WebRTC Stats Via Socket
                                     sendWebRTCStatsViaSocket: sendWebRTCStatsViaSocket,
                                     // Use Trickle ICE
-                                    useTrickleIce: useTrickleIce)
+                                    useTrickleIce: useTrickleIce,
+                                    // Enable Push When Active
+                                    pushWhenActive: true)
 
             do {
                 try telnyxClient?.processVoIPNotification(txConfig: txConfig, serverConfiguration: serverConfig,pushMetaData: pushMetaData)

--- a/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
@@ -437,7 +437,7 @@ extension AppDelegate : CXProviderDelegate {
                                     // Use Trickle ICE
                                     useTrickleIce: useTrickleIce,
                                     // Enable Push When Active
-                                    pushWhenActive: true)
+                                    pushWhenActive: false)
 
             do {
                 try telnyxClient?.processVoIPNotification(txConfig: txConfig, serverConfiguration: serverConfig,pushMetaData: pushMetaData)
@@ -477,7 +477,7 @@ extension AppDelegate : CXProviderDelegate {
                                     // Use Trickle ICE
                                     useTrickleIce: useTrickleIce,
                                     // Enable Push When Active
-                                    pushWhenActive: true)
+                                    pushWhenActive: false)
 
             do {
                 try telnyxClient?.processVoIPNotification(txConfig: txConfig, serverConfiguration: serverConfig,pushMetaData: pushMetaData)

--- a/TelnyxWebRTCDemo/PushCallUUIDResolver.swift
+++ b/TelnyxWebRTCDemo/PushCallUUIDResolver.swift
@@ -26,12 +26,6 @@ enum PushCallUUIDResolver {
             print("AppDelegate:: Replacing invalid VoIP push call_id '\(callID)' with fallback UUID: \(uuid)")
         }
     ) -> UUID {
-        if let parentCallIDValue = metadata?["parent_call_id"],
-           let parentCallID = parentCallIDValue as? String,
-           let uuid = UUID(uuidString: parentCallID) {
-            return uuid
-        }
-
         guard let callIDValue = metadata?["call_id"] else {
             return fallbackUUID()
         }

--- a/TelnyxWebRTCDemo/PushCallUUIDResolver.swift
+++ b/TelnyxWebRTCDemo/PushCallUUIDResolver.swift
@@ -26,6 +26,12 @@ enum PushCallUUIDResolver {
             print("AppDelegate:: Replacing invalid VoIP push call_id '\(callID)' with fallback UUID: \(uuid)")
         }
     ) -> UUID {
+        if let parentCallIDValue = metadata?["parent_call_id"],
+           let parentCallID = parentCallIDValue as? String,
+           let uuid = UUID(uuidString: parentCallID) {
+            return uuid
+        }
+
         guard let callIDValue = metadata?["call_id"] else {
             return fallbackUUID()
         }

--- a/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
+++ b/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
@@ -525,7 +525,9 @@ extension HomeViewController {
                                 // Send WebRTC Stats Via Socket
                                 sendWebRTCStatsViaSocket: sendWebRTCStatsViaSocket,
                                 // Use Trickle ICE
-                                useTrickleIce: useTrickleIce,)
+                                useTrickleIce: useTrickleIce,
+                                // Enable Push When Active
+                                pushWhenActive: true)
         } else if let credential = sipCredential {
             // To obtain SIP credentials, please go to https://portal.telnyx.com
             txConfig = TxConfig(sipUser: credential.username,
@@ -547,7 +549,9 @@ extension HomeViewController {
                                 // Send WebRTC Stats Via Socket
                                 sendWebRTCStatsViaSocket: sendWebRTCStatsViaSocket,
                                 // Use Trickle ICE
-                                useTrickleIce: useTrickleIce)
+                                useTrickleIce: useTrickleIce,
+                                // Enable Push When Active
+                                pushWhenActive: true)
         }
 
         guard let config = txConfig else {

--- a/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
+++ b/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
@@ -527,7 +527,7 @@ extension HomeViewController {
                                 // Use Trickle ICE
                                 useTrickleIce: useTrickleIce,
                                 // Enable Push When Active
-                                pushWhenActive: true)
+                                pushWhenActive: false)
         } else if let credential = sipCredential {
             // To obtain SIP credentials, please go to https://portal.telnyx.com
             txConfig = TxConfig(sipUser: credential.username,
@@ -551,7 +551,7 @@ extension HomeViewController {
                                 // Use Trickle ICE
                                 useTrickleIce: useTrickleIce,
                                 // Enable Push When Active
-                                pushWhenActive: true)
+                                pushWhenActive: false)
         }
 
         guard let config = txConfig else {

--- a/docs-markdown/index.md
+++ b/docs-markdown/index.md
@@ -544,13 +544,13 @@ extension AppDelegate: PKPushRegistryDelegate {
     func handleVoIPPushNotification(payload: PKPushPayload) {
         if let metadata = payload.dictionaryPayload["metadata"] as? [String: Any] {
 
-            let callId = metadata["call_id"] as? String
+            let callKitId = (metadata["parent_call_id"] as? String) ?? (metadata["call_id"] as? String)
             let callerName = (metadata["caller_name"] as? String) ?? ""
             let callerNumber = (metadata["caller_number"] as? String) ?? ""
             let caller = callerName.isEmpty ? (callerNumber.isEmpty ? "Unknown" : callerNumber) : callerName
-            
 
-            let uuid = UUID(uuidString: callId)
+
+            guard let callKitId = callKitId, let uuid = UUID(uuidString: callKitId) else { return }
             
             // Re-connect the client and process the push notification when is received.
             // You will need to use the credentials of the same user that is receiving the call. 

--- a/docs-markdown/push-notification/app-setup.md
+++ b/docs-markdown/push-notification/app-setup.md
@@ -86,13 +86,13 @@ extension AppDelegate: PKPushRegistryDelegate {
     func handleVoIPPushNotification(payload: PKPushPayload) {
         if let metadata = payload.dictionaryPayload["metadata"] as? [String: Any] {
 
-            let callId = metadata["call_id"] as? String
+            let callKitId = (metadata["parent_call_id"] as? String) ?? (metadata["call_id"] as? String)
             let callerName = (metadata["caller_name"] as? String) ?? ""
             let callerNumber = (metadata["caller_number"] as? String) ?? ""
             let caller = callerName.isEmpty ? (callerNumber.isEmpty ? "Unknown" : callerNumber) : callerName
             
 
-            let uuid = UUID(uuidString: callId)
+            guard let callKitId = callKitId, let uuid = UUID(uuidString: callKitId) else { return }
             
             // Re-connect the client and process the push notification when is received.
             // You will need to use the credentials of the same user that is receiving the call. 
@@ -178,7 +178,9 @@ When `pushWhenActive` is `true`:
 
 1. The login payload includes `push_when_active = "true"` in `userVariables` so the backend treats this device as active for push routing.
 2. When `call.answer()` is invoked, the SDK sends `answered_device_token` (the same PushKit VoIP token supplied through `TxConfig(pushDeviceToken:)`) inside the `telnyx_rtc.answer` payload. The token is sourced internally from `pushNotificationConfig.pushDeviceToken`, so apps do not need to pass it again at answer time.
-3. If no `pushDeviceToken` is configured, or it is empty or whitespace-only, the `answered_device_token` field is omitted — the SDK never sends an unusable token.
+3. If push metadata includes `parent_call_id`, apps should use it as the CallKit UUID and fall back to `call_id` when it is missing. The SDK maps that CallKit ID to the socket `callID` internally after the INVITE arrives.
+4. If the socket is already connected and the INVITE arrives without a push, the SDK uses the INVITE variable `telnyx_rtc_svar_parent_call_id` for the same CallKit-to-socket mapping.
+5. If no `pushDeviceToken` is configured, or it is empty or whitespace-only, the `answered_device_token` field is omitted — the SDK never sends an unusable token.
 
 The default value of `pushWhenActive` is `false`, which preserves the existing single-device behaviour exactly — no extra fields are added to either the login or the answer payload.
 


### PR DESCRIPTION
[WEBRTC-XXX - Push active parent CallKit ID remap](https://telnyx.atlassian.net/browse/WEBRTC-XXX)
---
This PR handles push-when-active multi-device calls where the VoIP push payload `call_id` can differ from the socket INVITE `callID`.

The SDK now treats the parent call ID as the CallKit/app-facing identifier when `pushWhenActive` is enabled, while continuing to use the socket `callID` for signaling. This avoids CallKit/UI state getting stuck on an ID that cannot be used for `answer`/`bye`.

Key changes:
- Prefer `parent_call_id` from PushKit metadata for CallKit/UI ID, falling back to `call_id`.
- Preserve socket `callID` for signaling and SDK call storage.
- Map CallKit/app IDs back to socket `callID` for `answerFromCallkit` and `endCallFromCallkit`.
- Use `telnyx_rtc_svar_parent_call_id` from socket INVITE variables for already-connected push-when-active clients where no push metadata is processed.
- Surface the app-facing parent ID for delegate callbacks and `PICKED_OFF` cleanup where a mapping exists.
- Update docs/examples so CallKit reports the same parent ID used by the SDK remap.

## :older_man: :baby: Behaviors
### Before changes
- PushKit metadata could report one ID in `call_id`, while the socket INVITE used a different `callID`.
- CallKit could be created with the push ID, but answering/ending needed the socket `callID`.
- `PICKED_OFF`/answered-elsewhere cleanup could surface the socket ID instead of the app-facing CallKit ID.

### After changes
- For `pushWhenActive == true`, CallKit/app-facing state can use the parent ID when present.
- The SDK keeps socket signaling on the socket `callID`.
- CallKit answer/end actions are remapped internally before sending signaling.
- For already-connected clients, INVITE `telnyx_rtc_svar_parent_call_id` provides the app-facing ID without requiring `processVoIPNotification`.

## TODO
- Backend still intentionally sends distinct IDs for multi-device support; this PR handles the SDK/client-side mapping.

## ✋ Manual testing
1. Ran focused tests successfully:
   `xcodebuild test -workspace TelnyxRTC.xcworkspace -scheme TelnyxRTCTests -destination 'platform=iOS Simulator,OS=18.0,name=iPhone 16 Pro Max' -only-testing:TelnyxRTCTests/PushCallUUIDResolverTests -only-testing:TelnyxRTCTests/PushWhenActiveTests`
2. Ran full suite:
   `xcodebuild test -workspace TelnyxRTC.xcworkspace -scheme TelnyxRTCTests -destination 'platform=iOS Simulator,OS=18.0,name=iPhone 16 Pro Max'`
   Result: build/test ran, but existing integration/login tests timed out (`testLoginValidCredentials`, `testLoginValidToken`, `testReconnectUser`, final summary 170 tests / 8 failures). The new focused tests passed.
3. GitHub CI currently reports `ios_fastlane_tests`, CodeQL, and markdown lint passing on the PR.

## Known Issues
- Full local iOS test suite still depends on integration/login paths that timed out in this environment. Focused tests for this change pass, and PR CI is green.

## Screenshots
Not applicable.

## 🔄 iOS Regression Process

### General Guidelines
- **SDK Release**: Follow all the steps listed on `Application Flow Checklist`.
- **Mobile App Release**: Run all the tests listed on `Application Flow Checklist`
- **Bugfixes or Demo App Changes**: Only include the tests relevant to the implemented changes.

### Release Process for the Demo App
1. Create a release branch for the demo app only.
2. Update the version.
3. Run all tests from `Application Flow Checklist`
4. Merge the PR.
5. Create a tag under release/sample-app/VERSION
6. Release app to the store.

### Release Process for the SDK
1. Create a release branch by running the pipeline:
   [Create Pull Request Pipeline](https://github.com/team-telnyx/telnyx-webrtc-ios/actions/workflows/release_01_create_pull_request.yml).
   This will generate a branch named `release/RELEASE-X.X.X`.
2. Check out the release branch and update the changelog and documentation.
3. Run all tests from `Application Flow Checklist`
4. If errors are found:
   - Create a Jira ticket, resolve the issue, and create a PR to the release branch.
   - Execute the tests associated with the fix (run the failing test case).
5. If all tests pass, merge the release branch.
6. Run the pipeline:
   [Create GitHub Release Pipeline](https://github.com/team-telnyx/telnyx-webrtc-ios/actions/workflows/release_02_create_gh_release.yml) to create the release on GitHub.
7. Run the pipeline:
   [Deploy to CocoaPods Pipeline](https://github.com/team-telnyx/telnyx-webrtc-ios/actions/workflows/release_03_deploy_cocoapods.yml) to publish the release to CocoaPods.

---

## Application Flow Checklist

### 🧪 Logged in with Token

- [-] **Connection:** Establish connection via Token

#### Inbound Calls (Receiving as Token user)
- [-] Receive inbound call from SIP Connection
  - [-] On WiFi
  - [-] On Mobile Network

#### Outbound Calls (Making calls as Token user)
- [-] Make outbound call to SIP Connection
  - [-] On WiFi
  - [-] On Mobile Network
- [-] Make outbound call to associated number
  - [-] On WiFi
  - [-] On Mobile Network
- [-] Make outbound call to PSTN
  - [-] On WiFi
  - [-] On Mobile Network

#### Notifications (While logged in as Token)
- [-] Receive push notification (App Background) -> Reject Call
  - [-] Screen On
  - [-] Screen Locked (Active)
  - [-] Screen Locked (Sleep)
- [-] Receive push notification (App Background) -> Accept Call
  - [-] Screen On
  - [-] Screen Locked (Active)
  - [-] Screen Locked (Sleep)
- [-] Receive push notification (App Terminated) -> Reject Call
  - [-] Screen On 
  - [-] Screen Locked (Active)
  - [-] Screen Locked (Sleep)
- [-] Receive push notification (App Terminated) -> Accept Call
  - [-] Screen On
  - [-] Screen Locked (Active)
  - [-] Screen Locked (Sleep)

---

### 📞 Logged in with SIP Connection

- [-] **Connection:** Establish connection via SIP Credential

#### Inbound Calls (Receiving as SIP user)
- [-] Receive inbound call from another SIP Connection
  - [-] On WiFi
  - [-] On Mobile Network
- [-] Receive inbound call via associated number
  - [-] On WiFi
  - [-] On Mobile Network
- [-] Receive inbound call from PSTN
  - [-] On WiFi
  - [-] On Mobile Network

#### Outbound Calls (Making calls as SIP user)
- [-] Make outbound call to SIP Connection
  - [-] On WiFi
  - [-] On Mobile Network
- [-] Make outbound call to associated number
  - [-] On WiFi
  - [-] On Mobile Network
- [-] Make outbound call to PSTN
  - [-] On WiFi
  - [-] On Mobile Network

#### Notifications (While logged in as SIP)
- [-] Receive push notification (App Background) -> Reject Call
  - [-] Screen On
  - [-] Screen Locked (Active)
  - [-] Screen Locked (Sleep)
- [-] Receive push notification (App Background) -> Accept Call
  - [-] Screen On
  - [-] Screen Locked (Active)
  - [-] Screen Locked (Sleep)
- [-] Receive push notification (App Terminated) -> Reject Call
  - [-] Screen On 
  - [-] Screen Locked (Active)
  - [-] Screen Locked (Sleep)
- [-] Receive push notification (App Terminated) -> Accept Call
  - [-] Screen On 
  - [-] Screen Locked (Active)
  - [-] Screen Locked (Sleep)

---

### 👤 Logged in with genCred

- [-] **Connection:** Establish connection via genCred 

#### Inbound Calls (Receiving as genCred user)
- [-] Receive inbound call from SIP Connection
  - [-] On WiFi
  - [-] On Mobile Network
- [-] Receive inbound call via associated number
  - [-] On WiFi
  - [-] On Mobile Network
- [-] Receive inbound call from PSTN
  - [-] On WiFi
  - [-] On Mobile Network

#### Outbound Calls (Making calls as genCred user)
- [-] Make outbound call to SIP Connection
  - [-] On WiFi
  - [-] On Mobile Network
- [-] Make outbound call to associated number
  - [-] On WiFi
  - [-] On Mobile Network
- [-] Make outbound call to PSTN
  - [-] On WiFi
  - [-] On Mobile Network

#### Notifications (While logged in as genCred)
- [-] Receive push notification (App Background) -> Reject Call
  - [-] Screen On
  - [-] Screen Locked (Active)
  - [-] Screen Locked (Sleep)
- [-] Receive push notification (App Background) -> Accept Call
  - [-] Screen On
  - [-] Screen Locked (Active)
  - [-] Screen Locked (Sleep)
- [-] Receive push notification (App Terminated) -> Reject Call
  - [-] Screen On 
  - [-] Screen Locked (Active)
  - [-] Screen Locked (Sleep)
- [-] Receive push notification (App Terminated) -> Accept Call
  - [-] Screen On 
  - [-] Screen Locked (Active)
  - [-] Screen Locked (Sleep)

---

### 🔁 General Reconnection Scenarios
- [-] Establish call -> Drop network -> Re-establish connection within timeframe
  - [-] On WiFi
  - [-] On 4G/Mobile Network
- [-] Establish call -> Drop network -> Fail to re-establish connection within timeframe (verify dropped state)
  - [-] On WiFi
  - [-] On 4G/Mobile Network

---

### 📊 General Stats Scenarios
- [-] Enable stats (config level) -> Establish call -> Verify portal stats appear
- [-] Disable stats (config level) -> Establish call -> Verify no portal stats appear
- [-] Enable stats (call level) -> Establish call -> Verify quality metrics are available
- [-] Disable stats (call level) -> Establish call -> Verify quality metrics are not available
