### PR TITLE
Remove delegate call ID override

### DIFF
--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -1344,8 +1344,7 @@ extension TxClient {
                                     telnyxSessionId: String,
                                     telnyxLegId: String,
                                     customHeaders:[String:String] = [:],
-                                    isAttach:Bool = false,
-                                    pushCallId: UUID? = nil
+                                    isAttach:Bool = false
     ) {
 
         guard let sessionId = self.sessionId,
@@ -1362,9 +1361,9 @@ extension TxClient {
             appFacingCallId = currentCallId
             signalingCallId = callId
             Logger.log.i(message: "TxClient:: Push call ID mapping: app=\(appFacingCallId) -> signaling=\(signalingCallId)")
-        } else if let pushId = pushCallId, pushId != callId {
-            // pushWhenActive flow: INVITE variable provides the push call_id
-            appFacingCallId = pushId
+        } else if let appId = socketToAppCallId[callId], appId != callId {
+            // Existing alias mapping learned from the push flow still wins for later socket events.
+            appFacingCallId = appId
             signalingCallId = callId
             Logger.log.i(message: "TxClient:: Push-when-active call ID mapping: app=\(appFacingCallId) -> signaling=\(signalingCallId)")
         } else {
@@ -2013,10 +2012,6 @@ extension TxClient : SocketDelegate {
                             Logger.log.w(message: "TxClient:: Telnyx Leg ID unavailable on INVITE message")
                         }
                         
-                        // Extract push call_id from INVITE variables for ID mapping
-                        let variables = params["variables"] as? [String: Any]
-                        let pushCallId = (variables?["telnyx_rtc_svar_push_call_id"] as? String).flatMap(UUID.init)
-
                         var customHeaders = [String:String]()
                         if params["dialogParams"] is [String:Any] {
                             do {
@@ -2034,8 +2029,7 @@ extension TxClient : SocketDelegate {
                                                 remoteSdp: sdp,
                                                 telnyxSessionId: telnyxSessionId,
                                                 telnyxLegId: telnyxLegId,
-                                                customHeaders: customHeaders,
-                                                pushCallId: pushCallId)
+                                                customHeaders: customHeaders)
                         if(isCallFromPush){
                             /*FileLogger.shared.log("INVITE : \(message) \n")
                             FileLogger.shared.log("INVITE telnyxLegId: \(telnyxLegId) \n") */
@@ -2070,10 +2064,6 @@ extension TxClient : SocketDelegate {
                         Logger.log.w(message: "TxClient:: Telnyx Leg ID unavailable on INVITE message")
                     }
                     
-                    // Extract push call_id from ATTACH variables for ID mapping
-                    let variables = params["variables"] as? [String: Any]
-                    let pushCallId = (variables?["telnyx_rtc_svar_push_call_id"] as? String).flatMap(UUID.init)
-
                     var customHeaders = [String:String]()
                     if params["dialogParams"] is [String:Any] {
                         do {
@@ -2094,8 +2084,7 @@ extension TxClient : SocketDelegate {
                                             telnyxSessionId: telnyxSessionId,
                                             telnyxLegId: telnyxLegId,
                                             customHeaders: customHeaders,
-                                            isAttach: true,
-                                            pushCallId: pushCallId
+                                            isAttach: true
                     )
                     
                 }

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -1576,10 +1576,9 @@ extension TxClient: CallProtocol {
         Logger.log.i(message: "TxClient:: callStateUpdated()")
 
         guard let callId = call.callInfo?.callId else { return }
-        let delegateCallId = self.delegateCallId(for: call.callState, fallbackCallId: callId)
         
         // Forward call state
-        self.delegate?.onCallStateUpdated(callState: call.callState, callId: delegateCallId)
+        self.delegate?.onCallStateUpdated(callState: call.callState, callId: callId)
 
         // Remove call if it has ended
         if case .DONE = call.callState,
@@ -1597,23 +1596,12 @@ extension TxClient: CallProtocol {
             
             //Forward call ended state with termination reason if available
             if case let .DONE(reason) = call.callState {
-                self.delegate?.onRemoteCallEnded(callId: delegateCallId, reason: reason)
+                self.delegate?.onRemoteCallEnded(callId: callId, reason: reason)
             } else {
-                self.delegate?.onRemoteCallEnded(callId: delegateCallId, reason: nil)
+                self.delegate?.onRemoteCallEnded(callId: callId, reason: nil)
             }
             self._isSpeakerEnabled = false
         }
-    }
-
-    private func delegateCallId(for callState: CallState, fallbackCallId: UUID) -> UUID {
-        guard case let .DONE(reason) = callState,
-              reason?.cause == "PICKED_OFF",
-              let sipCallId = reason?.sipCallId,
-              let sipCallUUID = UUID(uuidString: sipCallId) else {
-            return fallbackCallId
-        }
-
-        return sipCallUUID
     }
 
 }

--- a/TelnyxRTCTests/Verto/PushWhenActiveTests.swift
+++ b/TelnyxRTCTests/Verto/PushWhenActiveTests.swift
@@ -324,33 +324,34 @@ final class PushWhenActiveTests: XCTestCase {
                        "onRemoteCallEnded should receive the app-facing callId")
     }
 
-    // MARK: - TxClient: picked-off delegate call ID remap
+    // MARK: - TxClient: picked-off delegate call ID handling
 
-    func testPickedOffCallStateUsesSipCallIdForDelegateCallbacks() {
-        let socketCallId = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
-        let pushCallId = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+    func testPickedOffCallStateUsesAppFacingCallIdForDelegateCallbacks() {
+        let appCallId = UUID(uuidString: "11111111-1111-1111-1111-111111111111")!
+        let socketCallId = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
         let client = TxClient()
         let delegate = PickedOffCallIdDelegate()
         client.delegate = delegate
 
-        let call = Call(callId: socketCallId,
+        let call = Call(callId: appCallId,
+                        signalingCallId: socketCallId,
                         remoteSdp: "v=0\r\n",
                         sessionId: "session-1",
                         socket: Socket(),
                         delegate: client,
                         iceServers: [],
                         enableCallReports: false)
-        client.calls[socketCallId] = call
+        client.calls[appCallId] = call
 
         let reason = CallTerminationReason(cause: "PICKED_OFF",
                                            causeCode: 805,
                                            sipCode: 487,
-                                           sipCallId: pushCallId.uuidString)
+                                           sipCallId: appCallId.uuidString)
         call.updateCallState(callState: .DONE(reason: reason))
 
-        XCTAssertEqual(delegate.callStateUpdatedIds, [pushCallId])
-        XCTAssertEqual(delegate.remoteCallEndedIds, [pushCallId])
-        XCTAssertNil(client.calls[socketCallId])
+        XCTAssertEqual(delegate.callStateUpdatedIds, [appCallId])
+        XCTAssertEqual(delegate.remoteCallEndedIds, [appCallId])
+        XCTAssertNil(client.calls[appCallId])
     }
 
     func testNonPickedOffDoneStateUsesSocketCallIdForDelegateCallbacks() {


### PR DESCRIPTION
This PR now has two focused changes around push-when-active incoming-call ID handling:

1. Remove the PICKED_OFF delegate call ID override and use the `Call` object's app-facing `callInfo.callId` for delegate cleanup callbacks.
2. Simplify incoming-call remapping so the SDK only trusts the app-facing ID learned from the push payload, while continuing to use the socket `callID` internally for signaling.

Behavior after this change:
- Push flow:
  - app-facing ID comes from the push payload `call_id`
  - signaling continues to use the socket `callID`
- Socket-only flow:
  - app-facing ID stays as socket `callID`
- The SDK no longer relies on `telnyx_rtc_svar_push_call_id` from socket INVITE/ATTACH messages to create a new app-facing alias.
- If an alias was already learned from the push flow, later socket events can still resolve back to the app-facing ID through the existing internal mapping.

Why:
- The push payload is the single source of truth for the app-facing incoming-call ID in the mismatch case.
- That keeps CallKit/app-facing state stable without teaching the SDK to trust additional socket-side alias fields.
- The socket `callID` remains the correct ID for answer, bye, hold, peer/media handling, and cleanup.

Validation:
- `xcodebuild test -workspace TelnyxRTC.xcworkspace -scheme TelnyxRTCTests -destination 'platform=iOS Simulator,OS=18.0,name=iPhone 16 Pro Max' -only-testing:TelnyxRTCTests/PushWhenActiveTests`
- Result: 19 passed, 0 failed
