### PR TITLE
VSUP-199: Add signaling-health probing to call recovery

### DIFF
--- a/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
+++ b/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
@@ -13,6 +13,11 @@ internal final class SignalingHealthMonitor {
         case reattaching
     }
 
+    private enum SignalingProbePurpose {
+        case mediaRecovery
+        case healthCheck
+    }
+
     private let iceRestartTimeout: TimeInterval
     private let signalingProbeTimeout: TimeInterval
     private let recentInboundActivityThreshold: TimeInterval
@@ -30,6 +35,7 @@ internal final class SignalingHealthMonitor {
     private var signalingProbeTimeoutWorkItem: DispatchWorkItem?
     private var signalingHealthCheckTimer: DispatchSourceTimer?
     private var pendingSignalingProbeId: String?
+    private var pendingSignalingProbePurpose: SignalingProbePurpose?
     private var lastInboundSignalingActivity = Date()
     private var lastConfirmedOutboundActivity = Date()
     private weak var monitoredActiveCall: Call?
@@ -94,12 +100,18 @@ internal final class SignalingHealthMonitor {
             self.lastConfirmedOutboundActivity = Date()
             guard self.recoveryMode == .probing,
                   self.pendingSignalingProbeId == message.id,
-                  let call = self.recoveringCall else { return }
+                  let purpose = self.pendingSignalingProbePurpose else { return }
 
             Logger.log.i(message: "[CALL-RECOVERY] Signaling health probe succeeded")
             self.cancelSignalingProbeTimeout()
             self.recoveryMode = .idle
-            self.startIceRestartRecovery(for: call)
+            switch purpose {
+            case .mediaRecovery:
+                guard let call = self.recoveringCall else { return }
+                self.startIceRestartRecovery(for: call)
+            case .healthCheck:
+                self.recoveringCall = nil
+            }
         }
     }
 
@@ -166,7 +178,7 @@ internal final class SignalingHealthMonitor {
                 self.startIceRestartRecovery(for: call)
             } else {
                 Logger.log.w(message: "[CALL-RECOVERY] \(trigger) with stale signaling; probing before ICE restart")
-                self.startSignalingProbe(for: call)
+                self.startSignalingProbe(for: call, purpose: .mediaRecovery)
             }
         }
     }
@@ -183,7 +195,7 @@ internal final class SignalingHealthMonitor {
         startIceRestart(call)
     }
 
-    private func startSignalingProbe(for call: Call) {
+    private func startSignalingProbe(for call: Call, purpose: SignalingProbePurpose) {
         guard let probeId = sendSignalingProbe() else {
             Logger.log.e(message: "[CALL-RECOVERY] Unable to send signaling health probe")
             beginReattach()
@@ -193,6 +205,7 @@ internal final class SignalingHealthMonitor {
         cancelSignalingProbeTimeout()
         recoveryMode = .probing
         pendingSignalingProbeId = probeId
+        pendingSignalingProbePurpose = purpose
         let workItem = DispatchWorkItem { [weak self, weak call] in
             guard let self = self,
                   let call = call,
@@ -241,7 +254,7 @@ internal final class SignalingHealthMonitor {
 
         Logger.log.w(message: "[CALL-RECOVERY] Signaling activity is stale during an active call; probing")
         recoveringCall = call
-        startSignalingProbe(for: call)
+        startSignalingProbe(for: call, purpose: .healthCheck)
     }
 
     private func startIceRestartTimeout(for call: Call) {
@@ -284,6 +297,7 @@ internal final class SignalingHealthMonitor {
         signalingProbeTimeoutWorkItem?.cancel()
         signalingProbeTimeoutWorkItem = nil
         pendingSignalingProbeId = nil
+        pendingSignalingProbePurpose = nil
     }
 
     private func executeOnMain(_ block: @escaping () -> Void) {

--- a/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
+++ b/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
@@ -28,6 +28,7 @@ internal final class SignalingHealthMonitor {
     private let confirmedOutboundActivityThreshold: TimeInterval
     private let staleInboundActivityThreshold: TimeInterval
     private let signalingHealthCheckInterval: TimeInterval
+    private let peerDisconnectedRecoveryDelay: TimeInterval
     private let isSignalingAvailable: () -> Bool
     private let sendSignalingProbe: () -> String?
     private let startIceRestart: (Call) -> Void
@@ -38,6 +39,7 @@ internal final class SignalingHealthMonitor {
     private var iceRestartTimeoutWorkItem: DispatchWorkItem?
     private var signalingProbeTimeoutWorkItem: DispatchWorkItem?
     private var signalingHealthCheckTimer: DispatchSourceTimer?
+    private var peerDisconnectedRecoveryWorkItem: DispatchWorkItem?
     private var pendingSignalingProbeId: String?
     private var pendingSignalingProbePurpose: SignalingProbePurpose?
     private var lastInboundSignalingActivity = Date()
@@ -51,6 +53,7 @@ internal final class SignalingHealthMonitor {
         confirmedOutboundActivityThreshold: TimeInterval = 45,
         staleInboundActivityThreshold: TimeInterval = 20,
         signalingHealthCheckInterval: TimeInterval = 3,
+        peerDisconnectedRecoveryDelay: TimeInterval = 3,
         isSignalingAvailable: @escaping () -> Bool,
         sendSignalingProbe: @escaping () -> String?,
         startIceRestart: @escaping (Call) -> Void,
@@ -62,6 +65,7 @@ internal final class SignalingHealthMonitor {
         self.confirmedOutboundActivityThreshold = confirmedOutboundActivityThreshold
         self.staleInboundActivityThreshold = staleInboundActivityThreshold
         self.signalingHealthCheckInterval = signalingHealthCheckInterval
+        self.peerDisconnectedRecoveryDelay = peerDisconnectedRecoveryDelay
         self.isSignalingAvailable = isSignalingAvailable
         self.sendSignalingProbe = sendSignalingProbe
         self.startIceRestart = startIceRestart
@@ -71,6 +75,7 @@ internal final class SignalingHealthMonitor {
     deinit {
         signalingHealthCheckTimer?.setEventHandler {}
         signalingHealthCheckTimer?.cancel()
+        peerDisconnectedRecoveryWorkItem?.cancel()
     }
 
     func networkPathDidChange() {
@@ -91,12 +96,19 @@ internal final class SignalingHealthMonitor {
     }
 
     func peerConnectionStateDidChange(_ call: Call, state: RTCPeerConnectionState) {
-        guard state == .disconnected || state == .failed else { return }
         executeOnQueue { [weak self] in
-            let trigger = state == .disconnected
-                ? "peer_connection_disconnected"
-                : "peer_connection_failed"
-            self?.requestRecovery(for: call, trigger: trigger)
+            guard let self = self else { return }
+            switch state {
+            case .failed:
+                self.cancelPeerDisconnectedRecovery()
+                self.requestRecovery(for: call, trigger: "peer_connection_failed")
+            case .disconnected:
+                self.startPeerDisconnectedRecoveryDelay(for: call)
+            case .connected:
+                self.cancelPeerDisconnectedRecovery()
+            default:
+                break
+            }
         }
     }
 
@@ -155,6 +167,7 @@ internal final class SignalingHealthMonitor {
                 self.monitoredActiveCall = call
                 self.startSignalingHealthChecks()
             case .DONE, .DROPPED:
+                self.cancelPeerDisconnectedRecovery()
                 if self.monitoredActiveCall === call {
                     self.stopSignalingHealthChecks()
                     self.monitoredActiveCall = nil
@@ -169,6 +182,7 @@ internal final class SignalingHealthMonitor {
     }
 
     private func requestRecovery(for call: Call, trigger: String) {
+        cancelPeerDisconnectedRecovery()
         guard call.callState == .ACTIVE else {
             Logger.log.i(message: "[CALL-RECOVERY] Ignoring \(trigger); call is \(call.callState.value)")
             return
@@ -235,6 +249,29 @@ internal final class SignalingHealthMonitor {
         }
         signalingHealthCheckTimer = timer
         timer.resume()
+    }
+
+    /// `disconnected` is commonly transient while iOS changes radio or Wi-Fi
+    /// paths. Give WebRTC a short chance to return to connected before
+    /// renegotiating; terminal `failed` still recovers immediately.
+    private func startPeerDisconnectedRecoveryDelay(for call: Call) {
+        guard recoveryMode == .idle else { return }
+        cancelPeerDisconnectedRecovery()
+        let workItem = DispatchWorkItem { [weak self, weak call] in
+            guard let self = self,
+                  let call = call,
+                  self.recoveryMode == .idle,
+                  call.callState == .ACTIVE else { return }
+            Logger.log.w(message: "[CALL-RECOVERY] Peer remained disconnected for \(self.peerDisconnectedRecoveryDelay)s; starting recovery")
+            self.requestRecovery(for: call, trigger: "peer_connection_disconnected")
+        }
+        peerDisconnectedRecoveryWorkItem = workItem
+        queue.asyncAfter(deadline: .now() + peerDisconnectedRecoveryDelay, execute: workItem)
+    }
+
+    private func cancelPeerDisconnectedRecovery() {
+        peerDisconnectedRecoveryWorkItem?.cancel()
+        peerDisconnectedRecoveryWorkItem = nil
     }
 
     private func stopSignalingHealthChecks() {

--- a/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
+++ b/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
@@ -91,9 +91,12 @@ internal final class SignalingHealthMonitor {
     }
 
     func peerConnectionStateDidChange(_ call: Call, state: RTCPeerConnectionState) {
-        guard state == .failed else { return }
+        guard state == .disconnected || state == .failed else { return }
         executeOnQueue { [weak self] in
-            self?.requestRecovery(for: call, trigger: "peer_connection_failed")
+            let trigger = state == .disconnected
+                ? "peer_connection_disconnected"
+                : "peer_connection_failed"
+            self?.requestRecovery(for: call, trigger: trigger)
         }
     }
 

--- a/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
+++ b/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
@@ -6,6 +6,10 @@ import WebRTC
 /// The monitor owns recovery state and timers, while `Call` owns WebRTC
 /// renegotiation and `TxClient` owns reconnect/reattach mechanics.
 internal final class SignalingHealthMonitor {
+    /// Serializes recovery transitions and timer callbacks independently of the
+    /// main queue, where CallKit and other UI-facing work may run.
+    private let queue = DispatchQueue(label: "com.telnyx.SignalingHealthMonitor")
+
     private enum RecoveryMode: Equatable {
         case idle
         case probing
@@ -70,7 +74,7 @@ internal final class SignalingHealthMonitor {
     }
 
     func networkPathDidChange() {
-        executeOnMain { [weak self] in
+        executeOnQueue { [weak self] in
             guard let self = self, self.recoveryMode != .reattaching else { return }
             Logger.log.i(message: "[CALL-RECOVERY] Network path changed; using required reconnect/reattach flow")
             self.cancelRecoveryTimeouts()
@@ -81,18 +85,22 @@ internal final class SignalingHealthMonitor {
 
     func iceConnectionStateDidChange(_ call: Call, state: RTCIceConnectionState) {
         guard state == .failed else { return }
-        requestRecovery(for: call, trigger: "ice_failed")
+        executeOnQueue { [weak self] in
+            self?.requestRecovery(for: call, trigger: "ice_failed")
+        }
     }
 
     func peerConnectionStateDidChange(_ call: Call, state: RTCPeerConnectionState) {
         guard state == .failed else { return }
-        requestRecovery(for: call, trigger: "peer_connection_failed")
+        executeOnQueue { [weak self] in
+            self?.requestRecovery(for: call, trigger: "peer_connection_failed")
+        }
     }
 
     /// Records every inbound signaling frame. A probe is successful only when a
     /// result or error has the exact JSON-RPC id generated for that probe.
     func signalingMessageReceived(_ message: Message) {
-        executeOnMain { [weak self] in
+        executeOnQueue { [weak self] in
             guard let self = self else { return }
             self.lastInboundSignalingActivity = Date()
 
@@ -116,7 +124,7 @@ internal final class SignalingHealthMonitor {
     }
 
     func iceRestartDidComplete(for call: Call) {
-        executeOnMain { [weak self] in
+        executeOnQueue { [weak self] in
             guard let self = self, self.recoveryMode == .iceRestarting, self.recoveringCall === call else { return }
             Logger.log.i(message: "[CALL-RECOVERY] ICE restart answer applied")
             self.finishRecovery()
@@ -124,7 +132,7 @@ internal final class SignalingHealthMonitor {
     }
 
     func iceRestartRequestDidFail(for call: Call, error: Error) {
-        executeOnMain { [weak self] in
+        executeOnQueue { [weak self] in
             guard let self = self, self.recoveryMode == .iceRestarting, self.recoveringCall === call else { return }
             Logger.log.e(message: "[CALL-RECOVERY] ICE restart failed: \(error.localizedDescription)")
             self.beginReattach()
@@ -132,7 +140,7 @@ internal final class SignalingHealthMonitor {
     }
 
     func callStateDidChange(_ call: Call) {
-        executeOnMain { [weak self] in
+        executeOnQueue { [weak self] in
             guard let self = self else { return }
 
             switch call.callState {
@@ -158,28 +166,25 @@ internal final class SignalingHealthMonitor {
     }
 
     private func requestRecovery(for call: Call, trigger: String) {
-        executeOnMain { [weak self] in
-            guard let self = self else { return }
-            guard call.callState == .ACTIVE else {
-                Logger.log.i(message: "[CALL-RECOVERY] Ignoring \(trigger); call is \(call.callState.value)")
-                return
-            }
-            guard self.recoveryMode == .idle else {
-                Logger.log.i(message: "[CALL-RECOVERY] Ignoring \(trigger); recovery is already in progress")
-                return
-            }
+        guard call.callState == .ACTIVE else {
+            Logger.log.i(message: "[CALL-RECOVERY] Ignoring \(trigger); call is \(call.callState.value)")
+            return
+        }
+        guard recoveryMode == .idle else {
+            Logger.log.i(message: "[CALL-RECOVERY] Ignoring \(trigger); recovery is already in progress")
+            return
+        }
 
-            self.recoveringCall = call
-            if !self.isSignalingAvailable() {
-                Logger.log.w(message: "[CALL-RECOVERY] \(trigger) with signaling unavailable; starting reconnect/reattach")
-                self.beginReattach()
-            } else if self.hasRecentSignalingActivity() {
-                Logger.log.w(message: "[CALL-RECOVERY] \(trigger) with signaling available; starting ICE restart")
-                self.startIceRestartRecovery(for: call)
-            } else {
-                Logger.log.w(message: "[CALL-RECOVERY] \(trigger) with stale signaling; probing before ICE restart")
-                self.startSignalingProbe(for: call, purpose: .mediaRecovery)
-            }
+        recoveringCall = call
+        if !isSignalingAvailable() {
+            Logger.log.w(message: "[CALL-RECOVERY] \(trigger) with signaling unavailable; starting reconnect/reattach")
+            beginReattach()
+        } else if hasRecentSignalingActivity() {
+            Logger.log.w(message: "[CALL-RECOVERY] \(trigger) with signaling available; starting ICE restart")
+            startIceRestartRecovery(for: call)
+        } else {
+            Logger.log.w(message: "[CALL-RECOVERY] \(trigger) with stale signaling; probing before ICE restart")
+            startSignalingProbe(for: call, purpose: .mediaRecovery)
         }
     }
 
@@ -215,12 +220,12 @@ internal final class SignalingHealthMonitor {
             self.beginReattach()
         }
         signalingProbeTimeoutWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + signalingProbeTimeout, execute: workItem)
+        queue.asyncAfter(deadline: .now() + signalingProbeTimeout, execute: workItem)
     }
 
     private func startSignalingHealthChecks() {
         guard signalingHealthCheckTimer == nil else { return }
-        let timer = DispatchSource.makeTimerSource(queue: .main)
+        let timer = DispatchSource.makeTimerSource(queue: queue)
         timer.schedule(deadline: .now() + signalingHealthCheckInterval, repeating: signalingHealthCheckInterval)
         timer.setEventHandler { [weak self] in
             self?.checkSignalingHealth()
@@ -268,7 +273,7 @@ internal final class SignalingHealthMonitor {
             self.beginReattach()
         }
         iceRestartTimeoutWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + iceRestartTimeout, execute: workItem)
+        queue.asyncAfter(deadline: .now() + iceRestartTimeout, execute: workItem)
     }
 
     private func beginReattach() {
@@ -300,11 +305,7 @@ internal final class SignalingHealthMonitor {
         pendingSignalingProbePurpose = nil
     }
 
-    private func executeOnMain(_ block: @escaping () -> Void) {
-        if Thread.isMainThread {
-            block()
-        } else {
-            DispatchQueue.main.async(execute: block)
-        }
+    private func executeOnQueue(_ block: @escaping () -> Void) {
+        queue.async(execute: block)
     }
 }

--- a/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
+++ b/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
@@ -8,27 +8,44 @@ import WebRTC
 internal final class SignalingHealthMonitor {
     private enum RecoveryMode: Equatable {
         case idle
+        case probing
         case iceRestarting
         case reattaching
     }
 
     private let iceRestartTimeout: TimeInterval
+    private let signalingProbeTimeout: TimeInterval
+    private let recentInboundActivityThreshold: TimeInterval
+    private let confirmedOutboundActivityThreshold: TimeInterval
     private let isSignalingAvailable: () -> Bool
+    private let sendSignalingProbe: () -> String?
     private let startIceRestart: (Call) -> Void
     private let requestReattach: () -> Void
 
     private weak var recoveringCall: Call?
     private var recoveryMode: RecoveryMode = .idle
     private var iceRestartTimeoutWorkItem: DispatchWorkItem?
+    private var signalingProbeTimeoutWorkItem: DispatchWorkItem?
+    private var pendingSignalingProbeId: String?
+    private var lastInboundSignalingActivity = Date()
+    private var lastConfirmedOutboundActivity = Date()
 
     init(
         iceRestartTimeout: TimeInterval = 15,
+        signalingProbeTimeout: TimeInterval = 5,
+        recentInboundActivityThreshold: TimeInterval = 3,
+        confirmedOutboundActivityThreshold: TimeInterval = 45,
         isSignalingAvailable: @escaping () -> Bool,
+        sendSignalingProbe: @escaping () -> String?,
         startIceRestart: @escaping (Call) -> Void,
         requestReattach: @escaping () -> Void
     ) {
         self.iceRestartTimeout = iceRestartTimeout
+        self.signalingProbeTimeout = signalingProbeTimeout
+        self.recentInboundActivityThreshold = recentInboundActivityThreshold
+        self.confirmedOutboundActivityThreshold = confirmedOutboundActivityThreshold
         self.isSignalingAvailable = isSignalingAvailable
+        self.sendSignalingProbe = sendSignalingProbe
         self.startIceRestart = startIceRestart
         self.requestReattach = requestReattach
     }
@@ -37,7 +54,7 @@ internal final class SignalingHealthMonitor {
         executeOnMain { [weak self] in
             guard let self = self, self.recoveryMode != .reattaching else { return }
             Logger.log.i(message: "[CALL-RECOVERY] Network path changed; using required reconnect/reattach flow")
-            self.cancelIceRestartTimeout()
+            self.cancelRecoveryTimeouts()
             self.recoveringCall = nil
             self.recoveryMode = .reattaching
         }
@@ -51,6 +68,26 @@ internal final class SignalingHealthMonitor {
     func peerConnectionStateDidChange(_ call: Call, state: RTCPeerConnectionState) {
         guard state == .failed else { return }
         requestRecovery(for: call, trigger: "peer_connection_failed")
+    }
+
+    /// Records every inbound signaling frame. A probe is successful only when a
+    /// result or error has the exact JSON-RPC id generated for that probe.
+    func signalingMessageReceived(_ message: Message) {
+        executeOnMain { [weak self] in
+            guard let self = self else { return }
+            self.lastInboundSignalingActivity = Date()
+
+            guard message.result != nil || message.serverError != nil else { return }
+            self.lastConfirmedOutboundActivity = Date()
+            guard self.recoveryMode == .probing,
+                  self.pendingSignalingProbeId == message.id,
+                  let call = self.recoveringCall else { return }
+
+            Logger.log.i(message: "[CALL-RECOVERY] Signaling health probe succeeded")
+            self.cancelSignalingProbeTimeout()
+            self.recoveryMode = .idle
+            self.startIceRestartRecovery(for: call)
+        }
     }
 
     func iceRestartDidComplete(for call: Call) {
@@ -102,16 +139,51 @@ internal final class SignalingHealthMonitor {
             }
 
             self.recoveringCall = call
-            if self.isSignalingAvailable() {
-                Logger.log.w(message: "[CALL-RECOVERY] \(trigger) with signaling available; starting ICE restart")
-                self.recoveryMode = .iceRestarting
-                self.startIceRestartTimeout(for: call)
-                self.startIceRestart(call)
-            } else {
+            if !self.isSignalingAvailable() {
                 Logger.log.w(message: "[CALL-RECOVERY] \(trigger) with signaling unavailable; starting reconnect/reattach")
                 self.beginReattach()
+            } else if self.hasRecentSignalingActivity() {
+                Logger.log.w(message: "[CALL-RECOVERY] \(trigger) with signaling available; starting ICE restart")
+                self.startIceRestartRecovery(for: call)
+            } else {
+                Logger.log.w(message: "[CALL-RECOVERY] \(trigger) with stale signaling; probing before ICE restart")
+                self.startSignalingProbe(for: call)
             }
         }
+    }
+
+    private func hasRecentSignalingActivity() -> Bool {
+        let now = Date()
+        return now.timeIntervalSince(lastInboundSignalingActivity) <= recentInboundActivityThreshold
+            && now.timeIntervalSince(lastConfirmedOutboundActivity) <= confirmedOutboundActivityThreshold
+    }
+
+    private func startIceRestartRecovery(for call: Call) {
+        recoveryMode = .iceRestarting
+        startIceRestartTimeout(for: call)
+        startIceRestart(call)
+    }
+
+    private func startSignalingProbe(for call: Call) {
+        guard let probeId = sendSignalingProbe() else {
+            Logger.log.e(message: "[CALL-RECOVERY] Unable to send signaling health probe")
+            beginReattach()
+            return
+        }
+
+        cancelSignalingProbeTimeout()
+        recoveryMode = .probing
+        pendingSignalingProbeId = probeId
+        let workItem = DispatchWorkItem { [weak self, weak call] in
+            guard let self = self,
+                  let call = call,
+                  self.recoveryMode == .probing,
+                  self.recoveringCall === call else { return }
+            Logger.log.e(message: "[CALL-RECOVERY] Signaling health probe timed out after \(self.signalingProbeTimeout)s")
+            self.beginReattach()
+        }
+        signalingProbeTimeoutWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + signalingProbeTimeout, execute: workItem)
     }
 
     private func startIceRestartTimeout(for call: Call) {
@@ -129,20 +201,31 @@ internal final class SignalingHealthMonitor {
     }
 
     private func beginReattach() {
-        cancelIceRestartTimeout()
+        cancelRecoveryTimeouts()
         recoveryMode = .reattaching
         requestReattach()
     }
 
     private func finishRecovery() {
-        cancelIceRestartTimeout()
+        cancelRecoveryTimeouts()
         recoveringCall = nil
         recoveryMode = .idle
+    }
+
+    private func cancelRecoveryTimeouts() {
+        cancelIceRestartTimeout()
+        cancelSignalingProbeTimeout()
     }
 
     private func cancelIceRestartTimeout() {
         iceRestartTimeoutWorkItem?.cancel()
         iceRestartTimeoutWorkItem = nil
+    }
+
+    private func cancelSignalingProbeTimeout() {
+        signalingProbeTimeoutWorkItem?.cancel()
+        signalingProbeTimeoutWorkItem = nil
+        pendingSignalingProbeId = nil
     }
 
     private func executeOnMain(_ block: @escaping () -> Void) {

--- a/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
+++ b/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
@@ -17,6 +17,8 @@ internal final class SignalingHealthMonitor {
     private let signalingProbeTimeout: TimeInterval
     private let recentInboundActivityThreshold: TimeInterval
     private let confirmedOutboundActivityThreshold: TimeInterval
+    private let staleInboundActivityThreshold: TimeInterval
+    private let signalingHealthCheckInterval: TimeInterval
     private let isSignalingAvailable: () -> Bool
     private let sendSignalingProbe: () -> String?
     private let startIceRestart: (Call) -> Void
@@ -26,15 +28,19 @@ internal final class SignalingHealthMonitor {
     private var recoveryMode: RecoveryMode = .idle
     private var iceRestartTimeoutWorkItem: DispatchWorkItem?
     private var signalingProbeTimeoutWorkItem: DispatchWorkItem?
+    private var signalingHealthCheckTimer: DispatchSourceTimer?
     private var pendingSignalingProbeId: String?
     private var lastInboundSignalingActivity = Date()
     private var lastConfirmedOutboundActivity = Date()
+    private weak var monitoredActiveCall: Call?
 
     init(
         iceRestartTimeout: TimeInterval = 15,
         signalingProbeTimeout: TimeInterval = 5,
         recentInboundActivityThreshold: TimeInterval = 3,
         confirmedOutboundActivityThreshold: TimeInterval = 45,
+        staleInboundActivityThreshold: TimeInterval = 20,
+        signalingHealthCheckInterval: TimeInterval = 3,
         isSignalingAvailable: @escaping () -> Bool,
         sendSignalingProbe: @escaping () -> String?,
         startIceRestart: @escaping (Call) -> Void,
@@ -44,10 +50,17 @@ internal final class SignalingHealthMonitor {
         self.signalingProbeTimeout = signalingProbeTimeout
         self.recentInboundActivityThreshold = recentInboundActivityThreshold
         self.confirmedOutboundActivityThreshold = confirmedOutboundActivityThreshold
+        self.staleInboundActivityThreshold = staleInboundActivityThreshold
+        self.signalingHealthCheckInterval = signalingHealthCheckInterval
         self.isSignalingAvailable = isSignalingAvailable
         self.sendSignalingProbe = sendSignalingProbe
         self.startIceRestart = startIceRestart
         self.requestReattach = requestReattach
+    }
+
+    deinit {
+        signalingHealthCheckTimer?.setEventHandler {}
+        signalingHealthCheckTimer?.cancel()
     }
 
     func networkPathDidChange() {
@@ -116,7 +129,13 @@ internal final class SignalingHealthMonitor {
                     Logger.log.i(message: "[CALL-RECOVERY] Reattached call is active")
                     self.finishRecovery()
                 }
+                self.monitoredActiveCall = call
+                self.startSignalingHealthChecks()
             case .DONE, .DROPPED:
+                if self.monitoredActiveCall === call {
+                    self.stopSignalingHealthChecks()
+                    self.monitoredActiveCall = nil
+                }
                 if self.recoveringCall === call {
                     self.finishRecovery()
                 }
@@ -184,6 +203,45 @@ internal final class SignalingHealthMonitor {
         }
         signalingProbeTimeoutWorkItem = workItem
         DispatchQueue.main.asyncAfter(deadline: .now() + signalingProbeTimeout, execute: workItem)
+    }
+
+    private func startSignalingHealthChecks() {
+        guard signalingHealthCheckTimer == nil else { return }
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        timer.schedule(deadline: .now() + signalingHealthCheckInterval, repeating: signalingHealthCheckInterval)
+        timer.setEventHandler { [weak self] in
+            self?.checkSignalingHealth()
+        }
+        signalingHealthCheckTimer = timer
+        timer.resume()
+    }
+
+    private func stopSignalingHealthChecks() {
+        signalingHealthCheckTimer?.setEventHandler {}
+        signalingHealthCheckTimer?.cancel()
+        signalingHealthCheckTimer = nil
+    }
+
+    private func checkSignalingHealth() {
+        guard recoveryMode == .idle,
+              let call = monitoredActiveCall,
+              call.callState == .ACTIVE else { return }
+
+        guard isSignalingAvailable() else {
+            Logger.log.w(message: "[CALL-RECOVERY] Signaling socket is unavailable during an active call")
+            recoveringCall = call
+            beginReattach()
+            return
+        }
+
+        let now = Date()
+        let inboundIsStale = now.timeIntervalSince(lastInboundSignalingActivity) >= staleInboundActivityThreshold
+        let outboundIsStale = now.timeIntervalSince(lastConfirmedOutboundActivity) >= confirmedOutboundActivityThreshold
+        guard inboundIsStale || outboundIsStale else { return }
+
+        Logger.log.w(message: "[CALL-RECOVERY] Signaling activity is stale during an active call; probing")
+        recoveringCall = call
+        startSignalingProbe(for: call)
     }
 
     private func startIceRestartTimeout(for call: Call) {

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -188,6 +188,7 @@ public class TxClient {
             sendSignalingProbe: { [weak self] in
                 guard let self = self, self.socket?.isConnected == true else { return nil }
                 let ping = Message([:], method: .PING)
+                ping.jsonMessage["voice_sdk_id"] = self.voiceSdkId
                 guard let encodedPing = ping.encode() else { return nil }
                 self.socket?.sendMessage(message: encodedPing)
                 return ping.id

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -183,31 +183,48 @@ public class TxClient {
     private lazy var signalingHealthMonitor: SignalingHealthMonitor = {
         SignalingHealthMonitor(
             isSignalingAvailable: { [weak self] in
-                self?.socket?.isConnected == true
+                guard let self = self else { return false }
+                if Thread.isMainThread {
+                    return self.socket?.isConnected == true
+                }
+                return DispatchQueue.main.sync {
+                    self.socket?.isConnected == true
+                }
             },
             sendSignalingProbe: { [weak self] in
-                guard let self = self, self.socket?.isConnected == true else { return nil }
-                let ping = Message([:], method: .PING)
-                ping.jsonMessage["voice_sdk_id"] = self.voiceSdkId
-                guard let encodedPing = ping.encode() else { return nil }
-                self.socket?.sendMessage(message: encodedPing)
-                return ping.id
+                guard let self = self else { return nil }
+                let sendProbe: () -> String? = {
+                    guard self.socket?.isConnected == true else { return nil }
+                    let ping = Message([:], method: .PING)
+                    ping.jsonMessage["voice_sdk_id"] = self.voiceSdkId
+                    guard let encodedPing = ping.encode() else { return nil }
+                    self.socket?.sendMessage(message: encodedPing)
+                    return ping.id
+                }
+                if Thread.isMainThread {
+                    return sendProbe()
+                }
+                return DispatchQueue.main.sync(execute: sendProbe)
             },
             startIceRestart: { [weak self] call in
-                call.iceRestart { success, error in
-                    guard !success else { return }
-                    self?.signalingHealthMonitor.iceRestartRequestDidFail(
-                        for: call,
-                        error: error ?? NSError(
-                            domain: "SignalingHealthMonitor",
-                            code: -1,
-                            userInfo: [NSLocalizedDescriptionKey: "ICE restart request failed"]
+                DispatchQueue.main.async {
+                    call.iceRestart { success, error in
+                        guard !success else { return }
+                        self?.signalingHealthMonitor.iceRestartRequestDidFail(
+                            for: call,
+                            error: error ?? NSError(
+                                domain: "SignalingHealthMonitor",
+                                code: -1,
+                                userInfo: [NSLocalizedDescriptionKey: "ICE restart request failed"]
+                            )
                         )
-                    )
+                    }
                 }
             },
             requestReattach: { [weak self] in
-                self?.reconnectClient()
+                DispatchQueue.main.async {
+                    self?.reconnectClient()
+                }
             }
         )
     }()

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -185,6 +185,13 @@ public class TxClient {
             isSignalingAvailable: { [weak self] in
                 self?.socket?.isConnected == true
             },
+            sendSignalingProbe: { [weak self] in
+                guard let self = self, self.socket?.isConnected == true else { return nil }
+                let ping = Message([:], method: .PING)
+                guard let encodedPing = ping.encode() else { return nil }
+                self.socket?.sendMessage(message: encodedPing)
+                return ping.id
+            },
             startIceRestart: { [weak self] call in
                 call.iceRestart { success, error in
                     guard !success else { return }
@@ -1912,6 +1919,7 @@ extension TxClient : SocketDelegate {
         NotificationCenter.default.post(name: .telnyxWebSocketMessageReceived, object: nil, userInfo: ["message": message])
         
         guard let vertoMessage = Message().decode(message: message) else { return }
+        self.signalingHealthMonitor.signalingMessageReceived(vertoMessage)
         
         // Process message through AI Assistant Manager
         if let messageDict = try? JSONSerialization.jsonObject(with: Data(message.utf8), options: []) as? [String: Any] {

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -183,22 +183,16 @@ public class TxClient {
     private lazy var signalingHealthMonitor: SignalingHealthMonitor = {
         SignalingHealthMonitor(
             isSignalingAvailable: { [weak self] in
-                guard let self = self else { return false }
-                return DispatchQueue.main.sync {
-                    self.socket?.isConnected == true
-                }
+                self?.socket?.isConnected == true
             },
             sendSignalingProbe: { [weak self] in
                 guard let self = self else { return nil }
-                let sendProbe: () -> String? = {
-                    guard self.socket?.isConnected == true else { return nil }
-                    let ping = Message([:], method: .PING)
-                    ping.jsonMessage["voice_sdk_id"] = self.voiceSdkId
-                    guard let encodedPing = ping.encode() else { return nil }
-                    self.socket?.sendMessage(message: encodedPing)
-                    return ping.id
-                }
-                return DispatchQueue.main.sync(execute: sendProbe)
+                guard self.socket?.isConnected == true else { return nil }
+                let ping = Message([:], method: .PING)
+                ping.jsonMessage["voice_sdk_id"] = self.voiceSdkId
+                guard let encodedPing = ping.encode() else { return nil }
+                self.socket?.sendMessage(message: encodedPing)
+                return ping.id
             },
             startIceRestart: { [weak self] call in
                 DispatchQueue.main.async {

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -184,9 +184,6 @@ public class TxClient {
         SignalingHealthMonitor(
             isSignalingAvailable: { [weak self] in
                 guard let self = self else { return false }
-                if Thread.isMainThread {
-                    return self.socket?.isConnected == true
-                }
                 return DispatchQueue.main.sync {
                     self.socket?.isConnected == true
                 }
@@ -200,9 +197,6 @@ public class TxClient {
                     guard let encodedPing = ping.encode() else { return nil }
                     self.socket?.sendMessage(message: encodedPing)
                     return ping.id
-                }
-                if Thread.isMainThread {
-                    return sendProbe()
                 }
                 return DispatchQueue.main.sync(execute: sendProbe)
             },

--- a/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
+++ b/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
@@ -126,6 +126,32 @@ final class SignalingHealthMonitorTests: XCTestCase {
         wait(for: [probeExpectation], timeout: 1)
     }
 
+    func testSuccessfulActiveCallHealthProbeDoesNotRestartICE() {
+        let call = makeActiveCall()
+        let probeExpectation = expectation(description: "active call sends signaling probe")
+        var restartCount = 0
+        var reattachCount = 0
+        let monitor = SignalingHealthMonitor(
+            signalingProbeTimeout: 1,
+            staleInboundActivityThreshold: 0.01,
+            signalingHealthCheckInterval: 0.01,
+            isSignalingAvailable: { true },
+            sendSignalingProbe: {
+                probeExpectation.fulfill()
+                return "health-probe-id"
+            },
+            startIceRestart: { _ in restartCount += 1 },
+            requestReattach: { reattachCount += 1 }
+        )
+
+        monitor.callStateDidChange(call)
+        wait(for: [probeExpectation], timeout: 1)
+        monitor.signalingMessageReceived(makeResponse(id: "health-probe-id"))
+
+        XCTAssertEqual(restartCount, 0)
+        XCTAssertEqual(reattachCount, 0)
+    }
+
     func testActiveCallReattachesWhenSignalingProbeTimesOut() {
         let call = makeActiveCall()
         let reattachExpectation = expectation(description: "active call reattaches after probe timeout")

--- a/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
+++ b/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
@@ -25,6 +25,21 @@ final class SignalingHealthMonitorTests: XCTestCase {
         XCTAssertEqual(reattachCount, 0)
     }
 
+    func testPeerDisconnectionStartsIceRestartWhenSignalingIsHealthy() {
+        let call = makeActiveCall()
+        let restartExpectation = expectation(description: "starts ICE restart after peer disconnection")
+        let monitor = SignalingHealthMonitor(
+            isSignalingAvailable: { true },
+            sendSignalingProbe: { "probe-id" },
+            startIceRestart: { _ in restartExpectation.fulfill() },
+            requestReattach: { XCTFail("Should not reattach while signaling is healthy") }
+        )
+
+        monitor.peerConnectionStateDidChange(call, state: .disconnected)
+
+        wait(for: [restartExpectation], timeout: 1)
+    }
+
     func testPeerFailureWithUnavailableSignalingUsesReattach() {
         let call = makeActiveCall()
         var restartCount = 0

--- a/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
+++ b/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
@@ -25,10 +25,11 @@ final class SignalingHealthMonitorTests: XCTestCase {
         XCTAssertEqual(reattachCount, 0)
     }
 
-    func testPeerDisconnectionStartsIceRestartWhenSignalingIsHealthy() {
+    func testSustainedPeerDisconnectionStartsIceRestartWhenSignalingIsHealthy() {
         let call = makeActiveCall()
-        let restartExpectation = expectation(description: "starts ICE restart after peer disconnection")
+        let restartExpectation = expectation(description: "starts ICE restart after sustained peer disconnection")
         let monitor = SignalingHealthMonitor(
+            peerDisconnectedRecoveryDelay: 0.01,
             isSignalingAvailable: { true },
             sendSignalingProbe: { "probe-id" },
             startIceRestart: { _ in restartExpectation.fulfill() },
@@ -38,6 +39,24 @@ final class SignalingHealthMonitorTests: XCTestCase {
         monitor.peerConnectionStateDidChange(call, state: .disconnected)
 
         wait(for: [restartExpectation], timeout: 1)
+    }
+
+    func testPeerReconnectCancelsDisconnectedRecoveryDelay() {
+        let call = makeActiveCall()
+        let noRestartExpectation = expectation(description: "does not restart after transient peer disconnection")
+        noRestartExpectation.isInverted = true
+        let monitor = SignalingHealthMonitor(
+            peerDisconnectedRecoveryDelay: 0.02,
+            isSignalingAvailable: { true },
+            sendSignalingProbe: { "probe-id" },
+            startIceRestart: { _ in noRestartExpectation.fulfill() },
+            requestReattach: { XCTFail("Should not reattach after peer reconnects") }
+        )
+
+        monitor.peerConnectionStateDidChange(call, state: .disconnected)
+        monitor.peerConnectionStateDidChange(call, state: .connected)
+
+        wait(for: [noRestartExpectation], timeout: 0.1)
     }
 
     func testPeerFailureWithUnavailableSignalingUsesReattach() {

--- a/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
+++ b/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
@@ -105,6 +105,45 @@ final class SignalingHealthMonitorTests: XCTestCase {
         wait(for: [reattachExpectation], timeout: 1)
     }
 
+    func testActiveCallProbesAfterSustainedSignalingSilence() {
+        let call = makeActiveCall()
+        let probeExpectation = expectation(description: "active call sends signaling probe")
+        let monitor = SignalingHealthMonitor(
+            signalingProbeTimeout: 1,
+            staleInboundActivityThreshold: 0.01,
+            signalingHealthCheckInterval: 0.01,
+            isSignalingAvailable: { true },
+            sendSignalingProbe: {
+                probeExpectation.fulfill()
+                return "probe-id"
+            },
+            startIceRestart: { _ in XCTFail("Should not restart ICE") },
+            requestReattach: { XCTFail("Should not reattach before probe timeout") }
+        )
+
+        monitor.callStateDidChange(call)
+
+        wait(for: [probeExpectation], timeout: 1)
+    }
+
+    func testActiveCallReattachesWhenSignalingProbeTimesOut() {
+        let call = makeActiveCall()
+        let reattachExpectation = expectation(description: "active call reattaches after probe timeout")
+        let monitor = SignalingHealthMonitor(
+            signalingProbeTimeout: 0.01,
+            staleInboundActivityThreshold: 0.01,
+            signalingHealthCheckInterval: 0.01,
+            isSignalingAvailable: { true },
+            sendSignalingProbe: { "probe-id" },
+            startIceRestart: { _ in XCTFail("Should not restart ICE") },
+            requestReattach: { reattachExpectation.fulfill() }
+        )
+
+        monitor.callStateDidChange(call)
+
+        wait(for: [reattachExpectation], timeout: 1)
+    }
+
     private func makeResponse(id: String) -> Message {
         Message().decode(message: "{\"jsonrpc\":\"2.0\",\"id\":\"\(id)\",\"result\":{}}")!
     }

--- a/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
+++ b/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
@@ -6,16 +6,21 @@ final class SignalingHealthMonitorTests: XCTestCase {
         let call = makeActiveCall()
         var restartCount = 0
         var reattachCount = 0
+        let restartExpectation = expectation(description: "starts one ICE restart")
         let monitor = SignalingHealthMonitor(
             isSignalingAvailable: { true },
             sendSignalingProbe: { "probe-id" },
-            startIceRestart: { _ in restartCount += 1 },
+            startIceRestart: { _ in
+                restartCount += 1
+                restartExpectation.fulfill()
+            },
             requestReattach: { reattachCount += 1 }
         )
 
         monitor.iceConnectionStateDidChange(call, state: .failed)
         monitor.peerConnectionStateDidChange(call, state: .failed)
 
+        wait(for: [restartExpectation], timeout: 1)
         XCTAssertEqual(restartCount, 1)
         XCTAssertEqual(reattachCount, 0)
     }
@@ -24,15 +29,20 @@ final class SignalingHealthMonitorTests: XCTestCase {
         let call = makeActiveCall()
         var restartCount = 0
         var reattachCount = 0
+        let reattachExpectation = expectation(description: "requests reattach")
         let monitor = SignalingHealthMonitor(
             isSignalingAvailable: { false },
             sendSignalingProbe: { "probe-id" },
             startIceRestart: { _ in restartCount += 1 },
-            requestReattach: { reattachCount += 1 }
+            requestReattach: {
+                reattachCount += 1
+                reattachExpectation.fulfill()
+            }
         )
 
         monitor.peerConnectionStateDidChange(call, state: .failed)
 
+        wait(for: [reattachExpectation], timeout: 1)
         XCTAssertEqual(restartCount, 0)
         XCTAssertEqual(reattachCount, 1)
     }
@@ -57,15 +67,21 @@ final class SignalingHealthMonitorTests: XCTestCase {
         let call = makeActiveCall()
         var restartCount = 0
         var probeCount = 0
+        let probeExpectation = expectation(description: "sends a recovery probe")
+        let restartExpectation = expectation(description: "starts ICE restart after matching response")
         let monitor = SignalingHealthMonitor(
             signalingProbeTimeout: 1,
             recentInboundActivityThreshold: 0.01,
             isSignalingAvailable: { true },
             sendSignalingProbe: {
                 probeCount += 1
+                probeExpectation.fulfill()
                 return "expected-probe-id"
             },
-            startIceRestart: { _ in restartCount += 1 },
+            startIceRestart: { _ in
+                restartCount += 1
+                restartExpectation.fulfill()
+            },
             requestReattach: { XCTFail("Should not reattach") }
         )
 
@@ -75,13 +91,13 @@ final class SignalingHealthMonitorTests: XCTestCase {
         wait(for: [staleExpectation], timeout: 1)
         monitor.peerConnectionStateDidChange(call, state: .failed)
 
+        wait(for: [probeExpectation], timeout: 1)
         XCTAssertEqual(probeCount, 1)
-        XCTAssertEqual(restartCount, 0)
 
         monitor.signalingMessageReceived(makeResponse(id: "unrelated-id"))
-        XCTAssertEqual(restartCount, 0)
-
         monitor.signalingMessageReceived(makeResponse(id: "expected-probe-id"))
+
+        wait(for: [restartExpectation], timeout: 1)
         XCTAssertEqual(restartCount, 1)
     }
 
@@ -108,6 +124,7 @@ final class SignalingHealthMonitorTests: XCTestCase {
     func testActiveCallProbesAfterSustainedSignalingSilence() {
         let call = makeActiveCall()
         let probeExpectation = expectation(description: "active call sends signaling probe")
+        probeExpectation.assertForOverFulfill = false
         let monitor = SignalingHealthMonitor(
             signalingProbeTimeout: 1,
             staleInboundActivityThreshold: 0.01,
@@ -129,6 +146,7 @@ final class SignalingHealthMonitorTests: XCTestCase {
     func testSuccessfulActiveCallHealthProbeDoesNotRestartICE() {
         let call = makeActiveCall()
         let probeExpectation = expectation(description: "active call sends signaling probe")
+        probeExpectation.assertForOverFulfill = false
         var restartCount = 0
         var reattachCount = 0
         let monitor = SignalingHealthMonitor(
@@ -148,6 +166,9 @@ final class SignalingHealthMonitorTests: XCTestCase {
         wait(for: [probeExpectation], timeout: 1)
         monitor.signalingMessageReceived(makeResponse(id: "health-probe-id"))
 
+        let settledExpectation = expectation(description: "processes matching health probe response")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.02) { settledExpectation.fulfill() }
+        wait(for: [settledExpectation], timeout: 1)
         XCTAssertEqual(restartCount, 0)
         XCTAssertEqual(reattachCount, 0)
     }

--- a/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
+++ b/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
@@ -8,6 +8,7 @@ final class SignalingHealthMonitorTests: XCTestCase {
         var reattachCount = 0
         let monitor = SignalingHealthMonitor(
             isSignalingAvailable: { true },
+            sendSignalingProbe: { "probe-id" },
             startIceRestart: { _ in restartCount += 1 },
             requestReattach: { reattachCount += 1 }
         )
@@ -25,6 +26,7 @@ final class SignalingHealthMonitorTests: XCTestCase {
         var reattachCount = 0
         let monitor = SignalingHealthMonitor(
             isSignalingAvailable: { false },
+            sendSignalingProbe: { "probe-id" },
             startIceRestart: { _ in restartCount += 1 },
             requestReattach: { reattachCount += 1 }
         )
@@ -41,6 +43,7 @@ final class SignalingHealthMonitorTests: XCTestCase {
         let monitor = SignalingHealthMonitor(
             iceRestartTimeout: 0.01,
             isSignalingAvailable: { true },
+            sendSignalingProbe: { "probe-id" },
             startIceRestart: { _ in },
             requestReattach: { reattachExpectation.fulfill() }
         )
@@ -48,6 +51,62 @@ final class SignalingHealthMonitorTests: XCTestCase {
         monitor.peerConnectionStateDidChange(call, state: .failed)
 
         wait(for: [reattachExpectation], timeout: 1)
+    }
+
+    func testStaleSignalingDefersIceRestartUntilMatchingProbeResponse() {
+        let call = makeActiveCall()
+        var restartCount = 0
+        var probeCount = 0
+        let monitor = SignalingHealthMonitor(
+            signalingProbeTimeout: 1,
+            recentInboundActivityThreshold: 0.01,
+            isSignalingAvailable: { true },
+            sendSignalingProbe: {
+                probeCount += 1
+                return "expected-probe-id"
+            },
+            startIceRestart: { _ in restartCount += 1 },
+            requestReattach: { XCTFail("Should not reattach") }
+        )
+
+        // Let the initial freshness window expire before the failure.
+        let staleExpectation = expectation(description: "signaling becomes stale")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.02) { staleExpectation.fulfill() }
+        wait(for: [staleExpectation], timeout: 1)
+        monitor.peerConnectionStateDidChange(call, state: .failed)
+
+        XCTAssertEqual(probeCount, 1)
+        XCTAssertEqual(restartCount, 0)
+
+        monitor.signalingMessageReceived(makeResponse(id: "unrelated-id"))
+        XCTAssertEqual(restartCount, 0)
+
+        monitor.signalingMessageReceived(makeResponse(id: "expected-probe-id"))
+        XCTAssertEqual(restartCount, 1)
+    }
+
+    func testSignalingProbeTimeoutFallsBackToReattach() {
+        let call = makeActiveCall()
+        let reattachExpectation = expectation(description: "probe timeout requests reattach")
+        let monitor = SignalingHealthMonitor(
+            signalingProbeTimeout: 0.01,
+            recentInboundActivityThreshold: 0.01,
+            isSignalingAvailable: { true },
+            sendSignalingProbe: { "probe-id" },
+            startIceRestart: { _ in XCTFail("Should not restart ICE") },
+            requestReattach: { reattachExpectation.fulfill() }
+        )
+
+        let staleExpectation = expectation(description: "signaling becomes stale")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.02) { staleExpectation.fulfill() }
+        wait(for: [staleExpectation], timeout: 1)
+        monitor.iceConnectionStateDidChange(call, state: .failed)
+
+        wait(for: [reattachExpectation], timeout: 1)
+    }
+
+    private func makeResponse(id: String) -> Message {
+        Message().decode(message: "{\"jsonrpc\":\"2.0\",\"id\":\"\(id)\",\"result\":{}}")!
     }
 
     private func makeActiveCall() -> Call {

--- a/TelnyxRTCTests/WebRTC/CallTests.swift
+++ b/TelnyxRTCTests/WebRTC/CallTests.swift
@@ -38,14 +38,16 @@ class CallTests: XCTestCase {
      - NOTE: Due that we are not sending a valid sessionID we are going to get an "Authentication error" from the server.
      */
     func testNewCall() {
+        let timeout: TimeInterval = ProcessInfo.processInfo.environment["CI"] != nil ? 30.0 : 10.0
+
         //Wait for socket connection
         expectation = expectation(description: "socket")
-        waitForExpectations(timeout: 10)
+        waitForExpectations(timeout: timeout)
 
         //Wait to send invite message.
         expectation = expectation(description: "newCall")
         self.call?.newCall(callerName: "callerName", callerNumber: "callerNumber", destinationNumber: "destinationNumber")
-        waitForExpectations(timeout: 10)
+        waitForExpectations(timeout: timeout)
     }
     
     /**


### PR DESCRIPTION
## Linear Ticket

https://linear.app/telnyx/issue/VSUP-199/ios-add-signaling-health-probing-to-call-recovery

## Before

A connected signaling socket was assumed healthy. The SDK could only echo server-originated Pings and could start ICE restart while signaling was stale.

## After

- Sends a client-originated `telnyx_rtc.ping` with a unique JSON-RPC request ID.
- Requires an exact matching result/error before treating a probe as successful.
- Defers peer-failure ICE restart while signaling freshness is uncertain.
- Checks active calls every 3 seconds; probes after 20 seconds of inbound silence or 45 seconds without a confirmed outbound request.
- Falls back to existing reconnect/reattach on a 5-second probe timeout.

## Tests

- Focused `SignalingHealthMonitorTests` in the iPhone 16 simulator.
- Covers matching vs unrelated Ping responses, peer-failure probe timeout, active-call silence probe, and active-call probe timeout.

## Notes

This is intentionally stacked on VSUP-198. Path changes continue to use the existing mandatory teardown and reattach flow.