### PR TITLE
Preserve region for VoIP push connections

### DIFF
--- a/TelnyxRTC/Telnyx/Models/TxServerConfiguration.swift
+++ b/TelnyxRTC/Telnyx/Models/TxServerConfiguration.swift
@@ -17,6 +17,7 @@ public enum WebRTCEnvironment {
 public struct TxServerConfiguration {
 
     public internal(set) var environment: WebRTCEnvironment = .production
+    public internal(set) var region: Region = .auto
     public internal(set) var signalingServer: URL
     public internal(set) var pushMetaData: [String:Any]?
     public internal(set) var webRTCIceServers: [RTCIceServer]
@@ -28,6 +29,7 @@ public struct TxServerConfiguration {
     ///   - pushMetaData: Contains push info when a PN is received
     public init(signalingServer: URL? = nil, webRTCIceServers: [RTCIceServer]? = nil, environment: WebRTCEnvironment = .production,pushMetaData:[String: Any]? = nil,region:Region = Region.auto) {
         
+        self.region = region
         self.pushMetaData = pushMetaData
         // Get rtc_id  to setup TxPushServerConfig
         let rtc_id = (pushMetaData?["voice_sdk_id"] as? String)

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -1475,7 +1475,8 @@ extension TxClient {
             signalingServer:nil,
             webRTCIceServers: serverConfiguration.webRTCIceServers,
             environment: serverConfiguration.environment,
-            pushMetaData: pushMetaData)
+            pushMetaData: pushMetaData,
+            region: serverConfiguration.region)
                 
         let noActiveCalls = self.calls.filter { 
             $0.value.callState.isConsideredActive

--- a/TelnyxRTCTests/RegionTests.swift
+++ b/TelnyxRTCTests/RegionTests.swift
@@ -231,6 +231,7 @@ class RegionTests: XCTestCase {
         let apacConfig = TxServerConfiguration(environment: .production, region: .apac)
         let apacURL = apacConfig.signalingServer.absoluteString
         XCTAssertTrue(apacURL.contains("apac."), "APAC region should add 'apac.' prefix to URL")
+        XCTAssertEqual(apacConfig.region, .apac)
     }
     
     /**
@@ -268,6 +269,15 @@ class RegionTests: XCTestCase {
         XCTAssertTrue(usWestURL.contains("us-west."), "US West region should add prefix even with push metadata")
         // Check for URL-encoded version of underscores (%5F)
         XCTAssertTrue(usWestURL.contains("voice_sdk_id=test%5Fsdk%5Fid%5F123"), "URL should contain URL-encoded SDK ID")
+
+        let apacConfig = TxServerConfiguration(environment: .production, region: .apac)
+        let pushConfig = TxServerConfiguration(
+            webRTCIceServers: apacConfig.webRTCIceServers,
+            environment: apacConfig.environment,
+            pushMetaData: pushMetaData,
+            region: apacConfig.region
+        )
+        XCTAssertEqual(pushConfig.signalingServer.host, "apac.rtc.telnyx.com")
     }
     
     // MARK: - Socket Region Extraction Tests


### PR DESCRIPTION
## Summary
- retain the requested region in `TxServerConfiguration`
- preserve that region when rebuilding the server configuration for a VoIP push
- add APAC push URL regression coverage

## Validation
- `git diff --check`