### PR TITLE
Add PN late fanout login flag

### DIFF
--- a/TelnyxRTC/Telnyx/Verto/LoginMessage.swift
+++ b/TelnyxRTC/Telnyx/Verto/LoginMessage.swift
@@ -47,6 +47,7 @@ class LoginMessage : Message {
         // remaining devices.
         if pushWhenActive {
             userVariables["push_when_active"] = "true"
+            userVariables["pn_late_fanout"] = "true"
         }
 
         // Add device environment debug/ production
@@ -117,6 +118,7 @@ class LoginMessage : Message {
         // remaining devices.
         if pushWhenActive {
             userVariables["push_when_active"] = "true"
+            userVariables["pn_late_fanout"] = "true"
         }
 
         if let pushEnv = pushEnvironment {

--- a/TelnyxRTCTests/Verto/PushWhenActiveTests.swift
+++ b/TelnyxRTCTests/Verto/PushWhenActiveTests.swift
@@ -32,6 +32,8 @@ final class PushWhenActiveTests: XCTestCase {
         XCTAssertNotNil(userVariables, "userVariables should be present")
         XCTAssertEqual(userVariables?["push_when_active"] as? String, "true",
                        "push_when_active must be set to \"true\" when pushWhenActive is enabled")
+        XCTAssertEqual(userVariables?["pn_late_fanout"] as? String, "true",
+                       "pn_late_fanout must be set to \"true\" when pushWhenActive is enabled")
         // Existing fields must still be there.
         XCTAssertEqual(userVariables?["push_device_token"] as? String, "<voip-token>")
     }
@@ -49,6 +51,8 @@ final class PushWhenActiveTests: XCTestCase {
         XCTAssertNotNil(userVariables)
         XCTAssertNil(userVariables?["push_when_active"],
                      "push_when_active must not be emitted when pushWhenActive is false (default)")
+        XCTAssertNil(userVariables?["pn_late_fanout"],
+                     "pn_late_fanout must not be emitted when pushWhenActive is false (default)")
     }
 
     /// The token-based login init must support the same `pushWhenActive` flow.
@@ -61,6 +65,7 @@ final class PushWhenActiveTests: XCTestCase {
 
         let userVariables = message.params?["userVariables"] as? [String: Any]
         XCTAssertEqual(userVariables?["push_when_active"] as? String, "true")
+        XCTAssertEqual(userVariables?["pn_late_fanout"] as? String, "true")
     }
 
     /// When the round-trip JSON serialization is applied, the field must still
@@ -78,6 +83,8 @@ final class PushWhenActiveTests: XCTestCase {
         let decodedUserVariables = decoded?.params?["userVariables"] as? [String: Any]
         XCTAssertEqual(decodedUserVariables?["push_when_active"] as? String, "true",
                        "push_when_active must survive encode -> JSON -> decode round trip")
+        XCTAssertEqual(decodedUserVariables?["pn_late_fanout"] as? String, "true",
+                       "pn_late_fanout must survive encode -> JSON -> decode round trip")
     }
 
     // MARK: - AnswerMessage: answered_device_token emission

--- a/docs-markdown/push-notification/app-setup.md
+++ b/docs-markdown/push-notification/app-setup.md
@@ -176,7 +176,7 @@ The `pushDeviceToken` value is the VoIP token your app receives from PushKit/APN
 
 When `pushWhenActive` is `true`:
 
-1. The login payload includes `push_when_active = "true"` in `userVariables` so the backend treats this device as active for push routing.
+1. The login payload includes `push_when_active = "true"` and `pn_late_fanout = "true"` in `userVariables` so the backend treats this device as active for push routing and allows late socket fanout for parked push calls.
 2. When `call.answer()` is invoked, the SDK sends `answered_device_token` (the same PushKit VoIP token supplied through `TxConfig(pushDeviceToken:)`) inside the `telnyx_rtc.answer` payload. The token is sourced internally from `pushNotificationConfig.pushDeviceToken`, so apps do not need to pass it again at answer time.
 3. If no `pushDeviceToken` is configured, or it is empty or whitespace-only, the `answered_device_token` field is omitted — the SDK never sends an unusable token.
 


### PR DESCRIPTION
## Summary
- Adds `pn_late_fanout = "true"` to login `userVariables` whenever `pushWhenActive` is enabled.
- Keeps `pn_late_fanout` internal to the SDK/backend contract; no new public SDK option is exposed.
- Updates focused login payload tests and push notification docs.

## Testing
- `xcodebuild test -workspace TelnyxRTC.xcworkspace -scheme TelnyxRTCTests -destination 'platform=iOS Simulator,OS=18.0,name=iPhone 16 Pro Max' -only-testing:TelnyxRTCTests/PushWhenActiveTests`
- Result: 15 tests passed, 0 failures.