### PR TITLE
AIF-313: map push metadata call_id to socket callID (signalingCallId)

### DIFF
--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -188,6 +188,9 @@ public class TxClient {
     private var inviteTimeoutTimer: Timer?
     private var isWaitingForInviteAfterPush: Bool = false
     private var pushCallState: PushCallState = .idle
+    /// Maps socket callID -> app-facing callID for push-originated calls
+    /// where the two UUIDs differ.
+    private var socketToAppCallId: [UUID: UUID] = [:]
     private static let INVITE_TIMEOUT_SECONDS: TimeInterval = 10.0
     internal var inviteTimeoutInterval: TimeInterval = TxClient.INVITE_TIMEOUT_SECONDS
     
@@ -669,6 +672,7 @@ public class TxClient {
             call.hangup()
         }
         self.calls.removeAll()
+        self.socketToAppCallId.removeAll()
         self.stopReconnectTimeout()
         self.stopInviteTimeout()
 
@@ -894,7 +898,11 @@ public class TxClient {
             
             // Remove pending call from internal list
             if let callUUID = endAction.callUUID as UUID?,
-               let _ = self.calls[callUUID] {
+               let call = self.calls[callUUID] {
+                // Clean up reverse mapping if signaling ID differs
+                if call.signalingCallId != callUUID {
+                    socketToAppCallId.removeValue(forKey: call.signalingCallId)
+                }
                 self.calls.removeValue(forKey: callUUID)
             }
             
@@ -1164,7 +1172,16 @@ extension TxClient {
     /// - Parameter callId: The unique identifier of a call.
     /// - Returns: The` Call` object that matches the  requested `callId`. Returns `nil` if no call was found.
     public func getCall(callId: UUID) -> Call? {
-        return self.calls[callId]
+        return call(forSocketCallId: callId)
+    }
+
+    /// Looks up a Call by socket callID. First checks direct lookup (for non-push calls
+    /// where socket callID == app-facing callID). If not found, checks the reverse mapping
+    /// for push calls where they differ.
+    private func call(forSocketCallId socketCallId: UUID) -> Call? {
+        if let call = calls[socketCallId] { return call }
+        if let appId = socketToAppCallId[socketCallId] { return calls[appId] }
+        return nil
     }
 
     /// Creates a new Call and starts the call sequence, negotiate the ICE Candidates and sends the invite.
@@ -1327,7 +1344,8 @@ extension TxClient {
                                     telnyxSessionId: String,
                                     telnyxLegId: String,
                                     customHeaders:[String:String] = [:],
-                                    isAttach:Bool = false
+                                    isAttach:Bool = false,
+                                    pushCallId: UUID? = nil
     ) {
 
         guard let sessionId = self.sessionId,
@@ -1335,7 +1353,34 @@ extension TxClient {
             return
         }
 
-        let call = Call(callId: callId,
+        // Determine app-facing vs signaling call IDs
+        let appFacingCallId: UUID
+        let signalingCallId: UUID
+
+        if isCallFromPush && currentCallId != callId {
+            // Push flow: currentCallId is the push call_id, callId is the socket callID
+            appFacingCallId = currentCallId
+            signalingCallId = callId
+            Logger.log.i(message: "TxClient:: Push call ID mapping: app=\(appFacingCallId) -> signaling=\(signalingCallId)")
+        } else if let pushId = pushCallId, pushId != callId {
+            // pushWhenActive flow: INVITE variable provides the push call_id
+            appFacingCallId = pushId
+            signalingCallId = callId
+            Logger.log.i(message: "TxClient:: Push-when-active call ID mapping: app=\(appFacingCallId) -> signaling=\(signalingCallId)")
+        } else {
+            // Normal flow: no mismatch
+            appFacingCallId = callId
+            signalingCallId = callId
+        }
+
+        // Remove placeholder call if it exists from processVoIPNotification
+        if appFacingCallId != signalingCallId {
+            self.calls.removeValue(forKey: appFacingCallId)
+            socketToAppCallId[signalingCallId] = appFacingCallId
+        }
+
+        let call = Call(callId: appFacingCallId,
+                        signalingCallId: signalingCallId,
                         remoteSdp: remoteSdp,
                         sessionId: sessionId,
                         socket: socket,
@@ -1361,11 +1406,11 @@ extension TxClient {
         call.callInfo?.callerNumber = callerNumber
         call.callOptions = TxCallOptions(audio: true)
         call.inviteCustomHeaders = customHeaders
-        self.calls[callId] = call
+        self.calls[appFacingCallId] = call
         // propagate the incoming call to the App
         Logger.log.i(message: "TxClient:: push flow createIncomingCall \(call)")
-        
-        currentCallId = callId
+
+        currentCallId = appFacingCallId
         
         if isAttach {
             Logger.log.i(message: "TxClient :: Attaching Call....")
@@ -1541,7 +1586,12 @@ extension TxClient: CallProtocol {
            let callId = call.callInfo?.callId {
             Logger.log.i(message: "TxClient:: Remove call")
             self.calls.removeValue(forKey: callId)
-            
+
+            // Clean up reverse mapping if this was a push call with different signaling ID
+            if call.signalingCallId != callId {
+                socketToAppCallId.removeValue(forKey: call.signalingCallId)
+            }
+
             // Clear AI Assistant transcriptions when call ends
             self.aiAssistantManager.clearTranscriptions()
             
@@ -1906,7 +1956,7 @@ extension TxClient : SocketDelegate {
                action == "updateMedia",
                let callID = result["callID"] as? String,
                let callUUID = UUID(uuidString: callID),
-               let call = calls[callUUID] {
+               let call = call(forSocketCallId: callUUID) {
                 call.handleVertoMessage(message: vertoMessage, dataMessage: message, txClient: self)
                 // For ICE restart, we don't need to process sessionId, so we can return here
                 return
@@ -1922,7 +1972,7 @@ extension TxClient : SocketDelegate {
             if let params = vertoMessage.params,
                let callUUIDString = params["callID"] as? String,
                let callUUID = UUID(uuidString: callUUIDString),
-               let call = calls[callUUID] {
+               let call = call(forSocketCallId: callUUID) {
                 call.handleVertoMessage(message: vertoMessage, dataMessage: message, txClient: self)
             }
             
@@ -1975,6 +2025,10 @@ extension TxClient : SocketDelegate {
                             Logger.log.w(message: "TxClient:: Telnyx Leg ID unavailable on INVITE message")
                         }
                         
+                        // Extract push call_id from INVITE variables for ID mapping
+                        let variables = params["variables"] as? [String: Any]
+                        let pushCallId = (variables?["telnyx_rtc_svar_push_call_id"] as? String).flatMap(UUID.init)
+
                         var customHeaders = [String:String]()
                         if params["dialogParams"] is [String:Any] {
                             do {
@@ -1992,15 +2046,16 @@ extension TxClient : SocketDelegate {
                                                 remoteSdp: sdp,
                                                 telnyxSessionId: telnyxSessionId,
                                                 telnyxLegId: telnyxLegId,
-                                                customHeaders: customHeaders)
+                                                customHeaders: customHeaders,
+                                                pushCallId: pushCallId)
                         if(isCallFromPush){
                             /*FileLogger.shared.log("INVITE : \(message) \n")
                             FileLogger.shared.log("INVITE telnyxLegId: \(telnyxLegId) \n") */
                             self.sendFileLogs = true
                         }
-                        
+
                     }
-                   
+
                     break;
             case .ATTACH:
                 Logger.log.i(message: "Attach Received")
@@ -2027,6 +2082,10 @@ extension TxClient : SocketDelegate {
                         Logger.log.w(message: "TxClient:: Telnyx Leg ID unavailable on INVITE message")
                     }
                     
+                    // Extract push call_id from ATTACH variables for ID mapping
+                    let variables = params["variables"] as? [String: Any]
+                    let pushCallId = (variables?["telnyx_rtc_svar_push_call_id"] as? String).flatMap(UUID.init)
+
                     var customHeaders = [String:String]()
                     if params["dialogParams"] is [String:Any] {
                         do {
@@ -2038,9 +2097,7 @@ extension TxClient : SocketDelegate {
                             Logger.log.e(message: "Custom header decoding error: \(error)")
                         }
                     }
-        
-                    
-                    
+
                     Logger.log.i(message: "isAudioEnabled : \(self.isAudioDeviceEnabled)")
                     self.createIncomingCall(callerName: callerName,
                                             callerNumber: callerNumber,
@@ -2049,7 +2106,8 @@ extension TxClient : SocketDelegate {
                                             telnyxSessionId: telnyxSessionId,
                                             telnyxLegId: telnyxLegId,
                                             customHeaders: customHeaders,
-                                            isAttach: true
+                                            isAttach: true,
+                                            pushCallId: pushCallId
                     )
                     
                 }

--- a/TelnyxRTC/Telnyx/WebRTC/Call+IceRestart.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call+IceRestart.swift
@@ -9,7 +9,6 @@ extension Call {
     /// - Parameter completion: Callback indicating success or failure of the ICE restart
     public func iceRestart(completion: @escaping (_ success: Bool, _ error: Error?) -> Void) {
         guard let peer = self.peer,
-              let callId = self.callInfo?.callId,
               let sessionId = self.sessionId else {
             Logger.log.e(message: "[ICE-RESTART] Call:: ICE restart failed - missing peer, callId, or sessionId")
             completion(false, NSError(domain: "Call", code: -1, userInfo: [NSLocalizedDescriptionKey: "Missing required parameters for ICE restart"]))
@@ -59,7 +58,7 @@ extension Call {
             }
             
             // Send ICE restart message via telnyx_rtc.modify
-            let iceRestartMessage = ICERestartMessage(sessionId: sessionId, callId: callId.uuidString, sdp: sdp.sdp)
+            let iceRestartMessage = ICERestartMessage(sessionId: sessionId, callId: self.signalingCallId.uuidString, sdp: sdp.sdp)
             let message = iceRestartMessage.encode() ?? ""
             self.socket?.sendMessage(message: message)
             

--- a/TelnyxRTC/Telnyx/WebRTC/Call.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call.swift
@@ -328,7 +328,23 @@ public class Call {
     /// - callerNumber: Phone number or SIP URI of the caller
     /// See `TxCallInfo` for complete details.
     public var callInfo: TxCallInfo?
-    
+
+    /// The call ID used for signaling (verto messages over the socket).
+    /// When a push notification arrives, the app-facing callId (from push metadata)
+    /// may differ from the socket callID (from the INVITE). This property holds the
+    /// socket callID so signaling messages use the correct value while the app sees
+    /// the push callId via `callInfo.callId`.
+    internal var signalingCallId: UUID
+
+    /// Returns a `TxCallInfo` that uses `signalingCallId` instead of the app-facing callId.
+    /// Used when building verto messages that must carry the socket callID.
+    internal var signalingCallInfo: TxCallInfo {
+        var info = TxCallInfo(callId: signalingCallId)
+        info.callerName = callInfo?.callerName
+        info.callerNumber = callInfo?.callerNumber
+        return info
+    }
+
     /// The current state of the call. Possible values:
     /// - NEW: Call object created but not yet initiated
     /// - CONNECTING: Outbound call is being established
@@ -389,6 +405,7 @@ public class Call {
     // MARK: - Initializers
     /// Constructor for incoming calls
     init(callId: UUID,
+         signalingCallId: UUID? = nil,
          remoteSdp: String,
          sessionId: String,
          socket: Socket,
@@ -427,6 +444,7 @@ public class Call {
 
         self.remoteSdp = remoteSdp
         self.callInfo = TxCallInfo(callId: callId)
+        self.signalingCallId = signalingCallId ?? callId
         self.delegate = delegate
 
         // Configure iceServers
@@ -463,6 +481,7 @@ public class Call {
     
     //Contructor for attachCalls
     init(callId: UUID,
+         signalingCallId: UUID? = nil,
          remoteSdp: String,
          sessionId: String,
          socket: Socket,
@@ -492,6 +511,7 @@ public class Call {
 
         self.remoteSdp = remoteSdp
         self.callInfo = TxCallInfo(callId: callId)
+        self.signalingCallId = signalingCallId ?? callId
         self.delegate = delegate
 
         // Configure iceServers
@@ -536,6 +556,7 @@ public class Call {
         //this is the signaling server socket
         self.socket = socket
         self.callInfo = TxCallInfo(callId: callId)
+        self.signalingCallId = callId
         self.delegate = delegate
 
         // Configure iceServers
@@ -592,8 +613,8 @@ public class Call {
         self.peer?.socket = self.socket
         self.peer?.sessionId = self.sessionId
         // Set callId for trickle ICE messages - must match the callID sent in INVITE
-        self.peer?.callId = self.callInfo?.callId.uuidString.lowercased()
-        Logger.log.i(message: "[TRICKLE-ICE] Call:: Peer callId set to \(self.callInfo?.callId.uuidString.lowercased() ?? "nil") for trickle ICE")
+        self.peer?.callId = self.signalingCallId.uuidString.lowercased()
+        Logger.log.i(message: "[TRICKLE-ICE] Call:: Peer callId set to \(self.signalingCallId.uuidString.lowercased()) for trickle ICE")
         self.setupPeerEventLogging()
         self.peer?.offer(preferredCodecs: preferredCodecs, completion: { (sdp, error)  in
 
@@ -772,7 +793,7 @@ extension Call {
     ///     call.hangup()
     public func hangup() {
         Logger.log.i(message: "Call:: hangup()")
-        guard let sessionId = self.sessionId, let callId = self.callInfo?.callId else { return }
+        guard let sessionId = self.sessionId else { return }
         
         // Create a termination reason for local hangup
         // Use USER_BUSY for incoming calls (NEW state) and outbound calls not yet connected (RINGING, CONNECTING)
@@ -793,7 +814,7 @@ extension Call {
             causeCode: causeCode.rawValue
         )
 
-        let byeMessage = ByeMessage(sessionId: sessionId, callId: callId.uuidString, causeCode: causeCode)
+        let byeMessage = ByeMessage(sessionId: sessionId, callId: signalingCallId.uuidString, causeCode: causeCode)
         let message = byeMessage.encode() ?? ""
         self.socket?.sendMessage(message: message)
         self.endCall(terminationReason: terminationReason)
@@ -844,8 +865,8 @@ extension Call {
         self.peer?.socket = self.socket
         self.peer?.sessionId = self.sessionId
         // Set callId for trickle ICE messages - must match the callID from the incoming INVITE
-        self.peer?.callId = self.callInfo?.callId.uuidString.lowercased()
-        Logger.log.i(message: "[TRICKLE-ICE] Call:: Peer callId set to \(self.callInfo?.callId.uuidString.lowercased() ?? "nil") for trickle ICE")
+        self.peer?.callId = self.signalingCallId.uuidString.lowercased()
+        Logger.log.i(message: "[TRICKLE-ICE] Call:: Peer callId set to \(self.signalingCallId.uuidString.lowercased()) for trickle ICE")
         self.setupPeerEventLogging()
         self.incomingOffer(sdp: remoteSdp)
         self.peer?.answer(callLegId: self.telnyxLegId?.uuidString ?? "", completion: { (sdp, error)  in
@@ -894,8 +915,8 @@ extension Call {
         self.peer?.socket = self.socket
         self.peer?.sessionId = self.sessionId
         // Set callId for trickle ICE messages - must match the callID from ATTACH
-        self.peer?.callId = self.callInfo?.callId.uuidString.lowercased()
-        Logger.log.i(message: "[TRICKLE-ICE] Call:: Peer callId set to \(self.callInfo?.callId.uuidString.lowercased() ?? "nil") for ATTACH")
+        self.peer?.callId = self.signalingCallId.uuidString.lowercased()
+        Logger.log.i(message: "[TRICKLE-ICE] Call:: Peer callId set to \(self.signalingCallId.uuidString.lowercased()) for ATTACH")
         self.setupPeerEventLogging()
         self.incomingOffer(sdp: remoteSdp)
         self.peer?.answer(callLegId: self.telnyxLegId?.uuidString ?? "", completion: { (sdp, error)  in
@@ -1112,7 +1133,7 @@ extension Call {
 
         let dtmfMessage = InfoMessage(sessionId: sessionId,
                                       dtmf: dtmf,
-                                      callInfo: callInfo,
+                                      callInfo: signalingCallInfo,
                                       callOptions: callOptions)
         guard let message = dtmfMessage.encode(),
               let socket = self.socket else { return }
@@ -1178,9 +1199,8 @@ extension Call {
     ///     call.hold()
     public func hold() {
         Logger.log.i(message: "Call:: hold()")
-        guard let callId = self.callInfo?.callId,
-              let sessionId = self.sessionId else { return }
-        let hold = ModifyMessage(sessionId: sessionId, callId: callId.uuidString, action: .HOLD)
+        guard let sessionId = self.sessionId else { return }
+        let hold = ModifyMessage(sessionId: sessionId, callId: signalingCallId.uuidString, action: .HOLD)
         let message = hold.encode() ?? ""
         self.socket?.sendMessage(message: message)
         self.updateCallState(callState: .HELD)
@@ -1193,9 +1213,8 @@ extension Call {
     ///     call.unhold()
     public func unhold() {
         Logger.log.i(message: "Call:: unhold()")
-        guard let callId = self.callInfo?.callId,
-              let sessionId = self.sessionId else { return }
-        let unhold = ModifyMessage(sessionId: sessionId, callId: callId.uuidString, action: .UNHOLD)
+        guard let sessionId = self.sessionId else { return }
+        let unhold = ModifyMessage(sessionId: sessionId, callId: signalingCallId.uuidString, action: .UNHOLD)
         let message = unhold.encode() ?? ""
         self.socket?.sendMessage(message: message)
         self.updateCallState(callState: .ACTIVE)
@@ -1207,9 +1226,8 @@ extension Call {
     ///     call.toggleHold()
     public func toggleHold() {
         Logger.log.i(message: "Call:: toggleHold()")
-        guard let callId = self.callInfo?.callId,
-              let sessionId = self.sessionId else { return }
-        let toggleHold = ModifyMessage(sessionId: sessionId, callId: callId.uuidString, action: .TOGGLE_HOLD)
+        guard let sessionId = self.sessionId else { return }
+        let toggleHold = ModifyMessage(sessionId: sessionId, callId: signalingCallId.uuidString, action: .TOGGLE_HOLD)
         let message = toggleHold.encode() ?? ""
         self.socket?.sendMessage(message: message)
 
@@ -1248,7 +1266,7 @@ extension Call : PeerDelegate {
             //Build the telnyx_rtc.invite message and send it
             let inviteMessage = InviteMessage(sessionId: sessionId,
                                               sdp: sdp.sdp,
-                                              callInfo: callInfo,
+                                              callInfo: signalingCallInfo,
                                               callOptions: callOptions,
                                               customHeaders: self.inviteCustomHeaders ?? [:],
                                               trickle: self.useTrickleIce,
@@ -1264,7 +1282,7 @@ extension Call : PeerDelegate {
             let attachCallOption = TxCallOptions(destinationNumber: callOptions.destinationNumber,attach: true,userVariables: callOptions.userVariables)
 
             
-            let attachMessage = ReAttachMessage(sessionId: sessionId, sdp: sdp.sdp, callInfo: callInfo, callOptions: attachCallOption,
+            let attachMessage = ReAttachMessage(sessionId: sessionId, sdp: sdp.sdp, callInfo: signalingCallInfo, callOptions: attachCallOption,
                                               customHeaders: self.answerCustomHeaders ?? [:]
             )
             let message = attachMessage.encode() ?? ""
@@ -1274,7 +1292,7 @@ extension Call : PeerDelegate {
         } else {
             //Build the telnyx_rtc.answer message and send it
 
-            let answerMessage = AnswerMessage(sessionId: sessionId, sdp: sdp.sdp, callInfo: callInfo, callOptions: callOptions,
+            let answerMessage = AnswerMessage(sessionId: sessionId, sdp: sdp.sdp, callInfo: signalingCallInfo, callOptions: callOptions,
                                               customHeaders: self.answerCustomHeaders ?? [:],
                                               trickle: self.useTrickleIce,
                                               pushWhenActive: self.pushWhenActive,

--- a/TelnyxRTCTests/Verto/PushWhenActiveTests.swift
+++ b/TelnyxRTCTests/Verto/PushWhenActiveTests.swift
@@ -233,6 +233,90 @@ final class PushWhenActiveTests: XCTestCase {
                        "pushWhenActive must default to false on the token config init")
     }
 
+    // MARK: - Call: signalingCallId mapping
+
+    func testSignalingCallIdDefaultsToCallId() {
+        let callId = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+        let call = Call(callId: callId,
+                        remoteSdp: "v=0\r\n",
+                        sessionId: "session-1",
+                        socket: Socket(),
+                        delegate: TxClient(),
+                        iceServers: [],
+                        enableCallReports: false)
+
+        XCTAssertEqual(call.signalingCallId, callId,
+                       "signalingCallId should default to callId when not explicitly set")
+    }
+
+    func testSignalingCallIdCanDifferFromCallId() {
+        let appCallId = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+        let socketCallId = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+        let call = Call(callId: appCallId,
+                        signalingCallId: socketCallId,
+                        remoteSdp: "v=0\r\n",
+                        sessionId: "session-1",
+                        socket: Socket(),
+                        delegate: TxClient(),
+                        iceServers: [],
+                        enableCallReports: false)
+
+        XCTAssertEqual(call.callInfo?.callId, appCallId,
+                       "callInfo.callId should be the app-facing push call ID")
+        XCTAssertEqual(call.signalingCallId, socketCallId,
+                       "signalingCallId should be the socket callID for signaling messages")
+    }
+
+    func testSignalingCallInfoUsesSignalingCallId() {
+        let appCallId = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+        let socketCallId = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+        let call = Call(callId: appCallId,
+                        signalingCallId: socketCallId,
+                        remoteSdp: "v=0\r\n",
+                        sessionId: "session-1",
+                        socket: Socket(),
+                        delegate: TxClient(),
+                        iceServers: [],
+                        enableCallReports: false)
+        call.callInfo?.callerName = "Test Caller"
+        call.callInfo?.callerNumber = "+15551234567"
+
+        let sigInfo = call.signalingCallInfo
+        XCTAssertEqual(sigInfo.callId, socketCallId,
+                       "signalingCallInfo should use signalingCallId, not app-facing callId")
+        XCTAssertEqual(sigInfo.callerName, "Test Caller",
+                       "signalingCallInfo should preserve callerName")
+        XCTAssertEqual(sigInfo.callerNumber, "+15551234567",
+                       "signalingCallInfo should preserve callerNumber")
+    }
+
+    func testDelegateCallbackUsesAppFacingIdWithMismatch() {
+        let appCallId = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+        let socketCallId = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+        let client = TxClient()
+        let delegate = PickedOffCallIdDelegate()
+        client.delegate = delegate
+
+        let call = Call(callId: appCallId,
+                        signalingCallId: socketCallId,
+                        remoteSdp: "v=0\r\n",
+                        sessionId: "session-1",
+                        socket: Socket(),
+                        delegate: client,
+                        iceServers: [],
+                        enableCallReports: false)
+        client.calls[appCallId] = call
+
+        let reason = CallTerminationReason(cause: "NORMAL_CLEARING",
+                                           causeCode: 16)
+        call.updateCallState(callState: .DONE(reason: reason))
+
+        XCTAssertEqual(delegate.callStateUpdatedIds, [appCallId],
+                       "Delegate should receive the app-facing callId, not the socket callID")
+        XCTAssertEqual(delegate.remoteCallEndedIds, [appCallId],
+                       "onRemoteCallEnded should receive the app-facing callId")
+    }
+
     // MARK: - TxClient: picked-off delegate call ID remap
 
     func testPickedOffCallStateUsesSipCallIdForDelegateCallbacks() {

--- a/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
@@ -259,6 +259,7 @@ extension AppDelegate : CXProviderDelegate {
 
     func provider(_ provider: CXProvider, perform action: CXAnswerCallAction) {
         print("AppDelegate:: ANSWER call action: callKitUUID [\(String(describing: self.callKitUUID))] action [\(action.callUUID)]")
+        print("📞 [ID-MAP] CXAnswerCallAction -> actionUUID: \(action.callUUID) | callKitUUID: \(self.callKitUUID?.uuidString ?? "nil") | match: \(action.callUUID == self.callKitUUID)")
 
         // Track incoming call answer in call history
         if let call = self.telnyxClient?.calls[action.callUUID] {
@@ -272,10 +273,14 @@ extension AppDelegate : CXProviderDelegate {
         }
 
         self.telnyxClient?.answerFromCallkit(answerAction: action, customHeaders:  ["X-test-answer":"ios-test"], debug: true)
+        if let call = self.currentCall {
+            print("📞 [ID-MAP] After answerFromCallkit -> appFacingId: \(call.callInfo?.callId.uuidString ?? "nil")")
+        }
     }
 
     func provider(_ provider: CXProvider, perform action: CXEndCallAction) {
         print("AppDelegate:: END call action: callKitUUID [\(String(describing: self.callKitUUID))] action [\(action.callUUID)]")
+        print("📞 [ID-MAP] CXEndCallAction -> actionUUID: \(action.callUUID) | callKitUUID: \(self.callKitUUID?.uuidString ?? "nil") | currentCall: \(self.currentCall?.callInfo?.callId.uuidString ?? "nil") | match: \(action.callUUID == self.callKitUUID)")
 
         guard let telnyxClient = self.telnyxClient else {
             print("AppDelegate:: END call action failed because Telnyx client is unavailable")

--- a/TelnyxWebRTCDemo/Extensions/AppDelegateTelnyxVoIPExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/AppDelegateTelnyxVoIPExtension.swift
@@ -51,6 +51,7 @@ extension AppDelegate: TxClientDelegate {
             return
         }
         print("AppDelegate:: TxClientDelegate onIncomingCall() callKitUUID [\(String(describing: self.callKitUUID))] callId [\(callId)]")
+        print("📞 [ID-MAP] onIncomingCall -> appFacingId: \(callId) | callKitUUID: \(self.callKitUUID?.uuidString ?? "nil") | match: \(callId == self.callKitUUID)")
 
         self.callKitUUID = call.callInfo?.callId
         self.previousCall = self.currentCall
@@ -63,6 +64,7 @@ extension AppDelegate: TxClientDelegate {
     
     func onPushCall(call: Call) {
         print("AppDelegate:: TxClientDelegate onPushCall() \(call)")
+        print("📞 [ID-MAP] onPushCall -> appFacingId: \(call.callInfo?.callId.uuidString ?? "nil") | callKitUUID: \(self.callKitUUID?.uuidString ?? "nil") | match: \(call.callInfo?.callId == self.callKitUUID)")
         self.currentCall = call //Update the current call with the incoming call
         let headers = call.inviteCustomHeaders
         print("Custom Headers onPushCall: \(headers as AnyObject)")
@@ -70,6 +72,7 @@ extension AppDelegate: TxClientDelegate {
     
     func onRemoteCallEnded(callId: UUID, reason: CallTerminationReason? = nil) {
         print("AppDelegate:: TxClientDelegate onRemoteCallEnded() callKitUUID [\(String(describing: self.callKitUUID))] callId [\(callId)], reason: \(reason?.cause ?? "None")")
+        print("📞 [ID-MAP] onRemoteCallEnded -> callId: \(callId) | callKitUUID: \(self.callKitUUID?.uuidString ?? "nil") | match: \(callId == self.callKitUUID)")
         
         // If we have a SIP code, use it for the disconnect cause
         var disconnectCause = CXCallEndedReason.remoteEnded
@@ -128,6 +131,7 @@ extension AppDelegate: TxClientDelegate {
     
     func onCallStateUpdated(callState: CallState, callId: UUID) {
         print("AppDelegate:: TxClientDelegate onCallStateUpdated() callKitUUID [\(String(describing: self.callKitUUID))] callId [\(callId)]")
+        print("📞 [ID-MAP] onCallStateUpdated -> state: \(callState) | callId: \(callId) | callKitUUID: \(self.callKitUUID?.uuidString ?? "nil") | match: \(callId == self.callKitUUID)")
         self.voipDelegate?.onCallStateUpdated(callState: callState, callId: callId)
         
         if callState.isConsideredActive {


### PR DESCRIPTION
<!-- Ticket details and link -->
[AIF-313 - Voice SDK: map push metadata call_id to socket callID](https://linear.app/telnyx/issue/AIF-313/voice-sdk-map-push-metadata-call-id-to-socket-callid-call-id-mismatch)
---

Maps the push notification `metadata.call_id` (app-facing, used by CallKit) to the socket INVITE `params.callID` (internal signaling) so the SDK can correlate the two when they differ, as reported by Isaac.

## Summary

When a VoIP push arrives, `processVoIPNotification` exposes `metadata.call_id` to CallKit/UI. The subsequent socket INVITE carries a different `callID` in `params`. Without a mapping, `answer`/`bye`/ICE restart/trickle ICE use the wrong ID, CallKit state gets stuck, and `PICKED_OFF` / answered-elsewhere cleanup can't map the socket `BYE` back to the app-facing call.

This PR introduces an internal `Call.signalingCallId` (the socket `callID`) while keeping `Call.callInfo.callId` as the public/app-facing ID (the push `call_id`). All verto/signaling messages use `signalingCallId`; all delegate callbacks expose the app-facing ID transparently.

## :older_man: :baby: Behaviors

### Before changes
- `Call.callInfo.callId` was used for **both** CallKit/UI and socket signaling.
- When push `call_id` ≠ socket `callID`, `answer`/`bye`/trickle ICE/ICE restart sent the app-facing ID to the socket, which the backend didn't recognize.
- `onCallStateUpdated(... callId:)` and `onRemoteCallEnded(callId:)` could return the socket `callID`, breaking CallKit/UI cleanup consistency.
- `PICKED_OFF` / answered-elsewhere BYE from the socket couldn't be correlated back to the app-facing CallKit call.

### After changes
- `Call.callInfo.callId` = push metadata `call_id` (app-facing, public).
- `Call.signalingCallId` = socket INVITE `params.callID` (internal, SDK-only). Defaults to `callId` when there is no mismatch.
- `call.answer()`, `call.hangup()`, hold/unhold, ICE restart, and trickle ICE (`peer.callId`) use `signalingCallId`.
- `onIncomingCall()`, `onPushCall()`, `onCallStateUpdated(... callId:)`, and `onRemoteCallEnded(callId:)` expose the app-facing ID.
- `TxClient` maintains a reverse map `socketToAppCallId: [UUID: UUID]` for push-originated calls where the two IDs differ, so socket-arrived messages (`updateMedia`, `bye`, invite-timeout, etc.) resolve to the correct `Call`.
- `PICKED_OFF` / answered-elsewhere cleanup maps the socket `BYE` back to the app-facing ID.
- `getCall(callId:)` and internal socket handlers look up via the reverse map first when a direct lookup misses.
- Demo app logs `[ID-MAP]` lines in CallKit + VoIP extensions to aid debugging.

## ID mapping logic (TxClient.createIncomingCall)

```
push flow (isCallFromPush && currentCallId != callId):
  appFacingCallId = currentCallId        // push call_id
  signalingCallId = callId               // socket callID

pushWhenActive flow (pushCallId from INVITE variables.telnyx_rtc_svar_push_call_id):
  appFacingCallId = pushId
  signalingCallId = callId

normal flow:
  appFacingCallId = callId
  signalingCallId = callId
```

## Code sketch

```swift
public class Call {
    public var callInfo: TxCallInfo?
    internal var signalingCallId: UUID

    init(callId: UUID, signalingCallId: UUID? = nil, ...) {
        self.callInfo = TxCallInfo(callId: callId)
        self.signalingCallId = signalingCallId ?? callId
    }

    public func hangup() {
        let byeMessage = ByeMessage(sessionId: sessionId, callId: signalingCallId.uuidString, ...)
    }
}
```

## Files changed

- `TelnyxRTC/Telnyx/WebRTC/Call.swift` — add `signalingCallId` + `signalingCallInfo`; use `signalingCallId` in `hangup`, trickle ICE (`peer.callId`), incoming offer, attach.
- `TelnyxRTC/Telnyx/WebRTC/Call+IceRestart.swift` — ICE restart uses `signalingCallId`.
- `TelnyxRTC/Telnyx/TxClient.swift` — `socketToAppCallId` reverse map, `call(forSocketCallId:)` lookup, `createIncomingCall` ID resolution from push metadata + INVITE `telnyx_rtc_svar_push_call_id`, cleanup on end/remove/disconnect.
- `TelnyxRTCTests/Verto/PushWhenActiveTests.swift` — unit tests for `pushWhenActive` flag emission + backwards-compatible default.
- `TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift` — `[ID-MAP]` debug logs.
- `TelnyxWebRTCDemo/Extensions/AppDelegateTelnyxVoIPExtension.swift` — `[ID-MAP]` debug logs.

## TODO
- None.

## ✋ Manual testing
1. Configure a SIP/JWT user with `pushWhenActive` and a valid PushKit VoIP token.
2. Trigger an incoming call from a second device/account so a VoIP push arrives.
3. Verify the push `metadata.call_id` differs from the socket INVITE `params.callID` (see `[ID-MAP]` logs).
4. Answer the call on the device — confirm audio connects and `telnyx_rtc.answer` carries the signaling `callID`.
5. Hang up from either side — confirm `telnyx_rtc.bye` carries the signaling `callID` and CallKit UI clears.
6. Multi-device: answer the call on another device and confirm the remaining device receives `PICKED_OFF` and CallKit cleans up using the app-facing ID.
7. Run `PushWhenActiveTests`.

## Known Issues
None.

Closes AIF-313
