### PR TITLE
Add optional canary websocket query

### DIFF
--- a/TelnyxRTC/Telnyx/Models/TxServerConfiguration.swift
+++ b/TelnyxRTC/Telnyx/Models/TxServerConfiguration.swift
@@ -19,6 +19,7 @@ public struct TxServerConfiguration {
     public internal(set) var environment: WebRTCEnvironment = .production
     public internal(set) var signalingServer: URL
     public internal(set) var pushMetaData: [String:Any]?
+    public internal(set) var canary: Bool?
     public internal(set) var webRTCIceServers: [RTCIceServer]
 
     /// Constructor for the Server configuration parameters.
@@ -26,20 +27,14 @@ public struct TxServerConfiguration {
     ///   - signalingServer: To define the signaling server URL `wss://address:port`
     ///   - webRTCIceServers: To define custom ICE servers
     ///   - pushMetaData: Contains push info when a PN is received
-    public init(signalingServer: URL? = nil, webRTCIceServers: [RTCIceServer]? = nil, environment: WebRTCEnvironment = .production,pushMetaData:[String: Any]? = nil,region:Region = Region.auto) {
+    public init(signalingServer: URL? = nil, webRTCIceServers: [RTCIceServer]? = nil, environment: WebRTCEnvironment = .production,pushMetaData:[String: Any]? = nil, canary: Bool? = nil, region:Region = Region.auto) {
         
         self.pushMetaData = pushMetaData
+        self.canary = canary
         // Get rtc_id  to setup TxPushServerConfig
         let rtc_id = (pushMetaData?["voice_sdk_id"] as? String)
 
-
-        Logger.log.i(message: "TxServerConfiguration:: signalingServer [\(String(describing: signalingServer))] webRTCIceServers [\(String(describing: webRTCIceServers))] environment [\(String(describing: environment))] ip - [\(String(describing: rtc_id))] region [\(region)]")
-        
-        
-        func createQuery(with rtc_id: String) -> String {
-            let encodedId = rtc_id.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? ""
-            return "?voice_sdk_id=\(encodedId)"
-        }
+        Logger.log.i(message: "TxServerConfiguration:: signalingServer [\(String(describing: signalingServer))] webRTCIceServers [\(String(describing: webRTCIceServers))] environment [\(String(describing: environment))] ip - [\(String(describing: rtc_id))] canary [\(String(describing: canary))] region [\(region)]")
         
         let regionPrefix: String = {
             if region != .auto {
@@ -48,27 +43,37 @@ public struct TxServerConfiguration {
                return ""
            }()
 
+        func configuredSignalingServer(from baseURL: URL) -> URL {
+            guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
+                return baseURL
+            }
+
+            if let host = components.host, !regionPrefix.isEmpty, !host.hasPrefix(regionPrefix) {
+                components.host = "\(regionPrefix)\(host)"
+            }
+
+            var queryItems = components.queryItems ?? []
+            queryItems.removeAll { $0.name == "voice_sdk_id" || $0.name == "canary" }
+
+            if let rtc_id = rtc_id {
+                queryItems.append(URLQueryItem(name: "voice_sdk_id", value: rtc_id))
+            }
+
+            if let canary = canary {
+                queryItems.append(URLQueryItem(name: "canary", value: canary ? "true" : "false"))
+            }
+
+            components.queryItems = queryItems.isEmpty ? nil : queryItems
+            return components.url ?? baseURL
+        }
+
         // Determine the base URL or host based on the environment or signalingServer
         if let signalingServer = signalingServer {
-            if let rtc_id = rtc_id {
-                // Use only the host of signalingServer if it already has queries
-                let host = "wss://\(regionPrefix)\(signalingServer.host ?? "")"
-                let query = createQuery(with: rtc_id)
-                let pushRtcServer = "\(host)\(query)"
-                self.signalingServer = URL(string: pushRtcServer) ?? signalingServer
-            } else {
-                self.signalingServer = signalingServer
-            }
+            self.signalingServer = configuredSignalingServer(from: signalingServer)
         } else {
             // Always use production server unless explicitly set to development
             let baseURL = (environment == .development) ? InternalConfig.default.developmentSignalingServer : InternalConfig.default.prodSignalingServer
-            if let rtc_id = rtc_id {
-                let query = createQuery(with: rtc_id)
-                let pushRtcServer = "wss://\(regionPrefix)\(baseURL.host ?? "")\(query)"
-                self.signalingServer = URL(string: pushRtcServer) ?? baseURL
-            } else {
-                self.signalingServer = URL(string: "wss://\(regionPrefix)\(baseURL.host ?? "")")!
-            }
+            self.signalingServer = configuredSignalingServer(from: baseURL)
             self.environment = environment
         }
 

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -534,7 +534,8 @@ public class TxClient {
                                                              environment: serverConfiguration.environment,
                                                              pushMetaData: [
                                                                 "voice_sdk_id":self.voiceSdkId!
-                                                             ])
+                                                             ],
+                                                             canary: serverConfiguration.canary)
         } else {
             self.serverConfiguration = serverConfiguration
         }
@@ -558,7 +559,8 @@ public class TxClient {
         self.serverConfiguration = TxServerConfiguration(signalingServer: serverConfiguration.signalingServer,
                                                          webRTCIceServers: serverConfiguration.webRTCIceServers,
                                                          environment: serverConfiguration.environment,
-                                                         pushMetaData: self.pushMetaData)
+                                                         pushMetaData: self.pushMetaData,
+                                                         canary: serverConfiguration.canary)
 
         Logger.log.i(message: "TxClient:: serverConfiguration server: [\(self.serverConfiguration.signalingServer)] ICE Servers [\(self.serverConfiguration.webRTCIceServers)]")
         self.socket = Socket()
@@ -1026,7 +1028,8 @@ public class TxClient {
                     signalingServer: serverConfiguration.signalingServer,
                     webRTCIceServers: serverConfiguration.webRTCIceServers,
                     environment: serverConfiguration.environment,
-                    pushMetaData: ["voice_sdk_id": self.voiceSdkId!]
+                    pushMetaData: ["voice_sdk_id": self.voiceSdkId!],
+                    canary: serverConfiguration.canary
                 )
             } else {
                 Logger.log.i(message: "TxClient:: anonymousLogin() without voice_sdk_id")
@@ -1476,7 +1479,8 @@ extension TxClient {
             signalingServer:nil,
             webRTCIceServers: serverConfiguration.webRTCIceServers,
             environment: serverConfiguration.environment,
-            pushMetaData: pushMetaData)
+            pushMetaData: pushMetaData,
+            canary: serverConfiguration.canary)
                 
         let noActiveCalls = self.calls.filter { 
             $0.value.callState.isConsideredActive
@@ -1839,6 +1843,7 @@ extension TxClient : SocketDelegate {
                             webRTCIceServers: updatedServerConfig.webRTCIceServers,
                             environment: updatedServerConfig.environment,
                             pushMetaData: updatedServerConfig.pushMetaData,
+                            canary: updatedServerConfig.canary,
                             region: .auto
                         )
                     }

--- a/TelnyxRTCTests/RegionTests.swift
+++ b/TelnyxRTCTests/RegionTests.swift
@@ -259,15 +259,37 @@ class RegionTests: XCTestCase {
         let euConfig = TxServerConfiguration(environment: .production, pushMetaData: pushMetaData, region: .eu)
         let euURL = euConfig.signalingServer.absoluteString
         XCTAssertTrue(euURL.contains("eu."), "EU region should add prefix even with push metadata")
-        // Check for URL-encoded version of underscores (%5F)
-        XCTAssertTrue(euURL.contains("voice_sdk_id=test%5Fsdk%5Fid%5F123"), "URL should contain URL-encoded SDK ID")
+        XCTAssertTrue(euURL.contains("voice_sdk_id=test%5Fsdk%5Fid%5F123") || euURL.contains("voice_sdk_id=test_sdk_id_123"), "URL should contain SDK ID")
         
         // Test with US West region and push metadata
         let usWestConfig = TxServerConfiguration(environment: .production, pushMetaData: pushMetaData, region: .usWest)
         let usWestURL = usWestConfig.signalingServer.absoluteString
         XCTAssertTrue(usWestURL.contains("us-west."), "US West region should add prefix even with push metadata")
-        // Check for URL-encoded version of underscores (%5F)
-        XCTAssertTrue(usWestURL.contains("voice_sdk_id=test%5Fsdk%5Fid%5F123"), "URL should contain URL-encoded SDK ID")
+        XCTAssertTrue(usWestURL.contains("voice_sdk_id=test%5Fsdk%5Fid%5F123") || usWestURL.contains("voice_sdk_id=test_sdk_id_123"), "URL should contain SDK ID")
+    }
+
+    func testTxServerConfigurationIncludesCanaryQueryWhenEnabled() {
+        let config = TxServerConfiguration(environment: .production, canary: true)
+
+        let components = URLComponents(url: config.signalingServer, resolvingAgainstBaseURL: false)
+
+        XCTAssertEqual(components?.queryItems?.first(where: { $0.name == "canary" })?.value, "true")
+    }
+
+    func testTxServerConfigurationIncludesCanaryQueryWhenDisabled() {
+        let config = TxServerConfiguration(environment: .production, canary: false)
+
+        let components = URLComponents(url: config.signalingServer, resolvingAgainstBaseURL: false)
+
+        XCTAssertEqual(components?.queryItems?.first(where: { $0.name == "canary" })?.value, "false")
+    }
+
+    func testTxServerConfigurationOmitsCanaryQueryByDefault() {
+        let config = TxServerConfiguration(environment: .production)
+
+        let components = URLComponents(url: config.signalingServer, resolvingAgainstBaseURL: false)
+
+        XCTAssertNil(components?.queryItems?.first(where: { $0.name == "canary" }))
     }
     
     // MARK: - Socket Region Extraction Tests


### PR DESCRIPTION
## Summary
- add an optional `canary` flag to `TxServerConfiguration`
- append `canary=true|false` to the websocket URL only when the flag is set
- preserve existing push `voice_sdk_id` query handling and add focused region tests

## Behavior
- default: no `canary` query parameter
- `canary = true`: send `?canary=true`
- `canary = false`: send `?canary=false`

## Validation
- `xcodebuild test -workspace TelnyxRTC.xcworkspace -scheme TelnyxRTCTests -destination 'platform=iOS Simulator,OS=18.0,name=iPhone 16 Pro Max' -only-testing:TelnyxRTCTests/RegionTests`