### PR TITLE
[VSDK-350] Untrack GoogleService-Info.plist from iOS demo

### DIFF
--- a/TelnyxWebRTCDemo/GoogleService-Info.plist
+++ b/TelnyxWebRTCDemo/GoogleService-Info.plist
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict/>
-</plist>


### PR DESCRIPTION
## VSDK-350 — Stop committing TelnyxWebRTCDemo/GoogleService-Info.plist

**Linear:** https://linear.app/telnyx/issue/VSDK-350/ios-b1-ios-stop-committing-telnyxwebrtcdemogoogleservice-infoplist

## Problem
The demo app's `GoogleService-Info.plist` was tracked in git despite a .gitignore rule already existing. This file contains Firebase config and should never be committed.

## Fix
- `git rm --cached TelnyxWebRTCDemo/GoogleService-Info.plist` (untracked from git, file stays on disk)
- The existing .gitignore rule prevents future accidental commits

## Changes
- 1 file removed from git tracking (5 lines — was an empty plist stub)

## Risk
None. The file was an empty stub (`<dict/>`). Real Firebase config lives locally and is gitignored.