### PR TITLE
Revert PR #365

### DIFF
--- a/README.md
+++ b/README.md
@@ -934,13 +934,13 @@ extension AppDelegate: PKPushRegistryDelegate {
     func handleVoIPPushNotification(payload: PKPushPayload) {
         if let metadata = payload.dictionaryPayload["metadata"] as? [String: Any] {
 
-            let callKitId = metadata["call_id"] as? String
+            let callId = metadata["call_id"] as? String
             let callerName = (metadata["caller_name"] as? String) ?? ""
             let callerNumber = (metadata["caller_number"] as? String) ?? ""
             let caller = callerName.isEmpty ? (callerNumber.isEmpty ? "Unknown" : callerNumber) : callerName
             
 
-            guard let callKitId = callKitId, let uuid = UUID(uuidString: callKitId) else { return }
+            let uuid = UUID(uuidString: callId)
             
             // Re-connect the client and process the push notification when is received.
             // You will need to use the credentials of the same user that is receiving the call. 
@@ -949,8 +949,7 @@ extension AppDelegate: PKPushRegistryDelegate {
                                 pushDeviceToken: "APNS_PUSH_TOKEN")
                                 
                         
-            // Pass the full push metadata to the SDK so it can map the
-            // app-visible push call_id to the socket callID internally.
+            //Call processVoIPNotification method 
         
             try telnyxClient?.processVoIPNotification(txConfig: txConfig, serverConfiguration: serverConfig,pushMetaData: metadata)
             

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -188,9 +188,6 @@ public class TxClient {
     private var inviteTimeoutTimer: Timer?
     private var isWaitingForInviteAfterPush: Bool = false
     private var pushCallState: PushCallState = .idle
-    private var pendingPushCallKitId: UUID?
-    private var socketCallIdByCallKitId: [UUID: UUID] = [:]
-    private var callKitIdBySocketCallId: [UUID: UUID] = [:]
     private static let INVITE_TIMEOUT_SECONDS: TimeInterval = 10.0
     internal var inviteTimeoutInterval: TimeInterval = TxClient.INVITE_TIMEOUT_SECONDS
     
@@ -674,7 +671,6 @@ public class TxClient {
         self.calls.removeAll()
         self.stopReconnectTimeout()
         self.stopInviteTimeout()
-        self.pendingPushCallKitId = nil
 
         // Clear AI Assistant Manager data
         self.aiAssistantManager.clearAllData()
@@ -737,8 +733,7 @@ public class TxClient {
     public func answerFromCallkit(answerAction: CXAnswerCallAction,
                                   customHeaders: [String:String] = [:],
                                   debug: Bool = false) {
-        let resolvedCallId = signalingCallId(forCallKitId: answerAction.callUUID)
-        Logger.log.i(message: "TxClient:: answerFromCallkit - started for callId: \(String(describing: answerAction.callUUID)), resolvedCallId: \(resolvedCallId)")
+        Logger.log.i(message: "TxClient:: answerFromCallkit - started for callId: \(String(describing: answerAction.callUUID))")
         self.answerCallAction = answerAction
 
         // Check if the call was initiated by a push notification
@@ -773,7 +768,7 @@ public class TxClient {
         }
 
         // If already connected and there's a pending INVITE, immediately accept the call
-        if let currentCall = self.calls[resolvedCallId] ?? self.calls[currentCallId] {
+        if let currentCall = self.calls[currentCallId] {
             currentCall.answer(customHeaders: customHeaders,
                                debug: debug)
             answerCallAction?.fulfill()
@@ -796,50 +791,8 @@ public class TxClient {
         isReconnectPendingForCallKitDecline = false
         isCallFromPush = false
         pushCallState = .idle
-        pendingPushCallKitId = nil
         stopInviteTimeout()
         isWaitingForInviteAfterPush = false
-    }
-
-    private static func uuid(from metadata: [String: Any]?, key: String) -> UUID? {
-        guard let value = metadata?[key] as? String else { return nil }
-        return UUID(uuidString: value)
-    }
-
-    // Push path: use the app-visible push call_id and remap it to the socket callID when INVITE arrives.
-    private func pushCallKitId(from metadata: [String: Any]?, txConfig: TxConfig?) -> UUID? {
-        guard txConfig?.pushWhenActive == true else { return nil }
-        return Self.uuid(from: metadata, key: "call_id")
-    }
-
-    // Socket path: already-connected clients get the parent ID from INVITE variables instead of push metadata.
-    private func inviteCallKitId(from variables: [String: Any]?, socketCallId: UUID) -> UUID? {
-        guard (txConfig?.pushWhenActive ?? storedTxConfig?.pushWhenActive ?? false) else { return nil }
-        return Self.uuid(from: variables, key: "telnyx_rtc_svar_parent_call_id")
-            ?? pendingPushCallKitId
-            ?? callKitIdBySocketCallId[socketCallId]
-    }
-
-    func registerCallKitAlias(callKitId: UUID, socketCallId: UUID) {
-        pendingPushCallKitId = nil
-        guard callKitId != socketCallId else { return }
-        socketCallIdByCallKitId[callKitId] = socketCallId
-        callKitIdBySocketCallId[socketCallId] = callKitId
-        Logger.log.i(message: "TxClient:: registered CallKit alias callKitId \(callKitId) -> socketCallId \(socketCallId)")
-    }
-
-    func signalingCallId(forCallKitId callKitId: UUID) -> UUID {
-        return socketCallIdByCallKitId[callKitId] ?? callKitId
-    }
-
-    func appCallId(forSocketCallId socketCallId: UUID) -> UUID {
-        return callKitIdBySocketCallId[socketCallId] ?? socketCallId
-    }
-
-    func clearCallKitAlias(forSocketCallId socketCallId: UUID) {
-        if let callKitId = callKitIdBySocketCallId.removeValue(forKey: socketCallId) {
-            socketCallIdByCallKitId.removeValue(forKey: callKitId)
-        }
     }
 
     private func cleanupPendingCallKitDecline(reason: String) {
@@ -906,8 +859,7 @@ public class TxClient {
     /// To end and control callKit active and conn
     public func endCallFromCallkit(endAction: CXEndCallAction,
                                    callId: UUID? = nil) {
-        let resolvedCallId = signalingCallId(forCallKitId: callId ?? endAction.callUUID)
-        Logger.log.i(message: "TxClient:: endCallFromCallkit - started for callID \(String(describing: endAction.callUUID)), resolvedCallId: \(resolvedCallId)")
+        Logger.log.i(message: "TxClient:: endCallFromCallkit - started for callID \(String(describing: endAction.callUUID))")
 
         self.endCallAction = endAction
         
@@ -915,7 +867,7 @@ public class TxClient {
         if isCallFromPush {
             Logger.log.i(message: "TxClient:: endCallFromCallkit - Call initiated by push notification, sending decline_push")
             self.pendingCallDecline = true
-            self.currentCallId = resolvedCallId
+            self.currentCallId = callId ?? endAction.callUUID
 
             // Send a login message with decline_push: true to silently reject the call
             if isConnected() {
@@ -941,10 +893,9 @@ public class TxClient {
             }
             
             // Remove pending call from internal list
-            if let _ = self.calls[resolvedCallId] {
-                self.calls.removeValue(forKey: resolvedCallId)
-            } else if let _ = self.calls[endAction.callUUID] {
-                self.calls.removeValue(forKey: endAction.callUUID)
+            if let callUUID = endAction.callUUID as UUID?,
+               let _ = self.calls[callUUID] {
+                self.calls.removeValue(forKey: callUUID)
             }
             
             // Only reset push variables if socket is already connected
@@ -959,14 +910,14 @@ public class TxClient {
         
         // If the call was not initiated by push and there's an active call (currentCall exists)
         // Perform a standard call rejection
-        if let call = self.calls[resolvedCallId] {
-            Logger.log.i(message: "EndClient:: Ended Call with Id \(resolvedCallId)")
+        if let call = self.calls[endAction.callUUID] {
+            Logger.log.i(message: "EndClient:: Ended Call with Id \(endAction.callUUID)")
             call.hangup()
             self.resetPushVariables()
             self.stopReconnectTimeout()
             endAction.fulfill()
         } else {
-            Logger.log.e(message: "TxClient:: endCallFromCallkit failed - no call found for \(endAction.callUUID), resolvedCallId: \(resolvedCallId)")
+            Logger.log.e(message: "TxClient:: endCallFromCallkit failed - no call found for \(endAction.callUUID)")
             failEndCallAction(endAction)
         }
     }
@@ -1376,7 +1327,6 @@ extension TxClient {
                                     telnyxSessionId: String,
                                     telnyxLegId: String,
                                     customHeaders:[String:String] = [:],
-                                    callKitId: UUID? = nil,
                                     isAttach:Bool = false
     ) {
 
@@ -1411,12 +1361,6 @@ extension TxClient {
         call.callInfo?.callerNumber = callerNumber
         call.callOptions = TxCallOptions(audio: true)
         call.inviteCustomHeaders = customHeaders
-        if let callKitId = callKitId {
-            registerCallKitAlias(callKitId: callKitId, socketCallId: callId)
-            if callKitId != callId {
-                calls.removeValue(forKey: callKitId)
-            }
-        }
         self.calls[callId] = call
         // propagate the incoming call to the App
         Logger.log.i(message: "TxClient:: push flow createIncomingCall \(call)")
@@ -1505,18 +1449,13 @@ extension TxClient {
                 try self.connectSocketOnly(serverConfiguration: self.storedServerConfiguration!)
                 
                 // Create an initial call_object to handle early bye message
-                let pushCallUUID = Self.uuid(from: pushMetaData, key: "call_id")
-                // CallKit uses the app-visible push ID; signaling waits for the socket callID from INVITE.
-                let callKitUUID = pushCallKitId(from: pushMetaData, txConfig: txConfig) ?? pushCallUUID
-                pendingPushCallKitId = callKitUUID
-
-                if let pushCallUUID = pushCallUUID,
+                if let newCallId = pushMetaData["call_id"] as? String,
+                   let callUUID = UUID(uuidString: newCallId),
                    let socket = self.socket,
                    let iceServers = self.storedServerConfiguration?.webRTCIceServers {
-                    let placeholderUUID = callKitUUID ?? pushCallUUID
-                    self.calls[placeholderUUID] = Call(callId: placeholderUUID,
+                    self.calls[callUUID] = Call(callId: callUUID,
                                                remoteSdp: "",
-                                               sessionId: pushCallUUID.uuidString,
+                                               sessionId: newCallId,
                                                socket: socket,
                                                delegate: self,
                                                iceServers: iceServers,
@@ -1531,7 +1470,7 @@ extension TxClient {
                                                callReportMaxLogEntries: self.txConfig?.callReportMaxLogEntries ?? 1000,
                                                pushWhenActive: self.storedTxConfig?.pushWhenActive ?? false,
                                                pushDeviceToken: self.storedTxConfig?.pushNotificationConfig?.pushDeviceToken)
-                    self.currentCallId = placeholderUUID
+                    self.currentCallId = callUUID
                 } else {
                     Logger.log.e(message: "TxClient:: processVoIPNotification - Invalid call_id, socket, or ICE servers. Cannot create call object.")
                 }
@@ -1613,17 +1552,10 @@ extension TxClient: CallProtocol {
                 self.delegate?.onRemoteCallEnded(callId: delegateCallId, reason: nil)
             }
             self._isSpeakerEnabled = false
-            clearCallKitAlias(forSocketCallId: callId)
         }
     }
 
     private func delegateCallId(for callState: CallState, fallbackCallId: UUID) -> UUID {
-        // App callbacks use the app-facing CallKit ID; answer/end remap it back to socket callID.
-        let mappedCallId = appCallId(forSocketCallId: fallbackCallId)
-        if mappedCallId != fallbackCallId {
-            return mappedCallId
-        }
-
         guard case let .DONE(reason) = callState,
               reason?.cause == "PICKED_OFF",
               let sipCallId = reason?.sipCallId,
@@ -2035,8 +1967,6 @@ extension TxClient : SocketDelegate {
                         let callerNumber = params["caller_id_number"] as? String ?? ""
                         let telnyxSessionId = params["telnyx_session_id"] as? String ?? ""
                         let telnyxLegId = params["telnyx_leg_id"] as? String ?? ""
-                        let variables = params["variables"] as? [String: Any]
-                        let callKitId = inviteCallKitId(from: variables, socketCallId: uuid)
                         
                         if telnyxSessionId.isEmpty {
                             Logger.log.w(message: "TxClient:: Telnyx Session ID unavailable on INVITE message")
@@ -2062,8 +1992,7 @@ extension TxClient : SocketDelegate {
                                                 remoteSdp: sdp,
                                                 telnyxSessionId: telnyxSessionId,
                                                 telnyxLegId: telnyxLegId,
-                                                customHeaders: customHeaders,
-                                                callKitId: callKitId)
+                                                customHeaders: customHeaders)
                         if(isCallFromPush){
                             /*FileLogger.shared.log("INVITE : \(message) \n")
                             FileLogger.shared.log("INVITE telnyxLegId: \(telnyxLegId) \n") */
@@ -2090,8 +2019,6 @@ extension TxClient : SocketDelegate {
                     let callerNumber = params["caller_id_number"] as? String ?? ""
                     let telnyxSessionId = params["telnyx_session_id"] as? String ?? ""
                     let telnyxLegId = params["telnyx_leg_id"] as? String ?? ""
-                    let variables = params["variables"] as? [String: Any]
-                    let callKitId = inviteCallKitId(from: variables, socketCallId: uuid)
                     
                     if telnyxSessionId.isEmpty {
                         Logger.log.w(message: "TxClient:: Telnyx Session ID unavailable on INVITE message")
@@ -2122,7 +2049,6 @@ extension TxClient : SocketDelegate {
                                             telnyxSessionId: telnyxSessionId,
                                             telnyxLegId: telnyxLegId,
                                             customHeaders: customHeaders,
-                                            callKitId: callKitId,
                                             isAttach: true
                     )
                     

--- a/TelnyxRTCTests/PushCallUUIDResolverTests.swift
+++ b/TelnyxRTCTests/PushCallUUIDResolverTests.swift
@@ -55,37 +55,6 @@ final class PushCallUUIDResolverTests: XCTestCase {
         XCTAssertEqual(resolvedUUID, serverUUID)
     }
 
-    func testCallIDTakesPrecedenceOverParentCallID() {
-        let parentUUID = makeUUID("33333333-3333-3333-3333-333333333333")
-        let pushUUID = makeUUID("22222222-2222-2222-2222-222222222222")
-        let fallbackUUID = makeUUID("11111111-1111-1111-1111-111111111111")
-
-        let resolvedUUID = PushCallUUIDResolver.uuid(
-            from: [
-                "parent_call_id": parentUUID.uuidString,
-                "call_id": pushUUID.uuidString,
-            ],
-            fallbackUUID: { fallbackUUID }
-        )
-
-        XCTAssertEqual(resolvedUUID, pushUUID)
-    }
-
-    func testParentCallIDIsIgnoredWhenCallIDIsPresent() {
-        let pushUUID = makeUUID("22222222-2222-2222-2222-222222222222")
-        let fallbackUUID = makeUUID("11111111-1111-1111-1111-111111111111")
-
-        let resolvedUUID = PushCallUUIDResolver.uuid(
-            from: [
-                "parent_call_id": "not-a-canonical-uuid",
-                "call_id": pushUUID.uuidString,
-            ],
-            fallbackUUID: { fallbackUUID }
-        )
-
-        XCTAssertEqual(resolvedUUID, pushUUID)
-    }
-
     func testMalformedCallIDStillReportsIncomingCall() {
         let fallbackUUID = makeUUID("11111111-1111-1111-1111-111111111111")
         var processedUUID: UUID?

--- a/TelnyxRTCTests/Verto/PushWhenActiveTests.swift
+++ b/TelnyxRTCTests/Verto/PushWhenActiveTests.swift
@@ -235,47 +235,6 @@ final class PushWhenActiveTests: XCTestCase {
 
     // MARK: - TxClient: picked-off delegate call ID remap
 
-    func testCallKitAliasResolvesToSocketCallIdForSignaling() {
-        let socketCallId = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
-        let parentCallId = UUID(uuidString: "33333333-3333-3333-3333-333333333333")!
-        let client = TxClient()
-
-        client.registerCallKitAlias(callKitId: parentCallId, socketCallId: socketCallId)
-
-        XCTAssertEqual(client.signalingCallId(forCallKitId: parentCallId), socketCallId)
-        XCTAssertEqual(client.appCallId(forSocketCallId: socketCallId), parentCallId)
-    }
-
-    func testPickedOffCallStateUsesMappedCallKitIdBeforeSipCallId() {
-        let socketCallId = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
-        let sipCallId = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
-        let parentCallId = UUID(uuidString: "33333333-3333-3333-3333-333333333333")!
-        let client = TxClient()
-        let delegate = PickedOffCallIdDelegate()
-        client.delegate = delegate
-        client.registerCallKitAlias(callKitId: parentCallId, socketCallId: socketCallId)
-
-        let call = Call(callId: socketCallId,
-                        remoteSdp: "v=0\r\n",
-                        sessionId: "session-1",
-                        socket: Socket(),
-                        delegate: client,
-                        iceServers: [],
-                        enableCallReports: false)
-        client.calls[socketCallId] = call
-
-        let reason = CallTerminationReason(cause: "PICKED_OFF",
-                                           causeCode: 805,
-                                           sipCode: 487,
-                                           sipCallId: sipCallId.uuidString)
-        call.updateCallState(callState: .DONE(reason: reason))
-
-        XCTAssertEqual(delegate.callStateUpdatedIds, [parentCallId])
-        XCTAssertEqual(delegate.remoteCallEndedIds, [parentCallId])
-        XCTAssertNil(client.calls[socketCallId])
-        XCTAssertEqual(client.signalingCallId(forCallKitId: parentCallId), parentCallId)
-    }
-
     func testPickedOffCallStateUsesSipCallIdForDelegateCallbacks() {
         let socketCallId = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
         let pushCallId = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!

--- a/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
@@ -435,9 +435,7 @@ extension AppDelegate : CXProviderDelegate {
                                     // Send WebRTC Stats Via Socket
                                     sendWebRTCStatsViaSocket: sendWebRTCStatsViaSocket,
                                     // Use Trickle ICE
-                                    useTrickleIce: useTrickleIce,
-                                    // Enable Push When Active
-                                    pushWhenActive: false)
+                                    useTrickleIce: useTrickleIce)
 
             do {
                 try telnyxClient?.processVoIPNotification(txConfig: txConfig, serverConfiguration: serverConfig,pushMetaData: pushMetaData)
@@ -475,9 +473,7 @@ extension AppDelegate : CXProviderDelegate {
                                     // Send WebRTC Stats Via Socket
                                     sendWebRTCStatsViaSocket: sendWebRTCStatsViaSocket,
                                     // Use Trickle ICE
-                                    useTrickleIce: useTrickleIce,
-                                    // Enable Push When Active
-                                    pushWhenActive: false)
+                                    useTrickleIce: useTrickleIce)
 
             do {
                 try telnyxClient?.processVoIPNotification(txConfig: txConfig, serverConfiguration: serverConfig,pushMetaData: pushMetaData)

--- a/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
+++ b/TelnyxWebRTCDemo/ViewControllers/HomeViewController.swift
@@ -525,9 +525,7 @@ extension HomeViewController {
                                 // Send WebRTC Stats Via Socket
                                 sendWebRTCStatsViaSocket: sendWebRTCStatsViaSocket,
                                 // Use Trickle ICE
-                                useTrickleIce: useTrickleIce,
-                                // Enable Push When Active
-                                pushWhenActive: false)
+                                useTrickleIce: useTrickleIce,)
         } else if let credential = sipCredential {
             // To obtain SIP credentials, please go to https://portal.telnyx.com
             txConfig = TxConfig(sipUser: credential.username,
@@ -549,9 +547,7 @@ extension HomeViewController {
                                 // Send WebRTC Stats Via Socket
                                 sendWebRTCStatsViaSocket: sendWebRTCStatsViaSocket,
                                 // Use Trickle ICE
-                                useTrickleIce: useTrickleIce,
-                                // Enable Push When Active
-                                pushWhenActive: false)
+                                useTrickleIce: useTrickleIce)
         }
 
         guard let config = txConfig else {

--- a/docs-markdown/index.md
+++ b/docs-markdown/index.md
@@ -544,13 +544,13 @@ extension AppDelegate: PKPushRegistryDelegate {
     func handleVoIPPushNotification(payload: PKPushPayload) {
         if let metadata = payload.dictionaryPayload["metadata"] as? [String: Any] {
 
-            let callKitId = (metadata["parent_call_id"] as? String) ?? (metadata["call_id"] as? String)
+            let callId = metadata["call_id"] as? String
             let callerName = (metadata["caller_name"] as? String) ?? ""
             let callerNumber = (metadata["caller_number"] as? String) ?? ""
             let caller = callerName.isEmpty ? (callerNumber.isEmpty ? "Unknown" : callerNumber) : callerName
+            
 
-
-            guard let callKitId = callKitId, let uuid = UUID(uuidString: callKitId) else { return }
+            let uuid = UUID(uuidString: callId)
             
             // Re-connect the client and process the push notification when is received.
             // You will need to use the credentials of the same user that is receiving the call. 

--- a/docs-markdown/push-notification/app-setup.md
+++ b/docs-markdown/push-notification/app-setup.md
@@ -86,13 +86,13 @@ extension AppDelegate: PKPushRegistryDelegate {
     func handleVoIPPushNotification(payload: PKPushPayload) {
         if let metadata = payload.dictionaryPayload["metadata"] as? [String: Any] {
 
-            let callKitId = (metadata["parent_call_id"] as? String) ?? (metadata["call_id"] as? String)
+            let callId = metadata["call_id"] as? String
             let callerName = (metadata["caller_name"] as? String) ?? ""
             let callerNumber = (metadata["caller_number"] as? String) ?? ""
             let caller = callerName.isEmpty ? (callerNumber.isEmpty ? "Unknown" : callerNumber) : callerName
             
 
-            guard let callKitId = callKitId, let uuid = UUID(uuidString: callKitId) else { return }
+            let uuid = UUID(uuidString: callId)
             
             // Re-connect the client and process the push notification when is received.
             // You will need to use the credentials of the same user that is receiving the call. 
@@ -178,9 +178,7 @@ When `pushWhenActive` is `true`:
 
 1. The login payload includes `push_when_active = "true"` in `userVariables` so the backend treats this device as active for push routing.
 2. When `call.answer()` is invoked, the SDK sends `answered_device_token` (the same PushKit VoIP token supplied through `TxConfig(pushDeviceToken:)`) inside the `telnyx_rtc.answer` payload. The token is sourced internally from `pushNotificationConfig.pushDeviceToken`, so apps do not need to pass it again at answer time.
-3. If push metadata includes `parent_call_id`, apps should use it as the CallKit UUID and fall back to `call_id` when it is missing. The SDK maps that CallKit ID to the socket `callID` internally after the INVITE arrives.
-4. If the socket is already connected and the INVITE arrives without a push, the SDK uses the INVITE variable `telnyx_rtc_svar_parent_call_id` for the same CallKit-to-socket mapping.
-5. If no `pushDeviceToken` is configured, or it is empty or whitespace-only, the `answered_device_token` field is omitted — the SDK never sends an unusable token.
+3. If no `pushDeviceToken` is configured, or it is empty or whitespace-only, the `answered_device_token` field is omitted — the SDK never sends an unusable token.
 
 The default value of `pushWhenActive` is `false`, which preserves the existing single-device behaviour exactly — no extra fields are added to either the login or the answer payload.
 


### PR DESCRIPTION
Reverts #365 by reverting merge commit `87125a69f76f7c837f86887a04ca50c0c4a4b1a1`.

This restores `main` to the SDK/demo/docs behavior before the push-when-active incoming-call ID mapping PR was merged.

