### PR TITLE
VSUP-200: Force relay for failed VPN direct paths

### DIFF
--- a/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
+++ b/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
@@ -32,7 +32,8 @@ internal final class SignalingHealthMonitor {
     private let isSignalingAvailable: () -> Bool
     private let sendSignalingProbe: () -> String?
     private let startIceRestart: (Call) -> Void
-    private let requestReattach: () -> Void
+    private let shouldForceRelayForRecovery: (Call, @escaping (Bool) -> Void) -> Void
+    private let requestReattach: (Bool) -> Void
 
     private weak var recoveringCall: Call?
     private var recoveryMode: RecoveryMode = .idle
@@ -45,6 +46,7 @@ internal final class SignalingHealthMonitor {
     private var lastInboundSignalingActivity = Date()
     private var lastConfirmedOutboundActivity = Date()
     private weak var monitoredActiveCall: Call?
+    private var shouldEvaluateRelayFallback = false
 
     init(
         iceRestartTimeout: TimeInterval = 15,
@@ -57,7 +59,8 @@ internal final class SignalingHealthMonitor {
         isSignalingAvailable: @escaping () -> Bool,
         sendSignalingProbe: @escaping () -> String?,
         startIceRestart: @escaping (Call) -> Void,
-        requestReattach: @escaping () -> Void
+        shouldForceRelayForRecovery: @escaping (Call, @escaping (Bool) -> Void) -> Void = { _, completion in completion(false) },
+        requestReattach: @escaping (Bool) -> Void
     ) {
         self.iceRestartTimeout = iceRestartTimeout
         self.signalingProbeTimeout = signalingProbeTimeout
@@ -69,6 +72,7 @@ internal final class SignalingHealthMonitor {
         self.isSignalingAvailable = isSignalingAvailable
         self.sendSignalingProbe = sendSignalingProbe
         self.startIceRestart = startIceRestart
+        self.shouldForceRelayForRecovery = shouldForceRelayForRecovery
         self.requestReattach = requestReattach
     }
 
@@ -84,6 +88,7 @@ internal final class SignalingHealthMonitor {
             Logger.log.i(message: "[CALL-RECOVERY] Network path changed; using required reconnect/reattach flow")
             self.cancelRecoveryTimeouts()
             self.recoveringCall = nil
+            self.shouldEvaluateRelayFallback = false
             self.recoveryMode = .reattaching
         }
     }
@@ -193,6 +198,7 @@ internal final class SignalingHealthMonitor {
         }
 
         recoveringCall = call
+        shouldEvaluateRelayFallback = true
         if !isSignalingAvailable() {
             Logger.log.w(message: "[CALL-RECOVERY] \(trigger) with signaling unavailable; starting reconnect/reattach")
             beginReattach()
@@ -284,6 +290,7 @@ internal final class SignalingHealthMonitor {
         guard recoveryMode == .idle,
               let call = monitoredActiveCall,
               call.callState == .ACTIVE else { return }
+        shouldEvaluateRelayFallback = false
 
         guard isSignalingAvailable() else {
             Logger.log.w(message: "[CALL-RECOVERY] Signaling socket is unavailable during an active call")
@@ -319,12 +326,27 @@ internal final class SignalingHealthMonitor {
     private func beginReattach() {
         cancelRecoveryTimeouts()
         recoveryMode = .reattaching
-        requestReattach()
+        guard shouldEvaluateRelayFallback, let call = recoveringCall else {
+            requestReattach(false)
+            return
+        }
+
+        shouldEvaluateRelayFallback = false
+        shouldForceRelayForRecovery(call) { [weak self] shouldForceRelay in
+            self?.executeOnQueue { [weak self] in
+                guard let self = self, self.recoveryMode == .reattaching else { return }
+                if shouldForceRelay {
+                    Logger.log.w(message: "[CALL-RECOVERY] Failed VPN direct path; forcing relay for replacement call")
+                }
+                self.requestReattach(shouldForceRelay)
+            }
+        }
     }
 
     private func finishRecovery() {
         cancelRecoveryTimeouts()
         recoveringCall = nil
+        shouldEvaluateRelayFallback = false
         recoveryMode = .idle
     }
 

--- a/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
+++ b/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
@@ -67,7 +67,7 @@ internal final class SignalingHealthMonitor {
         staleInboundActivityThreshold: TimeInterval = 20,
         signalingHealthCheckInterval: TimeInterval = 3,
         inboundRtpCheckInterval: TimeInterval = 1,
-        inboundRtpStallTimeout: TimeInterval = 5,
+        inboundRtpStallTimeout: TimeInterval = 3,
         postIceRestartMediaTimeout: TimeInterval = 5,
         peerDisconnectedRecoveryDelay: TimeInterval = 3,
         isSignalingAvailable: @escaping () -> Bool,

--- a/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
+++ b/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
@@ -62,7 +62,7 @@ internal final class SignalingHealthMonitor {
         confirmedOutboundActivityThreshold: TimeInterval = 45,
         staleInboundActivityThreshold: TimeInterval = 20,
         signalingHealthCheckInterval: TimeInterval = 3,
-        postIceRestartMediaTimeout: TimeInterval = 3,
+        postIceRestartMediaTimeout: TimeInterval = 5,
         peerDisconnectedRecoveryDelay: TimeInterval = 3,
         isSignalingAvailable: @escaping () -> Bool,
         sendSignalingProbe: @escaping () -> String?,
@@ -158,16 +158,11 @@ internal final class SignalingHealthMonitor {
             Logger.log.i(message: "[CALL-RECOVERY] ICE restart answer applied")
             self.cancelIceRestartTimeout()
 
-            // An SDP response only proves signaling succeeded. Media recovery is
-            // complete only after the restarted transport receives RTP again.
-            if let restartStartedAt = self.iceRestartStartedAt,
-               let lastProgressAt = self.lastInboundRtpProgressAt,
-               lastProgressAt >= restartStartedAt {
-                Logger.log.i(message: "[CALL-RECOVERY] Inbound RTP resumed during ICE restart")
-                self.finishRecovery()
-                return
-            }
-
+            // An SDP response only proves signaling succeeded. Discard the
+            // old transport's RTP baseline so recovery requires packet growth
+            // sampled after the answer is applied.
+            self.lastInboundRtpPacketCount = nil
+            self.lastInboundRtpProgressAt = nil
             self.recoveryMode = .verifyingMedia
             self.mediaVerificationStartedAt = Date()
             call.setCallReportMediaVerificationSamplingEnabled(true)

--- a/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
+++ b/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
@@ -14,6 +14,7 @@ internal final class SignalingHealthMonitor {
         case idle
         case probing
         case iceRestarting
+        case verifyingMedia
         case reattaching
     }
 
@@ -28,10 +29,14 @@ internal final class SignalingHealthMonitor {
     private let confirmedOutboundActivityThreshold: TimeInterval
     private let staleInboundActivityThreshold: TimeInterval
     private let signalingHealthCheckInterval: TimeInterval
+    private let inboundRtpCheckInterval: TimeInterval
+    private let inboundRtpStallTimeout: TimeInterval
+    private let postIceRestartMediaTimeout: TimeInterval
     private let peerDisconnectedRecoveryDelay: TimeInterval
     private let isSignalingAvailable: () -> Bool
     private let sendSignalingProbe: () -> String?
     private let startIceRestart: (Call) -> Void
+    private let readInboundRtpPackets: (Call, @escaping (Int?) -> Void) -> Void
     private let shouldForceRelayForRecovery: (Call, @escaping (Bool) -> Void) -> Void
     private let requestReattach: (Bool) -> Void
 
@@ -40,6 +45,8 @@ internal final class SignalingHealthMonitor {
     private var iceRestartTimeoutWorkItem: DispatchWorkItem?
     private var signalingProbeTimeoutWorkItem: DispatchWorkItem?
     private var signalingHealthCheckTimer: DispatchSourceTimer?
+    private var inboundRtpCheckTimer: DispatchSourceTimer?
+    private var mediaVerificationTimeoutWorkItem: DispatchWorkItem?
     private var peerDisconnectedRecoveryWorkItem: DispatchWorkItem?
     private var pendingSignalingProbeId: String?
     private var pendingSignalingProbePurpose: SignalingProbePurpose?
@@ -47,6 +54,10 @@ internal final class SignalingHealthMonitor {
     private var lastConfirmedOutboundActivity = Date()
     private weak var monitoredActiveCall: Call?
     private var shouldEvaluateRelayFallback = false
+    private var lastInboundRtpPacketCount: Int?
+    private var lastInboundRtpProgressAt: Date?
+    private var iceRestartStartedAt: Date?
+    private var mediaVerificationStartedAt: Date?
 
     init(
         iceRestartTimeout: TimeInterval = 15,
@@ -55,10 +66,14 @@ internal final class SignalingHealthMonitor {
         confirmedOutboundActivityThreshold: TimeInterval = 45,
         staleInboundActivityThreshold: TimeInterval = 20,
         signalingHealthCheckInterval: TimeInterval = 3,
+        inboundRtpCheckInterval: TimeInterval = 1,
+        inboundRtpStallTimeout: TimeInterval = 5,
+        postIceRestartMediaTimeout: TimeInterval = 5,
         peerDisconnectedRecoveryDelay: TimeInterval = 3,
         isSignalingAvailable: @escaping () -> Bool,
         sendSignalingProbe: @escaping () -> String?,
         startIceRestart: @escaping (Call) -> Void,
+        readInboundRtpPackets: @escaping (Call, @escaping (Int?) -> Void) -> Void = { _, completion in completion(nil) },
         shouldForceRelayForRecovery: @escaping (Call, @escaping (Bool) -> Void) -> Void = { _, completion in completion(false) },
         requestReattach: @escaping (Bool) -> Void
     ) {
@@ -68,10 +83,14 @@ internal final class SignalingHealthMonitor {
         self.confirmedOutboundActivityThreshold = confirmedOutboundActivityThreshold
         self.staleInboundActivityThreshold = staleInboundActivityThreshold
         self.signalingHealthCheckInterval = signalingHealthCheckInterval
+        self.inboundRtpCheckInterval = inboundRtpCheckInterval
+        self.inboundRtpStallTimeout = inboundRtpStallTimeout
+        self.postIceRestartMediaTimeout = postIceRestartMediaTimeout
         self.peerDisconnectedRecoveryDelay = peerDisconnectedRecoveryDelay
         self.isSignalingAvailable = isSignalingAvailable
         self.sendSignalingProbe = sendSignalingProbe
         self.startIceRestart = startIceRestart
+        self.readInboundRtpPackets = readInboundRtpPackets
         self.shouldForceRelayForRecovery = shouldForceRelayForRecovery
         self.requestReattach = requestReattach
     }
@@ -79,6 +98,8 @@ internal final class SignalingHealthMonitor {
     deinit {
         signalingHealthCheckTimer?.setEventHandler {}
         signalingHealthCheckTimer?.cancel()
+        inboundRtpCheckTimer?.setEventHandler {}
+        inboundRtpCheckTimer?.cancel()
         peerDisconnectedRecoveryWorkItem?.cancel()
     }
 
@@ -147,7 +168,21 @@ internal final class SignalingHealthMonitor {
         executeOnQueue { [weak self] in
             guard let self = self, self.recoveryMode == .iceRestarting, self.recoveringCall === call else { return }
             Logger.log.i(message: "[CALL-RECOVERY] ICE restart answer applied")
-            self.finishRecovery()
+            self.cancelIceRestartTimeout()
+
+            // An SDP response only proves signaling succeeded. Media recovery is
+            // complete only after the restarted transport receives RTP again.
+            if let restartStartedAt = self.iceRestartStartedAt,
+               let lastProgressAt = self.lastInboundRtpProgressAt,
+               lastProgressAt >= restartStartedAt {
+                Logger.log.i(message: "[CALL-RECOVERY] Inbound RTP resumed during ICE restart")
+                self.finishRecovery()
+                return
+            }
+
+            self.recoveryMode = .verifyingMedia
+            self.mediaVerificationStartedAt = Date()
+            self.startMediaVerificationTimeout(for: call)
         }
     }
 
@@ -171,10 +206,18 @@ internal final class SignalingHealthMonitor {
                 }
                 self.monitoredActiveCall = call
                 self.startSignalingHealthChecks()
+                self.startInboundRtpChecks()
+                self.resetInboundRtpTracking()
+            case .HELD:
+                if self.monitoredActiveCall === call {
+                    self.stopInboundRtpChecks()
+                    self.resetInboundRtpTracking()
+                }
             case .DONE, .DROPPED:
                 self.cancelPeerDisconnectedRecovery()
                 if self.monitoredActiveCall === call {
                     self.stopSignalingHealthChecks()
+                    self.stopInboundRtpChecks()
                     self.monitoredActiveCall = nil
                 }
                 if self.recoveringCall === call {
@@ -219,6 +262,7 @@ internal final class SignalingHealthMonitor {
 
     private func startIceRestartRecovery(for call: Call) {
         recoveryMode = .iceRestarting
+        iceRestartStartedAt = Date()
         startIceRestartTimeout(for: call)
         startIceRestart(call)
     }
@@ -257,9 +301,12 @@ internal final class SignalingHealthMonitor {
         timer.resume()
     }
 
-    /// `disconnected` is commonly transient while iOS changes radio or Wi-Fi
-    /// paths. Give WebRTC a short chance to return to connected before
-    /// renegotiating; terminal `failed` still recovers immediately.
+    private func stopSignalingHealthChecks() {
+        signalingHealthCheckTimer?.setEventHandler {}
+        signalingHealthCheckTimer?.cancel()
+        signalingHealthCheckTimer = nil
+    }
+
     private func startPeerDisconnectedRecoveryDelay(for call: Call) {
         guard recoveryMode == .idle else { return }
         cancelPeerDisconnectedRecovery()
@@ -280,10 +327,73 @@ internal final class SignalingHealthMonitor {
         peerDisconnectedRecoveryWorkItem = nil
     }
 
-    private func stopSignalingHealthChecks() {
-        signalingHealthCheckTimer?.setEventHandler {}
-        signalingHealthCheckTimer?.cancel()
-        signalingHealthCheckTimer = nil
+    private func startInboundRtpChecks() {
+        guard inboundRtpCheckTimer == nil else { return }
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + inboundRtpCheckInterval, repeating: inboundRtpCheckInterval)
+        timer.setEventHandler { [weak self] in
+            self?.checkInboundRtpHealth()
+        }
+        inboundRtpCheckTimer = timer
+        timer.resume()
+    }
+
+    private func stopInboundRtpChecks() {
+        inboundRtpCheckTimer?.setEventHandler {}
+        inboundRtpCheckTimer?.cancel()
+        inboundRtpCheckTimer = nil
+    }
+
+    private func resetInboundRtpTracking() {
+        lastInboundRtpPacketCount = nil
+        lastInboundRtpProgressAt = Date()
+        iceRestartStartedAt = nil
+        mediaVerificationStartedAt = nil
+    }
+
+    private func checkInboundRtpHealth() {
+        guard let call = monitoredActiveCall,
+              call.callState == .ACTIVE,
+              recoveryMode == .idle || recoveryMode == .iceRestarting || recoveryMode == .verifyingMedia else { return }
+
+        readInboundRtpPackets(call) { [weak self, weak call] packetsReceived in
+            guard let call = call else { return }
+            self?.executeOnQueue {
+                self?.recordInboundRtpPackets(packetsReceived, for: call)
+            }
+        }
+    }
+
+    private func recordInboundRtpPackets(_ packetsReceived: Int?, for call: Call) {
+        guard monitoredActiveCall === call, call.callState == .ACTIVE else { return }
+        guard let packetsReceived = packetsReceived else { return }
+
+        let now = Date()
+        let previousPacketCount = lastInboundRtpPacketCount
+        lastInboundRtpPacketCount = packetsReceived
+
+        guard let previousPacketCount = previousPacketCount else {
+            lastInboundRtpProgressAt = now
+            return
+        }
+
+        guard packetsReceived > previousPacketCount else {
+            if recoveryMode == .idle,
+               let lastProgressAt = lastInboundRtpProgressAt,
+               now.timeIntervalSince(lastProgressAt) >= inboundRtpStallTimeout {
+                Logger.log.w(message: "[CALL-RECOVERY] Inbound RTP has not advanced for \(inboundRtpStallTimeout)s; starting ICE restart")
+                requestRecovery(for: call, trigger: "inbound_rtp_stalled")
+            }
+            return
+        }
+
+        lastInboundRtpProgressAt = now
+        if recoveryMode == .verifyingMedia,
+           let verificationStartedAt = mediaVerificationStartedAt,
+           now >= verificationStartedAt {
+            Logger.log.i(message: "[CALL-RECOVERY] Inbound RTP resumed after ICE restart")
+            finishRecovery()
+        }
     }
 
     private func checkSignalingHealth() {
@@ -323,6 +433,20 @@ internal final class SignalingHealthMonitor {
         queue.asyncAfter(deadline: .now() + iceRestartTimeout, execute: workItem)
     }
 
+    private func startMediaVerificationTimeout(for call: Call) {
+        cancelMediaVerificationTimeout()
+        let workItem = DispatchWorkItem { [weak self, weak call] in
+            guard let self = self,
+                  let call = call,
+                  self.recoveryMode == .verifyingMedia,
+                  self.recoveringCall === call else { return }
+            Logger.log.e(message: "[CALL-RECOVERY] ICE restart did not restore inbound RTP after \(self.postIceRestartMediaTimeout)s; reattaching")
+            self.beginReattach()
+        }
+        mediaVerificationTimeoutWorkItem = workItem
+        queue.asyncAfter(deadline: .now() + postIceRestartMediaTimeout, execute: workItem)
+    }
+
     private func beginReattach() {
         cancelRecoveryTimeouts()
         recoveryMode = .reattaching
@@ -348,11 +472,14 @@ internal final class SignalingHealthMonitor {
         recoveringCall = nil
         shouldEvaluateRelayFallback = false
         recoveryMode = .idle
+        iceRestartStartedAt = nil
+        mediaVerificationStartedAt = nil
     }
 
     private func cancelRecoveryTimeouts() {
         cancelIceRestartTimeout()
         cancelSignalingProbeTimeout()
+        cancelMediaVerificationTimeout()
     }
 
     private func cancelIceRestartTimeout() {
@@ -365,6 +492,11 @@ internal final class SignalingHealthMonitor {
         signalingProbeTimeoutWorkItem = nil
         pendingSignalingProbeId = nil
         pendingSignalingProbePurpose = nil
+    }
+
+    private func cancelMediaVerificationTimeout() {
+        mediaVerificationTimeoutWorkItem?.cancel()
+        mediaVerificationTimeoutWorkItem = nil
     }
 
     private func executeOnQueue(_ block: @escaping () -> Void) {

--- a/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
+++ b/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
@@ -29,7 +29,8 @@ internal final class SignalingHealthMonitor {
     private let confirmedOutboundActivityThreshold: TimeInterval
     private let staleInboundActivityThreshold: TimeInterval
     private let signalingHealthCheckInterval: TimeInterval
-    private let inboundRtpCheckInterval: TimeInterval
+    private let inboundRtpSteadyStateCheckInterval: TimeInterval
+    private let inboundRtpVerificationCheckInterval: TimeInterval
     private let inboundRtpStallTimeout: TimeInterval
     private let postIceRestartMediaTimeout: TimeInterval
     private let peerDisconnectedRecoveryDelay: TimeInterval
@@ -66,7 +67,8 @@ internal final class SignalingHealthMonitor {
         confirmedOutboundActivityThreshold: TimeInterval = 45,
         staleInboundActivityThreshold: TimeInterval = 20,
         signalingHealthCheckInterval: TimeInterval = 3,
-        inboundRtpCheckInterval: TimeInterval = 1,
+        inboundRtpSteadyStateCheckInterval: TimeInterval = 3,
+        inboundRtpVerificationCheckInterval: TimeInterval = 1,
         inboundRtpStallTimeout: TimeInterval = 3,
         postIceRestartMediaTimeout: TimeInterval = 5,
         peerDisconnectedRecoveryDelay: TimeInterval = 3,
@@ -83,7 +85,8 @@ internal final class SignalingHealthMonitor {
         self.confirmedOutboundActivityThreshold = confirmedOutboundActivityThreshold
         self.staleInboundActivityThreshold = staleInboundActivityThreshold
         self.signalingHealthCheckInterval = signalingHealthCheckInterval
-        self.inboundRtpCheckInterval = inboundRtpCheckInterval
+        self.inboundRtpSteadyStateCheckInterval = inboundRtpSteadyStateCheckInterval
+        self.inboundRtpVerificationCheckInterval = inboundRtpVerificationCheckInterval
         self.inboundRtpStallTimeout = inboundRtpStallTimeout
         self.postIceRestartMediaTimeout = postIceRestartMediaTimeout
         self.peerDisconnectedRecoveryDelay = peerDisconnectedRecoveryDelay
@@ -182,6 +185,7 @@ internal final class SignalingHealthMonitor {
 
             self.recoveryMode = .verifyingMedia
             self.mediaVerificationStartedAt = Date()
+            self.startInboundRtpChecks(interval: self.inboundRtpVerificationCheckInterval)
             self.startMediaVerificationTimeout(for: call)
         }
     }
@@ -206,7 +210,7 @@ internal final class SignalingHealthMonitor {
                 }
                 self.monitoredActiveCall = call
                 self.startSignalingHealthChecks()
-                self.startInboundRtpChecks()
+                self.startInboundRtpChecks(interval: self.inboundRtpSteadyStateCheckInterval)
                 self.resetInboundRtpTracking()
             case .HELD:
                 if self.monitoredActiveCall === call {
@@ -327,10 +331,13 @@ internal final class SignalingHealthMonitor {
         peerDisconnectedRecoveryWorkItem = nil
     }
 
-    private func startInboundRtpChecks() {
-        guard inboundRtpCheckTimer == nil else { return }
+    /// Full WebRTC stats are expensive. In healthy media we sample once every
+    /// three seconds (immediate baseline plus one comparison); only the short
+    /// post-restart verification window samples once per second.
+    private func startInboundRtpChecks(interval: TimeInterval) {
+        stopInboundRtpChecks()
         let timer = DispatchSource.makeTimerSource(queue: queue)
-        timer.schedule(deadline: .now() + inboundRtpCheckInterval, repeating: inboundRtpCheckInterval)
+        timer.schedule(deadline: .now(), repeating: interval)
         timer.setEventHandler { [weak self] in
             self?.checkInboundRtpHealth()
         }
@@ -474,6 +481,9 @@ internal final class SignalingHealthMonitor {
         recoveryMode = .idle
         iceRestartStartedAt = nil
         mediaVerificationStartedAt = nil
+        if monitoredActiveCall?.callState == .ACTIVE {
+            startInboundRtpChecks(interval: inboundRtpSteadyStateCheckInterval)
+        }
     }
 
     private func cancelRecoveryTimeouts() {

--- a/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
+++ b/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
@@ -29,6 +29,7 @@ internal final class SignalingHealthMonitor {
     private let confirmedOutboundActivityThreshold: TimeInterval
     private let staleInboundActivityThreshold: TimeInterval
     private let signalingHealthCheckInterval: TimeInterval
+    private let inboundRtpStallTimeout: TimeInterval
     private let postIceRestartMediaTimeout: TimeInterval
     private let peerDisconnectedRecoveryDelay: TimeInterval
     private let isSignalingAvailable: () -> Bool
@@ -62,6 +63,7 @@ internal final class SignalingHealthMonitor {
         confirmedOutboundActivityThreshold: TimeInterval = 45,
         staleInboundActivityThreshold: TimeInterval = 20,
         signalingHealthCheckInterval: TimeInterval = 3,
+        inboundRtpStallTimeout: TimeInterval = 3,
         postIceRestartMediaTimeout: TimeInterval = 3,
         peerDisconnectedRecoveryDelay: TimeInterval = 3,
         isSignalingAvailable: @escaping () -> Bool,
@@ -76,6 +78,7 @@ internal final class SignalingHealthMonitor {
         self.confirmedOutboundActivityThreshold = confirmedOutboundActivityThreshold
         self.staleInboundActivityThreshold = staleInboundActivityThreshold
         self.signalingHealthCheckInterval = signalingHealthCheckInterval
+        self.inboundRtpStallTimeout = inboundRtpStallTimeout
         self.postIceRestartMediaTimeout = postIceRestartMediaTimeout
         self.peerDisconnectedRecoveryDelay = peerDisconnectedRecoveryDelay
         self.isSignalingAvailable = isSignalingAvailable
@@ -170,7 +173,6 @@ internal final class SignalingHealthMonitor {
 
             self.recoveryMode = .verifyingMedia
             self.mediaVerificationStartedAt = Date()
-            call.setCallReportMediaVerificationSamplingEnabled(true)
             self.startMediaVerificationTimeout(for: call)
         }
     }
@@ -202,7 +204,6 @@ internal final class SignalingHealthMonitor {
                 }
             case .DONE, .DROPPED:
                 self.cancelPeerDisconnectedRecovery()
-                call.setCallReportMediaVerificationSamplingEnabled(false)
                 if self.monitoredActiveCall === call {
                     self.stopSignalingHealthChecks()
                     self.monitoredActiveCall = nil
@@ -342,7 +343,15 @@ internal final class SignalingHealthMonitor {
             return
         }
 
-        guard packetsReceived > previousPacketCount else { return }
+        guard packetsReceived > previousPacketCount else {
+            if recoveryMode == .idle,
+               let lastProgressAt = lastInboundRtpProgressAt,
+               now.timeIntervalSince(lastProgressAt) >= inboundRtpStallTimeout {
+                Logger.log.w(message: "[CALL-RECOVERY] Inbound RTP has not advanced for \(inboundRtpStallTimeout)s; starting ICE restart")
+                requestRecovery(for: call, trigger: "inbound_rtp_stalled")
+            }
+            return
+        }
 
         lastInboundRtpProgressAt = now
         if recoveryMode == .verifyingMedia,
@@ -405,7 +414,6 @@ internal final class SignalingHealthMonitor {
     }
 
     private func beginReattach() {
-        recoveringCall?.setCallReportMediaVerificationSamplingEnabled(false)
         cancelRecoveryTimeouts()
         recoveryMode = .reattaching
         guard shouldEvaluateRelayFallback, let call = recoveringCall else {
@@ -426,7 +434,6 @@ internal final class SignalingHealthMonitor {
     }
 
     private func finishRecovery() {
-        recoveringCall?.setCallReportMediaVerificationSamplingEnabled(false)
         cancelRecoveryTimeouts()
         recoveringCall = nil
         shouldEvaluateRelayFallback = false

--- a/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
+++ b/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
@@ -29,7 +29,6 @@ internal final class SignalingHealthMonitor {
     private let confirmedOutboundActivityThreshold: TimeInterval
     private let staleInboundActivityThreshold: TimeInterval
     private let signalingHealthCheckInterval: TimeInterval
-    private let inboundRtpStallTimeout: TimeInterval
     private let postIceRestartMediaTimeout: TimeInterval
     private let peerDisconnectedRecoveryDelay: TimeInterval
     private let isSignalingAvailable: () -> Bool
@@ -63,8 +62,7 @@ internal final class SignalingHealthMonitor {
         confirmedOutboundActivityThreshold: TimeInterval = 45,
         staleInboundActivityThreshold: TimeInterval = 20,
         signalingHealthCheckInterval: TimeInterval = 3,
-        inboundRtpStallTimeout: TimeInterval = 3,
-        postIceRestartMediaTimeout: TimeInterval = 5,
+        postIceRestartMediaTimeout: TimeInterval = 3,
         peerDisconnectedRecoveryDelay: TimeInterval = 3,
         isSignalingAvailable: @escaping () -> Bool,
         sendSignalingProbe: @escaping () -> String?,
@@ -78,7 +76,6 @@ internal final class SignalingHealthMonitor {
         self.confirmedOutboundActivityThreshold = confirmedOutboundActivityThreshold
         self.staleInboundActivityThreshold = staleInboundActivityThreshold
         self.signalingHealthCheckInterval = signalingHealthCheckInterval
-        self.inboundRtpStallTimeout = inboundRtpStallTimeout
         self.postIceRestartMediaTimeout = postIceRestartMediaTimeout
         self.peerDisconnectedRecoveryDelay = peerDisconnectedRecoveryDelay
         self.isSignalingAvailable = isSignalingAvailable
@@ -173,6 +170,7 @@ internal final class SignalingHealthMonitor {
 
             self.recoveryMode = .verifyingMedia
             self.mediaVerificationStartedAt = Date()
+            call.setCallReportMediaVerificationSamplingEnabled(true)
             self.startMediaVerificationTimeout(for: call)
         }
     }
@@ -204,6 +202,7 @@ internal final class SignalingHealthMonitor {
                 }
             case .DONE, .DROPPED:
                 self.cancelPeerDisconnectedRecovery()
+                call.setCallReportMediaVerificationSamplingEnabled(false)
                 if self.monitoredActiveCall === call {
                     self.stopSignalingHealthChecks()
                     self.monitoredActiveCall = nil
@@ -343,15 +342,7 @@ internal final class SignalingHealthMonitor {
             return
         }
 
-        guard packetsReceived > previousPacketCount else {
-            if recoveryMode == .idle,
-               let lastProgressAt = lastInboundRtpProgressAt,
-               now.timeIntervalSince(lastProgressAt) >= inboundRtpStallTimeout {
-                Logger.log.w(message: "[CALL-RECOVERY] Inbound RTP has not advanced for \(inboundRtpStallTimeout)s; starting ICE restart")
-                requestRecovery(for: call, trigger: "inbound_rtp_stalled")
-            }
-            return
-        }
+        guard packetsReceived > previousPacketCount else { return }
 
         lastInboundRtpProgressAt = now
         if recoveryMode == .verifyingMedia,
@@ -414,6 +405,7 @@ internal final class SignalingHealthMonitor {
     }
 
     private func beginReattach() {
+        recoveringCall?.setCallReportMediaVerificationSamplingEnabled(false)
         cancelRecoveryTimeouts()
         recoveryMode = .reattaching
         guard shouldEvaluateRelayFallback, let call = recoveringCall else {
@@ -434,6 +426,7 @@ internal final class SignalingHealthMonitor {
     }
 
     private func finishRecovery() {
+        recoveringCall?.setCallReportMediaVerificationSamplingEnabled(false)
         cancelRecoveryTimeouts()
         recoveringCall = nil
         shouldEvaluateRelayFallback = false

--- a/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
+++ b/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
@@ -29,15 +29,12 @@ internal final class SignalingHealthMonitor {
     private let confirmedOutboundActivityThreshold: TimeInterval
     private let staleInboundActivityThreshold: TimeInterval
     private let signalingHealthCheckInterval: TimeInterval
-    private let inboundRtpSteadyStateCheckInterval: TimeInterval
-    private let inboundRtpVerificationCheckInterval: TimeInterval
     private let inboundRtpStallTimeout: TimeInterval
     private let postIceRestartMediaTimeout: TimeInterval
     private let peerDisconnectedRecoveryDelay: TimeInterval
     private let isSignalingAvailable: () -> Bool
     private let sendSignalingProbe: () -> String?
     private let startIceRestart: (Call) -> Void
-    private let readInboundRtpPackets: (Call, @escaping (Int?) -> Void) -> Void
     private let shouldForceRelayForRecovery: (Call, @escaping (Bool) -> Void) -> Void
     private let requestReattach: (Bool) -> Void
 
@@ -46,7 +43,6 @@ internal final class SignalingHealthMonitor {
     private var iceRestartTimeoutWorkItem: DispatchWorkItem?
     private var signalingProbeTimeoutWorkItem: DispatchWorkItem?
     private var signalingHealthCheckTimer: DispatchSourceTimer?
-    private var inboundRtpCheckTimer: DispatchSourceTimer?
     private var mediaVerificationTimeoutWorkItem: DispatchWorkItem?
     private var peerDisconnectedRecoveryWorkItem: DispatchWorkItem?
     private var pendingSignalingProbeId: String?
@@ -67,15 +63,12 @@ internal final class SignalingHealthMonitor {
         confirmedOutboundActivityThreshold: TimeInterval = 45,
         staleInboundActivityThreshold: TimeInterval = 20,
         signalingHealthCheckInterval: TimeInterval = 3,
-        inboundRtpSteadyStateCheckInterval: TimeInterval = 3,
-        inboundRtpVerificationCheckInterval: TimeInterval = 1,
         inboundRtpStallTimeout: TimeInterval = 3,
         postIceRestartMediaTimeout: TimeInterval = 5,
         peerDisconnectedRecoveryDelay: TimeInterval = 3,
         isSignalingAvailable: @escaping () -> Bool,
         sendSignalingProbe: @escaping () -> String?,
         startIceRestart: @escaping (Call) -> Void,
-        readInboundRtpPackets: @escaping (Call, @escaping (Int?) -> Void) -> Void = { _, completion in completion(nil) },
         shouldForceRelayForRecovery: @escaping (Call, @escaping (Bool) -> Void) -> Void = { _, completion in completion(false) },
         requestReattach: @escaping (Bool) -> Void
     ) {
@@ -85,15 +78,12 @@ internal final class SignalingHealthMonitor {
         self.confirmedOutboundActivityThreshold = confirmedOutboundActivityThreshold
         self.staleInboundActivityThreshold = staleInboundActivityThreshold
         self.signalingHealthCheckInterval = signalingHealthCheckInterval
-        self.inboundRtpSteadyStateCheckInterval = inboundRtpSteadyStateCheckInterval
-        self.inboundRtpVerificationCheckInterval = inboundRtpVerificationCheckInterval
         self.inboundRtpStallTimeout = inboundRtpStallTimeout
         self.postIceRestartMediaTimeout = postIceRestartMediaTimeout
         self.peerDisconnectedRecoveryDelay = peerDisconnectedRecoveryDelay
         self.isSignalingAvailable = isSignalingAvailable
         self.sendSignalingProbe = sendSignalingProbe
         self.startIceRestart = startIceRestart
-        self.readInboundRtpPackets = readInboundRtpPackets
         self.shouldForceRelayForRecovery = shouldForceRelayForRecovery
         self.requestReattach = requestReattach
     }
@@ -101,8 +91,6 @@ internal final class SignalingHealthMonitor {
     deinit {
         signalingHealthCheckTimer?.setEventHandler {}
         signalingHealthCheckTimer?.cancel()
-        inboundRtpCheckTimer?.setEventHandler {}
-        inboundRtpCheckTimer?.cancel()
         peerDisconnectedRecoveryWorkItem?.cancel()
     }
 
@@ -185,7 +173,6 @@ internal final class SignalingHealthMonitor {
 
             self.recoveryMode = .verifyingMedia
             self.mediaVerificationStartedAt = Date()
-            self.startInboundRtpChecks(interval: self.inboundRtpVerificationCheckInterval)
             self.startMediaVerificationTimeout(for: call)
         }
     }
@@ -210,18 +197,15 @@ internal final class SignalingHealthMonitor {
                 }
                 self.monitoredActiveCall = call
                 self.startSignalingHealthChecks()
-                self.startInboundRtpChecks(interval: self.inboundRtpSteadyStateCheckInterval)
                 self.resetInboundRtpTracking()
             case .HELD:
                 if self.monitoredActiveCall === call {
-                    self.stopInboundRtpChecks()
                     self.resetInboundRtpTracking()
                 }
             case .DONE, .DROPPED:
                 self.cancelPeerDisconnectedRecovery()
                 if self.monitoredActiveCall === call {
                     self.stopSignalingHealthChecks()
-                    self.stopInboundRtpChecks()
                     self.monitoredActiveCall = nil
                 }
                 if self.recoveringCall === call {
@@ -331,26 +315,6 @@ internal final class SignalingHealthMonitor {
         peerDisconnectedRecoveryWorkItem = nil
     }
 
-    /// Full WebRTC stats are expensive. In healthy media we sample once every
-    /// three seconds (immediate baseline plus one comparison); only the short
-    /// post-restart verification window samples once per second.
-    private func startInboundRtpChecks(interval: TimeInterval) {
-        stopInboundRtpChecks()
-        let timer = DispatchSource.makeTimerSource(queue: queue)
-        timer.schedule(deadline: .now(), repeating: interval)
-        timer.setEventHandler { [weak self] in
-            self?.checkInboundRtpHealth()
-        }
-        inboundRtpCheckTimer = timer
-        timer.resume()
-    }
-
-    private func stopInboundRtpChecks() {
-        inboundRtpCheckTimer?.setEventHandler {}
-        inboundRtpCheckTimer?.cancel()
-        inboundRtpCheckTimer = nil
-    }
-
     private func resetInboundRtpTracking() {
         lastInboundRtpPacketCount = nil
         lastInboundRtpProgressAt = Date()
@@ -358,22 +322,17 @@ internal final class SignalingHealthMonitor {
         mediaVerificationStartedAt = nil
     }
 
-    private func checkInboundRtpHealth() {
-        guard let call = monitoredActiveCall,
-              call.callState == .ACTIVE,
-              recoveryMode == .idle || recoveryMode == .iceRestarting || recoveryMode == .verifyingMedia else { return }
-
-        readInboundRtpPackets(call) { [weak self, weak call] packetsReceived in
-            guard let call = call else { return }
-            self?.executeOnQueue {
-                self?.recordInboundRtpPackets(packetsReceived, for: call)
-            }
+    /// Receives the inbound packet counter from the call-report collector's
+    /// existing WebRTC sample. This intentionally does not request a second
+    /// full stats report solely for media health.
+    func inboundRtpSampleReceived(_ packetsReceived: Int, for call: Call) {
+        executeOnQueue { [weak self] in
+            self?.recordInboundRtpPackets(packetsReceived, for: call)
         }
     }
 
-    private func recordInboundRtpPackets(_ packetsReceived: Int?, for call: Call) {
+    private func recordInboundRtpPackets(_ packetsReceived: Int, for call: Call) {
         guard monitoredActiveCall === call, call.callState == .ACTIVE else { return }
-        guard let packetsReceived = packetsReceived else { return }
 
         let now = Date()
         let previousPacketCount = lastInboundRtpPacketCount
@@ -481,9 +440,6 @@ internal final class SignalingHealthMonitor {
         recoveryMode = .idle
         iceRestartStartedAt = nil
         mediaVerificationStartedAt = nil
-        if monitoredActiveCall?.callState == .ACTIVE {
-            startInboundRtpChecks(interval: inboundRtpSteadyStateCheckInterval)
-        }
     }
 
     private func cancelRecoveryTimeouts() {

--- a/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
+++ b/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
@@ -29,7 +29,6 @@ internal final class SignalingHealthMonitor {
     private let confirmedOutboundActivityThreshold: TimeInterval
     private let staleInboundActivityThreshold: TimeInterval
     private let signalingHealthCheckInterval: TimeInterval
-    private let inboundRtpStallTimeout: TimeInterval
     private let postIceRestartMediaTimeout: TimeInterval
     private let peerDisconnectedRecoveryDelay: TimeInterval
     private let isSignalingAvailable: () -> Bool
@@ -63,7 +62,6 @@ internal final class SignalingHealthMonitor {
         confirmedOutboundActivityThreshold: TimeInterval = 45,
         staleInboundActivityThreshold: TimeInterval = 20,
         signalingHealthCheckInterval: TimeInterval = 3,
-        inboundRtpStallTimeout: TimeInterval = 3,
         postIceRestartMediaTimeout: TimeInterval = 3,
         peerDisconnectedRecoveryDelay: TimeInterval = 3,
         isSignalingAvailable: @escaping () -> Bool,
@@ -78,7 +76,6 @@ internal final class SignalingHealthMonitor {
         self.confirmedOutboundActivityThreshold = confirmedOutboundActivityThreshold
         self.staleInboundActivityThreshold = staleInboundActivityThreshold
         self.signalingHealthCheckInterval = signalingHealthCheckInterval
-        self.inboundRtpStallTimeout = inboundRtpStallTimeout
         self.postIceRestartMediaTimeout = postIceRestartMediaTimeout
         self.peerDisconnectedRecoveryDelay = peerDisconnectedRecoveryDelay
         self.isSignalingAvailable = isSignalingAvailable
@@ -173,6 +170,7 @@ internal final class SignalingHealthMonitor {
 
             self.recoveryMode = .verifyingMedia
             self.mediaVerificationStartedAt = Date()
+            call.setCallReportMediaVerificationSamplingEnabled(true)
             self.startMediaVerificationTimeout(for: call)
         }
     }
@@ -204,6 +202,7 @@ internal final class SignalingHealthMonitor {
                 }
             case .DONE, .DROPPED:
                 self.cancelPeerDisconnectedRecovery()
+                call.setCallReportMediaVerificationSamplingEnabled(false)
                 if self.monitoredActiveCall === call {
                     self.stopSignalingHealthChecks()
                     self.monitoredActiveCall = nil
@@ -343,15 +342,7 @@ internal final class SignalingHealthMonitor {
             return
         }
 
-        guard packetsReceived > previousPacketCount else {
-            if recoveryMode == .idle,
-               let lastProgressAt = lastInboundRtpProgressAt,
-               now.timeIntervalSince(lastProgressAt) >= inboundRtpStallTimeout {
-                Logger.log.w(message: "[CALL-RECOVERY] Inbound RTP has not advanced for \(inboundRtpStallTimeout)s; starting ICE restart")
-                requestRecovery(for: call, trigger: "inbound_rtp_stalled")
-            }
-            return
-        }
+        guard packetsReceived > previousPacketCount else { return }
 
         lastInboundRtpProgressAt = now
         if recoveryMode == .verifyingMedia,
@@ -414,6 +405,7 @@ internal final class SignalingHealthMonitor {
     }
 
     private func beginReattach() {
+        recoveringCall?.setCallReportMediaVerificationSamplingEnabled(false)
         cancelRecoveryTimeouts()
         recoveryMode = .reattaching
         guard shouldEvaluateRelayFallback, let call = recoveringCall else {
@@ -434,6 +426,7 @@ internal final class SignalingHealthMonitor {
     }
 
     private func finishRecovery() {
+        recoveringCall?.setCallReportMediaVerificationSamplingEnabled(false)
         cancelRecoveryTimeouts()
         recoveringCall = nil
         shouldEvaluateRelayFallback = false

--- a/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
+++ b/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
@@ -352,11 +352,13 @@ internal final class SignalingHealthMonitor {
         guard recoveryMode == .idle,
               let call = monitoredActiveCall,
               call.callState == .ACTIVE else { return }
-        shouldEvaluateRelayFallback = false
 
         guard isSignalingAvailable() else {
             Logger.log.w(message: "[CALL-RECOVERY] Signaling socket is unavailable during an active call")
             recoveringCall = call
+            // This is a proactive signaling-health recovery, not evidence of
+            // a failed direct media path.
+            shouldEvaluateRelayFallback = false
             beginReattach()
             return
         }
@@ -368,6 +370,10 @@ internal final class SignalingHealthMonitor {
 
         Logger.log.w(message: "[CALL-RECOVERY] Signaling activity is stale during an active call; probing")
         recoveringCall = call
+        // A health-check probe must not inherit relay-fallback intent from a
+        // different recovery. Failure-triggered recovery keeps its intent
+        // until beginReattach consumes it.
+        shouldEvaluateRelayFallback = false
         startSignalingProbe(for: call, purpose: .healthCheck)
     }
 

--- a/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
+++ b/TelnyxRTC/Telnyx/Services/CallRecovery/SignalingHealthMonitor.swift
@@ -356,8 +356,6 @@ internal final class SignalingHealthMonitor {
         guard isSignalingAvailable() else {
             Logger.log.w(message: "[CALL-RECOVERY] Signaling socket is unavailable during an active call")
             recoveringCall = call
-            // This is a proactive signaling-health recovery, not evidence of
-            // a failed direct media path.
             shouldEvaluateRelayFallback = false
             beginReattach()
             return
@@ -370,9 +368,6 @@ internal final class SignalingHealthMonitor {
 
         Logger.log.w(message: "[CALL-RECOVERY] Signaling activity is stale during an active call; probing")
         recoveringCall = call
-        // A health-check probe must not inherit relay-fallback intent from a
-        // different recovery. Failure-triggered recovery keeps its intent
-        // until beginReattach consumes it.
         shouldEvaluateRelayFallback = false
         startSignalingProbe(for: call, purpose: .healthCheck)
     }

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -216,9 +216,6 @@ public class TxClient {
                     }
                 }
             },
-            readInboundRtpPackets: { call, completion in
-                call.inboundAudioRtpPackets(completion: completion)
-            },
             shouldForceRelayForRecovery: { call, completion in
                 call.shouldForceRelayForRecovery(completion: completion)
             },
@@ -1643,6 +1640,10 @@ extension TxClient: CallProtocol {
 
     func callStateUpdated(call: Call) {
         Logger.log.i(message: "TxClient:: callStateUpdated()")
+        call.onInboundRtpSample = { [weak self, weak call] packetsReceived in
+            guard let self = self, let call = call else { return }
+            self.signalingHealthMonitor.inboundRtpSampleReceived(packetsReceived, for: call)
+        }
         self.signalingHealthMonitor.callStateDidChange(call)
 
         guard let callId = call.callInfo?.callId else { return }

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -1640,7 +1640,7 @@ extension TxClient: CallProtocol {
 
     func callStateUpdated(call: Call) {
         Logger.log.i(message: "TxClient:: callStateUpdated()")
-        call.onInboundRtpSample = { [weak self, weak call] packetsReceived in
+        call.onInboundRtpSample = { [weak self, weak call] _, packetsReceived in
             guard let self = self, let call = call else { return }
             self.signalingHealthMonitor.inboundRtpSampleReceived(packetsReceived, for: call)
         }

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -174,6 +174,7 @@ public class TxClient {
     private var isACMResetInProgress: Bool = false
     private var pendingAnonymousLoginMessage: AnonymousLoginMessage?
     private var forceRelayForNextRecoveredCall = false
+    private let forceRelayForNextRecoveredCallLock = NSLock()
     
     /// AI Assistant Manager for handling AI-related functionality
     public let aiAssistantManager = AIAssistantManager()
@@ -1439,10 +1440,7 @@ extension TxClient {
         }
 
         let forceRelayCandidate = (self.txConfig?.forceRelayCandidate ?? false)
-            || (isAttach && self.forceRelayForNextRecoveredCall)
-        if isAttach {
-            self.forceRelayForNextRecoveredCall = false
-        }
+            || (isAttach && takeForceRelayForNextRecoveredCall())
 
         let call = Call(callId: appFacingCallId,
                         signalingCallId: signalingCallId,
@@ -1761,7 +1759,9 @@ extension TxClient : SocketDelegate {
     }
    
     func reconnectClient(forceRelayCandidateForRecovery: Bool = false) {
+        forceRelayForNextRecoveredCallLock.lock()
         forceRelayForNextRecoveredCall = forceRelayCandidateForRecovery
+        forceRelayForNextRecoveredCallLock.unlock()
         if self.isCallsActive {
             updateActiveCallsState(callState: CallState.RECONNECTING(reason: .networkSwitch))
             startReconnectTimeout()
@@ -1784,6 +1784,17 @@ extension TxClient : SocketDelegate {
         }else {
             Logger.log.e(message:"TxClient:: Not Reconnecting")
         }
+    }
+
+    /// Consumes the one-shot relay override on the socket callback thread.
+    /// A lock keeps this handoff race-free with reconnectClient on the main
+    /// thread without moving all socket work onto the main queue.
+    private func takeForceRelayForNextRecoveredCall() -> Bool {
+        forceRelayForNextRecoveredCallLock.lock()
+        defer { forceRelayForNextRecoveredCallLock.unlock() }
+        let shouldForceRelay = forceRelayForNextRecoveredCall
+        forceRelayForNextRecoveredCall = false
+        return shouldForceRelay
     }
     
     func updateActiveCallsState(callState: CallState) {

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -216,6 +216,9 @@ public class TxClient {
                     }
                 }
             },
+            readInboundRtpPackets: { call, completion in
+                call.inboundAudioRtpPackets(completion: completion)
+            },
             shouldForceRelayForRecovery: { call, completion in
                 call.shouldForceRelayForRecovery(completion: completion)
             },

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -173,6 +173,7 @@ public class TxClient {
     private var enableQualityMetrics: Bool = false
     private var isACMResetInProgress: Bool = false
     private var pendingAnonymousLoginMessage: AnonymousLoginMessage?
+    private var forceRelayForNextRecoveredCall = false
     
     /// AI Assistant Manager for handling AI-related functionality
     public let aiAssistantManager = AIAssistantManager()
@@ -215,9 +216,12 @@ public class TxClient {
                     }
                 }
             },
-            requestReattach: { [weak self] in
+            shouldForceRelayForRecovery: { call, completion in
+                call.shouldForceRelayForRecovery(completion: completion)
+            },
+            requestReattach: { [weak self] forceRelay in
                 DispatchQueue.main.async {
-                    self?.reconnectClient()
+                    self?.reconnectClient(forceRelayCandidateForRecovery: forceRelay)
                 }
             }
         )
@@ -1434,6 +1438,12 @@ extension TxClient {
             socketToAppCallId[signalingCallId] = appFacingCallId
         }
 
+        let forceRelayCandidate = (self.txConfig?.forceRelayCandidate ?? false)
+            || (isAttach && self.forceRelayForNextRecoveredCall)
+        if isAttach {
+            self.forceRelayForNextRecoveredCall = false
+        }
+
         let call = Call(callId: appFacingCallId,
                         signalingCallId: signalingCallId,
                         remoteSdp: remoteSdp,
@@ -1447,7 +1457,7 @@ extension TxClient {
                         iceServers: self.serverConfiguration.webRTCIceServers,
                         isAttach: isAttach,
                         debug: self.txConfig?.debug ?? false,
-                        forceRelayCandidate: self.txConfig?.forceRelayCandidate ?? false,
+                        forceRelayCandidate: forceRelayCandidate,
                         sendWebRTCStatsViaSocket: self.txConfig?.sendWebRTCStatsViaSocket ?? false,
                         useTrickleIce: self.txConfig?.useTrickleIce ?? false,
                         enableMissedCallNotifications: self.txConfig?.enableMissedCallNotifications ?? false,
@@ -1746,7 +1756,8 @@ extension TxClient : SocketDelegate {
         }
     }
    
-    func reconnectClient() {
+    func reconnectClient(forceRelayCandidateForRecovery: Bool = false) {
+        forceRelayForNextRecoveredCall = forceRelayCandidateForRecovery
         if self.isCallsActive {
             updateActiveCallsState(callState: CallState.RECONNECTING(reason: .networkSwitch))
             startReconnectTimeout()

--- a/TelnyxRTC/Telnyx/WebRTC/Call.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call.swift
@@ -226,6 +226,7 @@ public class Call {
     
     var statsReporter: WebRTCStatsReporter?
     var callReportCollector: TelnyxCallReportCollector?
+    var onInboundRtpSample: ((Call, Int) -> Void)?
     
     /// Flag to track if we're currently performing ICE restart
     internal var isIceRestarting: Bool = false
@@ -1042,7 +1043,12 @@ extension Call {
             maxEntries: callReportMaxLogEntries
         )
         
-        self.callReportCollector = TelnyxCallReportCollector(config: config, logCollectorConfig: logConfig)
+        let collector = TelnyxCallReportCollector(config: config, logCollectorConfig: logConfig)
+        collector.onInboundRtpSample = { [weak self] packetsReceived in
+            guard let self = self else { return }
+            self.onInboundRtpSample?(self, packetsReceived)
+        }
+        self.callReportCollector = collector
     }
     
     /// Sets up Peer callbacks that log signaling, ICE gathering, and ICE connection

--- a/TelnyxRTC/Telnyx/WebRTC/Call.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call.swift
@@ -1050,6 +1050,10 @@ extension Call {
         }
         self.callReportCollector = collector
     }
+
+    func setCallReportMediaVerificationSamplingEnabled(_ enabled: Bool) {
+        callReportCollector?.setMediaVerificationSamplingEnabled(enabled)
+    }
     
     /// Sets up Peer callbacks that log signaling, ICE gathering, and ICE connection
     /// state changes into the call report collector. Called after peer creation.

--- a/TelnyxRTC/Telnyx/WebRTC/Call.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call.swift
@@ -755,32 +755,6 @@ public class Call {
         }
     }
 
-    /// Reads the cumulative inbound audio RTP packet counter used by the
-    /// recovery watchdog. A growing counter proves media is arriving even
-    /// when the remote speaker is silent.
-    internal func inboundAudioRtpPackets(completion: @escaping (Int?) -> Void) {
-        guard let connection = peer?.connection else {
-            completion(nil)
-            return
-        }
-
-        connection.statistics { report in
-            let inboundAudio = report.statistics.values.first { statistic in
-                guard statistic.type == "inbound-rtp" else { return false }
-                return (statistic.values["kind"] as? String) == "audio"
-                    || (statistic.values["mediaType"] as? String) == "audio"
-            }
-
-            if let packets = inboundAudio?.values["packetsReceived"] as? NSNumber {
-                completion(packets.intValue)
-            } else if let packets = inboundAudio?.values["packetsReceived"] as? Int {
-                completion(packets)
-            } else {
-                completion(nil)
-            }
-        }
-    }
-
     internal static func selectedCandidateUsesDirectVPN(_ statistics: [String: [String: Any]]) -> Bool {
         guard let transport = statistics.values.first(where: { $0["type"] as? String == "transport" }),
               let candidatePairId = transport["selectedCandidatePairId"] as? String,

--- a/TelnyxRTC/Telnyx/WebRTC/Call.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call.swift
@@ -1051,6 +1051,10 @@ extension Call {
         self.callReportCollector = collector
     }
 
+    func setCallReportMediaVerificationSamplingEnabled(_ enabled: Bool) {
+        callReportCollector?.setMediaVerificationSamplingEnabled(enabled)
+    }
+
     /// Sets up Peer callbacks that log signaling, ICE gathering, and ICE connection
     /// state changes into the call report collector. Called after peer creation.
     private func setupPeerEventLogging() {

--- a/TelnyxRTC/Telnyx/WebRTC/Call.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call.swift
@@ -754,6 +754,32 @@ public class Call {
         }
     }
 
+    /// Reads the cumulative inbound audio RTP packet counter used by the
+    /// recovery watchdog. A growing counter proves media is arriving even
+    /// when the remote speaker is silent.
+    internal func inboundAudioRtpPackets(completion: @escaping (Int?) -> Void) {
+        guard let connection = peer?.connection else {
+            completion(nil)
+            return
+        }
+
+        connection.statistics { report in
+            let inboundAudio = report.statistics.values.first { statistic in
+                guard statistic.type == "inbound-rtp" else { return false }
+                return (statistic.values["kind"] as? String) == "audio"
+                    || (statistic.values["mediaType"] as? String) == "audio"
+            }
+
+            if let packets = inboundAudio?.values["packetsReceived"] as? NSNumber {
+                completion(packets.intValue)
+            } else if let packets = inboundAudio?.values["packetsReceived"] as? Int {
+                completion(packets)
+            } else {
+                completion(nil)
+            }
+        }
+    }
+
     internal static func selectedCandidateUsesDirectVPN(_ statistics: [String: [String: Any]]) -> Bool {
         guard let transport = statistics.values.first(where: { $0["type"] as? String == "transport" }),
               let candidatePairId = transport["selectedCandidatePairId"] as? String,

--- a/TelnyxRTC/Telnyx/WebRTC/Call.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call.swift
@@ -734,6 +734,40 @@ public class Call {
         self.peer?.dispose()
     }
 
+    /// Checks whether the selected local ICE candidate is a non-relay VPN path.
+    /// This is evaluated only after a peer failure and only affects the replacement
+    /// call created by reconnect/reattach.
+    internal func shouldForceRelayForRecovery(completion: @escaping (Bool) -> Void) {
+        guard let connection = peer?.connection else {
+            completion(false)
+            return
+        }
+
+        connection.statistics { report in
+            var statistics = [String: [String: Any]]()
+            for stat in report.statistics.values {
+                var values = stat.values
+                values["type"] = stat.type as NSObject
+                statistics[stat.id] = values.mapValues { $0 as Any }
+            }
+            completion(Self.selectedCandidateUsesDirectVPN(statistics))
+        }
+    }
+
+    internal static func selectedCandidateUsesDirectVPN(_ statistics: [String: [String: Any]]) -> Bool {
+        guard let transport = statistics.values.first(where: { $0["type"] as? String == "transport" }),
+              let candidatePairId = transport["selectedCandidatePairId"] as? String,
+              let candidatePair = statistics[candidatePairId],
+              let localCandidateId = candidatePair["localCandidateId"] as? String,
+              let localCandidate = statistics[localCandidateId],
+              let networkType = localCandidate["networkType"] as? String,
+              let candidateType = localCandidate["candidateType"] as? String else {
+            return false
+        }
+
+        return networkType.lowercased() == "vpn" && candidateType.lowercased() != "relay"
+    }
+
     internal func updateCallState(callState: CallState) {
         Logger.log.i(message: "Call state updated: \(callState)")
         self.callState = callState

--- a/TelnyxRTC/Telnyx/WebRTC/Call.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call.swift
@@ -1051,10 +1051,6 @@ extension Call {
         self.callReportCollector = collector
     }
 
-    func setCallReportMediaVerificationSamplingEnabled(_ enabled: Bool) {
-        callReportCollector?.setMediaVerificationSamplingEnabled(enabled)
-    }
-    
     /// Sets up Peer callbacks that log signaling, ICE gathering, and ICE connection
     /// state changes into the call report collector. Called after peer creation.
     private func setupPeerEventLogging() {

--- a/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
@@ -47,7 +47,6 @@ public class TelnyxCallReportCollector {
     private let logCollectorConfig: LogCollectorConfig
     private weak var peerConnection: RTCPeerConnection?
     private var timer: Timer?
-    private var isMediaVerificationSamplingEnabled = false
     private var statsBuffer: [CallReportInterval] = []
     private var intervalStartTime: Date?
     private(set) var callStartTime: Date
@@ -112,12 +111,12 @@ public class TelnyxCallReportCollector {
         self.peerConnection = peerConnection
         self.intervalStartTime = Date()
         
-        Logger.log.i(message: "TelnyxCallReportCollector: Starting stats collection (interval: \(config.interval)s, logCollectorActive: \(logCollector?.isActive() ?? false))")
+        Logger.log.i(message: "TelnyxCallReportCollector: Starting stats collection (sample: \(sampleInterval)s, interval: \(config.interval)s, logCollectorActive: \(logCollector?.isActive() ?? false))")
 
         logCollector?.addEntry(
             level: "info",
             message: "CallReportCollector: Starting stats and log collection",
-            context: ["interval": config.interval, "logLevel": logCollectorConfig.level]
+            context: ["sampleInterval": sampleInterval, "interval": config.interval, "logLevel": logCollectorConfig.level]
         )
 
         // Schedule on main RunLoop — start() may be called from a WebRTC background thread
@@ -128,18 +127,6 @@ public class TelnyxCallReportCollector {
         }
     }
 
-    /// Temporarily increases the existing collector cadence while an ICE
-    /// restart is verifying media. Normal reporting remains at the configured
-    /// interval; this does not introduce a second stats query.
-    internal func setMediaVerificationSamplingEnabled(_ enabled: Bool) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self,
-                  self.isMediaVerificationSamplingEnabled != enabled else { return }
-            self.isMediaVerificationSamplingEnabled = enabled
-            self.scheduleStatsTimer()
-        }
-    }
-    
     /// Stop collecting stats and prepare for final report
     public func stop() {
         // Timer was scheduled on main RunLoop, must invalidate there
@@ -445,12 +432,16 @@ public class TelnyxCallReportCollector {
 
     private func scheduleStatsTimer() {
         timer?.invalidate()
-        let interval = isMediaVerificationSamplingEnabled
-            ? min(config.interval, 1.0)
-            : config.interval
-        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+        timer = Timer.scheduledTimer(withTimeInterval: sampleInterval, repeats: true) { [weak self] _ in
             self?.collectStats()
         }
+    }
+
+    /// WebRTC counters are sampled at most once per second so health logic can
+    /// detect three seconds without inbound media. Report rows and interval
+    /// logs are still emitted only when `config.interval` elapses.
+    private var sampleInterval: TimeInterval {
+        min(config.interval, 1.0)
     }
 
     private func parseStatsReport(_ report: RTCStatisticsReport) -> ParsedStats {

--- a/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
@@ -47,6 +47,7 @@ public class TelnyxCallReportCollector {
     private let logCollectorConfig: LogCollectorConfig
     private weak var peerConnection: RTCPeerConnection?
     private var timer: Timer?
+    private var isMediaVerificationSamplingEnabled = false
     private var statsBuffer: [CallReportInterval] = []
     private var intervalStartTime: Date?
     private(set) var callStartTime: Date
@@ -123,12 +124,19 @@ public class TelnyxCallReportCollector {
         // where RunLoop.current is not running, which would prevent the timer from firing.
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
-            // One shared sample per second preserves the three-second media
-            // stall decision while report intervals remain configurable.
-            let sampleInterval = min(self.config.interval, 1.0)
-            self.timer = Timer.scheduledTimer(withTimeInterval: sampleInterval, repeats: true) { [weak self] _ in
-                self?.collectStats()
-            }
+            self.scheduleStatsTimer()
+        }
+    }
+
+    /// Temporarily increases the existing collector cadence while an ICE
+    /// restart is verifying media. Normal reporting remains at the configured
+    /// interval; this does not introduce a second stats query.
+    internal func setMediaVerificationSamplingEnabled(_ enabled: Bool) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self,
+                  self.isMediaVerificationSamplingEnabled != enabled else { return }
+            self.isMediaVerificationSamplingEnabled = enabled
+            self.scheduleStatsTimer()
         }
     }
     
@@ -432,6 +440,16 @@ public class TelnyxCallReportCollector {
             if intervalDuration >= self.config.interval {
                 self.finalizeInterval(start: intervalStartTime, end: now, parsed: parsed)
             }
+        }
+    }
+
+    private func scheduleStatsTimer() {
+        timer?.invalidate()
+        let interval = isMediaVerificationSamplingEnabled
+            ? min(config.interval, 1.0)
+            : config.interval
+        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+            self?.collectStats()
         }
     }
 

--- a/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
@@ -47,6 +47,7 @@ public class TelnyxCallReportCollector {
     private let logCollectorConfig: LogCollectorConfig
     private weak var peerConnection: RTCPeerConnection?
     private var timer: Timer?
+    private var isMediaVerificationSamplingEnabled = false
     private var statsBuffer: [CallReportInterval] = []
     private var intervalStartTime: Date?
     private(set) var callStartTime: Date
@@ -111,18 +112,30 @@ public class TelnyxCallReportCollector {
         self.peerConnection = peerConnection
         self.intervalStartTime = Date()
         
-        Logger.log.i(message: "TelnyxCallReportCollector: Starting stats collection (sample: \(sampleInterval)s, interval: \(config.interval)s, logCollectorActive: \(logCollector?.isActive() ?? false))")
+        Logger.log.i(message: "TelnyxCallReportCollector: Starting stats collection (interval: \(config.interval)s, logCollectorActive: \(logCollector?.isActive() ?? false))")
 
         logCollector?.addEntry(
             level: "info",
             message: "CallReportCollector: Starting stats and log collection",
-            context: ["sampleInterval": sampleInterval, "interval": config.interval, "logLevel": logCollectorConfig.level]
+            context: ["interval": config.interval, "logLevel": logCollectorConfig.level]
         )
 
         // Schedule on main RunLoop — start() may be called from a WebRTC background thread
         // where RunLoop.current is not running, which would prevent the timer from firing.
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
+            self.scheduleStatsTimer()
+        }
+    }
+
+    /// Temporarily increases the existing collector cadence while an ICE
+    /// restart is verifying media. Normal reporting remains at the configured
+    /// interval; this does not introduce a second stats query.
+    internal func setMediaVerificationSamplingEnabled(_ enabled: Bool) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self,
+                  self.isMediaVerificationSamplingEnabled != enabled else { return }
+            self.isMediaVerificationSamplingEnabled = enabled
             self.scheduleStatsTimer()
         }
     }
@@ -432,16 +445,12 @@ public class TelnyxCallReportCollector {
 
     private func scheduleStatsTimer() {
         timer?.invalidate()
-        timer = Timer.scheduledTimer(withTimeInterval: sampleInterval, repeats: true) { [weak self] _ in
+        let interval = isMediaVerificationSamplingEnabled
+            ? min(config.interval, 1.0)
+            : config.interval
+        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
             self?.collectStats()
         }
-    }
-
-    /// WebRTC counters are sampled at most once per second so health logic can
-    /// detect three seconds without inbound media. Report rows and interval
-    /// logs are still emitted only when `config.interval` elapses.
-    private var sampleInterval: TimeInterval {
-        min(config.interval, 1.0)
     }
 
     private func parseStatsReport(_ report: RTCStatisticsReport) -> ParsedStats {

--- a/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
@@ -58,6 +58,10 @@ public class TelnyxCallReportCollector {
     private var intervalJitters: [Double] = []
     private var intervalRTTs: [Double] = []
     private var intervalBitrates: (outbound: [Double], inbound: [Double]) = ([], [])
+
+    /// Delivers the audio inbound packet counter from the collector's normal
+    /// WebRTC sample, allowing call recovery to avoid a duplicate stats query.
+    internal var onInboundRtpSample: ((Int) -> Void)?
     
     // Previous values for rate calculations
     private var previousStats = PreviousStats()
@@ -119,7 +123,10 @@ public class TelnyxCallReportCollector {
         // where RunLoop.current is not running, which would prevent the timer from firing.
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
-            self.timer = Timer.scheduledTimer(withTimeInterval: self.config.interval, repeats: true) { [weak self] _ in
+            // One shared sample per second preserves the three-second media
+            // stall decision while report intervals remain configurable.
+            let sampleInterval = min(self.config.interval, 1.0)
+            self.timer = Timer.scheduledTimer(withTimeInterval: sampleInterval, repeats: true) { [weak self] _ in
                 self?.collectStats()
             }
         }
@@ -415,6 +422,9 @@ public class TelnyxCallReportCollector {
 
             let now = Date()
             let parsed = self.parseStatsReport(report)
+            if let packetsReceived = parsed.inbound?.packetsReceived {
+                self.onInboundRtpSample?(packetsReceived)
+            }
             self.accumulateSamples(parsed: parsed, statistics: report.statistics, now: now)
 
             // Check if interval is complete (end of collection period)

--- a/TelnyxRTC/Telnyx/WebRTC/Stats/WebRTCStatsReporter.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Stats/WebRTCStatsReporter.swift
@@ -12,7 +12,8 @@ import Foundation
 /// - Network statistics
 ///
 /// The reporter is enabled when the `debug` flag is set to true in the Call configuration.
-/// Statistics are collected every 2 seconds and sent to Telnyx's servers for analysis.
+/// Statistics are sampled once per second for quality callbacks. When debug socket
+/// reporting is explicitly enabled, a condensed report is sent every two seconds.
 ///
 /// ## Usage
 /// ```swift
@@ -59,6 +60,10 @@ class WebRTCStatsReporter {
     
     /// Interval for sending stats to socket (in seconds)
     private var socketSendInterval: TimeInterval = 2.0
+
+    /// Sampling cadence for local quality metrics. Raw samples are intentionally
+    /// not logged: `RTCStatisticsReport` is large and would overwhelm call logs.
+    private let statsSampleInterval: TimeInterval = 1.0
     
     /// Timestamp of last socket send
     private var lastSocketSendTime: TimeInterval = 0
@@ -91,7 +96,7 @@ class WebRTCStatsReporter {
         self.setupEventHandler()
         let queue = DispatchQueue.main
         timer = DispatchSource.makeTimerSource(queue: queue)
-        timer?.schedule(deadline: .now(), repeating: 0.2) // Even more frequent updates for ultra-responsive waveform
+        timer?.schedule(deadline: .now(), repeating: statsSampleInterval)
         timer?.setEventHandler { [weak self] in
             self?.executeTask()
         }
@@ -107,7 +112,6 @@ class WebRTCStatsReporter {
     // MARK: - Private Helper Methods
     private func sendDebugReportStartMessage(id: UUID) {
         if self.call?.debug == false || self.call?.sendWebRTCStatsViaSocket == false {
-            Logger.log.i(message: "WebRTCStatsReporter:: Skipping sending stats message - debug not enabled or socket sending disabled")
             return
         }
         let statsMessage = DebugReportStartMessage(reportID: id.uuidString.lowercased())
@@ -121,7 +125,6 @@ class WebRTCStatsReporter {
     
     private func sendDebugReportStopMessage(id: UUID) {
         if self.call?.debug == false || self.call?.sendWebRTCStatsViaSocket == false {
-            Logger.log.i(message: "WebRTCStatsReporter:: Skipping sending stats message - debug not enabled or socket sending disabled")
             return
         }
         let statsMessage = DebugReportStopMessage(reportID: id.uuidString.lowercased())
@@ -135,12 +138,10 @@ class WebRTCStatsReporter {
     
     private func sendDebugReportDataMessage(id: UUID, data: [String: Any]) {
         if self.call?.debug == false || self.call?.sendWebRTCStatsViaSocket == false {
-            Logger.log.i(message: "WebRTCStatsReporter:: Skipping sending stats message - debug not enabled or socket sending disabled")
             return
         }
         // Skip sending messages if reporting is paused due to socket disconnection or call state
         if isReportingPaused {
-            Logger.log.i(message: "WebRTCStatsReporter:: Skipping stats message while socket is disconnected or call is recovering")
             return
         }
         
@@ -371,11 +372,12 @@ class WebRTCStatsReporter {
             updateReportingState(shouldPause: false)
         }
         
-        // Always collect stats for real-time metrics (every 0.2s)
+        // Sample local quality metrics once per second. Keep the raw report
+        // internal; it is large and is not useful as a per-sample log entry.
         let currentTime = Date().timeIntervalSince1970
-        let shouldSendToSocket = (currentTime - lastSocketSendTime) >= socketSendInterval
-        
-        Logger.log.i(message: "WebRTCStatsReporter:: Task executed at \(Date()) - SendToSocket: \(shouldSendToSocket)")
+        let isSocketReportingEnabled = call.debug && call.sendWebRTCStatsViaSocket
+        let shouldSendToSocket = isSocketReportingEnabled
+            && (currentTime - lastSocketSendTime) >= socketSendInterval
         peer.connection?.statistics(completionHandler: { [weak self] reports in
             guard let self = self else { return }
             var statsEvent = [String: Any]()
@@ -387,8 +389,6 @@ class WebRTCStatsReporter {
             var connectionCandidates = [Any]()
             var statsData = [String: Any]()
             var statsObject = [String: Any]()
-            Logger.log.i(message: "WebRTCStatsReporter:: Task executed at \(reports.statistics)")
-
             reports.statistics.forEach { report in
                 var values = report.value.values
                 values["type"] = report.value.type as NSObject
@@ -426,7 +426,6 @@ class WebRTCStatsReporter {
                     }
 
                 case "candidate-pair":
-                    Logger.log.i(message: "Default_Values : \(values)")
                     connectionCandidates.append(values)
                     statsObject[report.key] = values
 
@@ -512,7 +511,7 @@ class WebRTCStatsReporter {
                 // Calculate real-time metrics
                 let metrics = self.toRealTimeMetrics(inboundboundAudio: typedAudioInboundStats, audio: remoteData)
                 
-                // Always emit metrics for real-time visualization (every 0.2s)
+                // Emit local quality metrics at the one-second sample cadence.
                 self.onStatsFrame?(metrics)
             }
             
@@ -524,8 +523,6 @@ class WebRTCStatsReporter {
                 self.lastSocketSendTime = currentTime
                 self.sendDebugReportDataMessage(id: self.reportId, data: statsEvent)
                 Logger.log.i(message: "WebRTCStatsReporter:: Stats sent to socket at \(Date())")
-            } else {
-                Logger.log.i(message: "WebRTCStatsReporter:: Stats collected but not sent to socket (waiting for interval)")
             }
         })
     }
@@ -534,11 +531,9 @@ class WebRTCStatsReporter {
     private func enqueueMessage(_ message: String) {
         messageQueue.async { [weak self] in
             guard let self = self, !self.isReportingPaused else {
-                Logger.log.i(message: "WebRTCStatsReporter:: Message sending skipped due to paused state")
                 return
             }
             guard self.call?.sendWebRTCStatsViaSocket == true else {
-                Logger.log.i(message: "WebRTCStatsReporter:: Message sending skipped - socket sending disabled")
                 return
             }
             self.socket?.sendMessage(message: message)

--- a/TelnyxRTC/Telnyx/WebRTC/Stats/WebRTCStatsReporter.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Stats/WebRTCStatsReporter.swift
@@ -12,8 +12,7 @@ import Foundation
 /// - Network statistics
 ///
 /// The reporter is enabled when the `debug` flag is set to true in the Call configuration.
-/// Statistics are sampled once per second for quality callbacks. When debug socket
-/// reporting is explicitly enabled, a condensed report is sent every two seconds.
+/// Statistics are collected every 2 seconds and sent to Telnyx's servers for analysis.
 ///
 /// ## Usage
 /// ```swift
@@ -61,10 +60,6 @@ class WebRTCStatsReporter {
     /// Interval for sending stats to socket (in seconds)
     private var socketSendInterval: TimeInterval = 2.0
 
-    /// Sampling cadence for local quality metrics. Raw samples are intentionally
-    /// not logged: `RTCStatisticsReport` is large and would overwhelm call logs.
-    private let statsSampleInterval: TimeInterval = 1.0
-    
     /// Timestamp of last socket send
     private var lastSocketSendTime: TimeInterval = 0
     
@@ -76,7 +71,7 @@ class WebRTCStatsReporter {
     
     public func startDebugReport(peerId: UUID,
                                  call: Call) {
-        
+
         self.peerId = peerId
         self.peer = call.peer
         self.call  = call
@@ -96,7 +91,7 @@ class WebRTCStatsReporter {
         self.setupEventHandler()
         let queue = DispatchQueue.main
         timer = DispatchSource.makeTimerSource(queue: queue)
-        timer?.schedule(deadline: .now(), repeating: statsSampleInterval)
+        timer?.schedule(deadline: .now(), repeating: 0.2) // Even more frequent updates for ultra-responsive waveform
         timer?.setEventHandler { [weak self] in
             self?.executeTask()
         }
@@ -112,6 +107,7 @@ class WebRTCStatsReporter {
     // MARK: - Private Helper Methods
     private func sendDebugReportStartMessage(id: UUID) {
         if self.call?.debug == false || self.call?.sendWebRTCStatsViaSocket == false {
+            Logger.log.i(message: "WebRTCStatsReporter:: Skipping sending stats message - debug not enabled or socket sending disabled")
             return
         }
         let statsMessage = DebugReportStartMessage(reportID: id.uuidString.lowercased())
@@ -125,6 +121,7 @@ class WebRTCStatsReporter {
     
     private func sendDebugReportStopMessage(id: UUID) {
         if self.call?.debug == false || self.call?.sendWebRTCStatsViaSocket == false {
+            Logger.log.i(message: "WebRTCStatsReporter:: Skipping sending stats message - debug not enabled or socket sending disabled")
             return
         }
         let statsMessage = DebugReportStopMessage(reportID: id.uuidString.lowercased())
@@ -138,10 +135,12 @@ class WebRTCStatsReporter {
     
     private func sendDebugReportDataMessage(id: UUID, data: [String: Any]) {
         if self.call?.debug == false || self.call?.sendWebRTCStatsViaSocket == false {
+            Logger.log.i(message: "WebRTCStatsReporter:: Skipping sending stats message - debug not enabled or socket sending disabled")
             return
         }
         // Skip sending messages if reporting is paused due to socket disconnection or call state
         if isReportingPaused {
+            Logger.log.i(message: "WebRTCStatsReporter:: Skipping stats message while socket is disconnected or call is recovering")
             return
         }
         
@@ -372,12 +371,11 @@ class WebRTCStatsReporter {
             updateReportingState(shouldPause: false)
         }
         
-        // Sample local quality metrics once per second. Keep the raw report
-        // internal; it is large and is not useful as a per-sample log entry.
+        // Always collect stats for real-time metrics (every 0.2s)
         let currentTime = Date().timeIntervalSince1970
-        let isSocketReportingEnabled = call.debug && call.sendWebRTCStatsViaSocket
-        let shouldSendToSocket = isSocketReportingEnabled
-            && (currentTime - lastSocketSendTime) >= socketSendInterval
+        let shouldSendToSocket = (currentTime - lastSocketSendTime) >= socketSendInterval
+
+        Logger.log.i(message: "WebRTCStatsReporter:: Task executed at \(Date()) - SendToSocket: \(shouldSendToSocket)")
         peer.connection?.statistics(completionHandler: { [weak self] reports in
             guard let self = self else { return }
             var statsEvent = [String: Any]()
@@ -389,6 +387,8 @@ class WebRTCStatsReporter {
             var connectionCandidates = [Any]()
             var statsData = [String: Any]()
             var statsObject = [String: Any]()
+            Logger.log.i(message: "WebRTCStatsReporter:: Task executed at \(reports.statistics)")
+
             reports.statistics.forEach { report in
                 var values = report.value.values
                 values["type"] = report.value.type as NSObject
@@ -426,6 +426,7 @@ class WebRTCStatsReporter {
                     }
 
                 case "candidate-pair":
+                    Logger.log.i(message: "Default_Values : \(values)")
                     connectionCandidates.append(values)
                     statsObject[report.key] = values
 
@@ -511,7 +512,7 @@ class WebRTCStatsReporter {
                 // Calculate real-time metrics
                 let metrics = self.toRealTimeMetrics(inboundboundAudio: typedAudioInboundStats, audio: remoteData)
                 
-                // Emit local quality metrics at the one-second sample cadence.
+                // Always emit metrics for real-time visualization (every 0.2s)
                 self.onStatsFrame?(metrics)
             }
             
@@ -523,6 +524,8 @@ class WebRTCStatsReporter {
                 self.lastSocketSendTime = currentTime
                 self.sendDebugReportDataMessage(id: self.reportId, data: statsEvent)
                 Logger.log.i(message: "WebRTCStatsReporter:: Stats sent to socket at \(Date())")
+            } else {
+                Logger.log.i(message: "WebRTCStatsReporter:: Stats collected but not sent to socket (waiting for interval)")
             }
         })
     }
@@ -531,9 +534,11 @@ class WebRTCStatsReporter {
     private func enqueueMessage(_ message: String) {
         messageQueue.async { [weak self] in
             guard let self = self, !self.isReportingPaused else {
+                Logger.log.i(message: "WebRTCStatsReporter:: Message sending skipped due to paused state")
                 return
             }
             guard self.call?.sendWebRTCStatsViaSocket == true else {
+                Logger.log.i(message: "WebRTCStatsReporter:: Message sending skipped - socket sending disabled")
                 return
             }
             self.socket?.sendMessage(message: message)

--- a/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
+++ b/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
@@ -14,7 +14,7 @@ final class SignalingHealthMonitorTests: XCTestCase {
                 restartCount += 1
                 restartExpectation.fulfill()
             },
-            requestReattach: { reattachCount += 1 }
+            requestReattach: { _ in reattachCount += 1 }
         )
 
         monitor.iceConnectionStateDidChange(call, state: .failed)
@@ -68,7 +68,7 @@ final class SignalingHealthMonitorTests: XCTestCase {
             isSignalingAvailable: { false },
             sendSignalingProbe: { "probe-id" },
             startIceRestart: { _ in restartCount += 1 },
-            requestReattach: {
+            requestReattach: { _ in
                 reattachCount += 1
                 reattachExpectation.fulfill()
             }
@@ -81,6 +81,27 @@ final class SignalingHealthMonitorTests: XCTestCase {
         XCTAssertEqual(reattachCount, 1)
     }
 
+    func testPeerFailureForProvenVPNDirectPathForcesRelayOnReattach() {
+        let call = makeActiveCall()
+        var reattachForceRelay: Bool?
+        let reattachExpectation = expectation(description: "reattaches with forced relay")
+        let monitor = SignalingHealthMonitor(
+            isSignalingAvailable: { false },
+            sendSignalingProbe: { "probe-id" },
+            startIceRestart: { _ in XCTFail("Should not restart ICE") },
+            shouldForceRelayForRecovery: { _, completion in completion(true) },
+            requestReattach: { forceRelay in
+                reattachForceRelay = forceRelay
+                reattachExpectation.fulfill()
+            }
+        )
+
+        monitor.peerConnectionStateDidChange(call, state: .failed)
+
+        wait(for: [reattachExpectation], timeout: 1)
+        XCTAssertEqual(reattachForceRelay, true)
+    }
+
     func testIceRestartTimeoutFallsBackToReattach() {
         let call = makeActiveCall()
         let reattachExpectation = expectation(description: "ICE restart timeout requests reattach")
@@ -89,7 +110,7 @@ final class SignalingHealthMonitorTests: XCTestCase {
             isSignalingAvailable: { true },
             sendSignalingProbe: { "probe-id" },
             startIceRestart: { _ in },
-            requestReattach: { reattachExpectation.fulfill() }
+            requestReattach: { _ in reattachExpectation.fulfill() }
         )
 
         monitor.peerConnectionStateDidChange(call, state: .failed)
@@ -116,7 +137,7 @@ final class SignalingHealthMonitorTests: XCTestCase {
                 restartCount += 1
                 restartExpectation.fulfill()
             },
-            requestReattach: { XCTFail("Should not reattach") }
+            requestReattach: { _ in XCTFail("Should not reattach") }
         )
 
         // Let the initial freshness window expire before the failure.
@@ -144,7 +165,7 @@ final class SignalingHealthMonitorTests: XCTestCase {
             isSignalingAvailable: { true },
             sendSignalingProbe: { "probe-id" },
             startIceRestart: { _ in XCTFail("Should not restart ICE") },
-            requestReattach: { reattachExpectation.fulfill() }
+            requestReattach: { _ in reattachExpectation.fulfill() }
         )
 
         let staleExpectation = expectation(description: "signaling becomes stale")
@@ -169,7 +190,7 @@ final class SignalingHealthMonitorTests: XCTestCase {
                 return "probe-id"
             },
             startIceRestart: { _ in XCTFail("Should not restart ICE") },
-            requestReattach: { XCTFail("Should not reattach before probe timeout") }
+            requestReattach: { _ in XCTFail("Should not reattach before probe timeout") }
         )
 
         monitor.callStateDidChange(call)
@@ -193,7 +214,7 @@ final class SignalingHealthMonitorTests: XCTestCase {
                 return "health-probe-id"
             },
             startIceRestart: { _ in restartCount += 1 },
-            requestReattach: { reattachCount += 1 }
+            requestReattach: { _ in reattachCount += 1 }
         )
 
         monitor.callStateDidChange(call)
@@ -217,7 +238,7 @@ final class SignalingHealthMonitorTests: XCTestCase {
             isSignalingAvailable: { true },
             sendSignalingProbe: { "probe-id" },
             startIceRestart: { _ in XCTFail("Should not restart ICE") },
-            requestReattach: { reattachExpectation.fulfill() }
+            requestReattach: { _ in reattachExpectation.fulfill() }
         )
 
         monitor.callStateDidChange(call)

--- a/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
+++ b/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
@@ -250,17 +250,18 @@ final class SignalingHealthMonitorTests: XCTestCase {
         let call = makeActiveCall()
         let restartExpectation = expectation(description: "inbound RTP stall starts ICE restart")
         let monitor = SignalingHealthMonitor(
-            inboundRtpSteadyStateCheckInterval: 0.01,
-            inboundRtpVerificationCheckInterval: 0.01,
             inboundRtpStallTimeout: 0.02,
             isSignalingAvailable: { true },
             sendSignalingProbe: { "probe-id" },
             startIceRestart: { _ in restartExpectation.fulfill() },
-            readInboundRtpPackets: { _, completion in completion(100) },
             requestReattach: { _ in XCTFail("Should restart ICE before reattaching") }
         )
 
         monitor.callStateDidChange(call)
+        monitor.inboundRtpSampleReceived(100, for: call)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.03) {
+            monitor.inboundRtpSampleReceived(100, for: call)
+        }
 
         wait(for: [restartExpectation], timeout: 1)
     }
@@ -270,13 +271,10 @@ final class SignalingHealthMonitorTests: XCTestCase {
         let restartExpectation = expectation(description: "starts ICE restart")
         let reattachExpectation = expectation(description: "reattaches after media verification timeout")
         let monitor = SignalingHealthMonitor(
-            inboundRtpSteadyStateCheckInterval: 0.01,
-            inboundRtpVerificationCheckInterval: 0.01,
             postIceRestartMediaTimeout: 0.02,
             isSignalingAvailable: { true },
             sendSignalingProbe: { "probe-id" },
             startIceRestart: { _ in restartExpectation.fulfill() },
-            readInboundRtpPackets: { _, completion in completion(100) },
             requestReattach: { _ in reattachExpectation.fulfill() }
         )
 
@@ -290,43 +288,22 @@ final class SignalingHealthMonitorTests: XCTestCase {
 
     func testInboundRtpGrowthAfterRestartAnswerCompletesRecovery() {
         let call = makeActiveCall()
-        let initialSampleExpectation = expectation(description: "captures inbound RTP baseline")
         let restartExpectation = expectation(description: "starts ICE restart")
-        let resumedExpectation = expectation(description: "watchdog observes inbound RTP growth")
-        var packetsReceived = 100
-        var shouldExpectGrowth = false
-        var didCaptureInitialSample = false
         var reattachCount = 0
         let monitor = SignalingHealthMonitor(
-            inboundRtpSteadyStateCheckInterval: 0.01,
-            inboundRtpVerificationCheckInterval: 0.01,
             postIceRestartMediaTimeout: 0.1,
             isSignalingAvailable: { true },
             sendSignalingProbe: { "probe-id" },
             startIceRestart: { _ in restartExpectation.fulfill() },
-            readInboundRtpPackets: { _, completion in
-                if !didCaptureInitialSample {
-                    didCaptureInitialSample = true
-                    initialSampleExpectation.fulfill()
-                }
-                if shouldExpectGrowth && packetsReceived == 101 {
-                    resumedExpectation.fulfill()
-                    shouldExpectGrowth = false
-                }
-                completion(packetsReceived)
-            },
             requestReattach: { _ in reattachCount += 1 }
         )
 
         monitor.callStateDidChange(call)
-        wait(for: [initialSampleExpectation], timeout: 1)
+        monitor.inboundRtpSampleReceived(100, for: call)
         monitor.peerConnectionStateDidChange(call, state: .failed)
         wait(for: [restartExpectation], timeout: 1)
         monitor.iceRestartDidComplete(for: call)
-        packetsReceived = 101
-        shouldExpectGrowth = true
-
-        wait(for: [resumedExpectation], timeout: 1)
+        monitor.inboundRtpSampleReceived(101, for: call)
         let settledExpectation = expectation(description: "media verification window expires")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) { settledExpectation.fulfill() }
         wait(for: [settledExpectation], timeout: 1)

--- a/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
+++ b/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
@@ -246,15 +246,15 @@ final class SignalingHealthMonitorTests: XCTestCase {
         wait(for: [reattachExpectation], timeout: 1)
     }
 
-    func testInboundRtpStallStartsIceRestartAfterThreeSecondThreshold() {
+    func testSteadyStateInboundRtpSamplesDoNotTriggerStatsDrivenRecovery() {
         let call = makeActiveCall()
-        let restartExpectation = expectation(description: "inbound RTP stall starts ICE restart")
+        let noRestartExpectation = expectation(description: "allows steady-state sampling")
+        noRestartExpectation.isInverted = true
         let monitor = SignalingHealthMonitor(
-            inboundRtpStallTimeout: 0.02,
             isSignalingAvailable: { true },
             sendSignalingProbe: { "probe-id" },
-            startIceRestart: { _ in restartExpectation.fulfill() },
-            requestReattach: { _ in XCTFail("Should restart ICE before reattaching") }
+            startIceRestart: { _ in noRestartExpectation.fulfill() },
+            requestReattach: { _ in XCTFail("Should not reattach") }
         )
 
         monitor.callStateDidChange(call)
@@ -263,7 +263,7 @@ final class SignalingHealthMonitorTests: XCTestCase {
             monitor.inboundRtpSampleReceived(100, for: call)
         }
 
-        wait(for: [restartExpectation], timeout: 1)
+        wait(for: [noRestartExpectation], timeout: 0.1)
     }
 
     func testRestartAnswerWithoutInboundRtpFallsBackToReattach() {

--- a/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
+++ b/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
@@ -246,7 +246,7 @@ final class SignalingHealthMonitorTests: XCTestCase {
         wait(for: [reattachExpectation], timeout: 1)
     }
 
-    func testInboundRtpStallStartsIceRestartAfterFiveSecondThreshold() {
+    func testInboundRtpStallStartsIceRestartAfterThreeSecondThreshold() {
         let call = makeActiveCall()
         let restartExpectation = expectation(description: "inbound RTP stall starts ICE restart")
         let monitor = SignalingHealthMonitor(

--- a/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
+++ b/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
@@ -246,24 +246,26 @@ final class SignalingHealthMonitorTests: XCTestCase {
         wait(for: [reattachExpectation], timeout: 1)
     }
 
-    func testInboundRtpStallStartsIceRestartAfterThreeSecondThreshold() {
+    func testInboundRtpStallDoesNotRestartDuringHealthySteadyStateSampling() {
         let call = makeActiveCall()
-        let restartExpectation = expectation(description: "inbound RTP stall starts ICE restart")
+        var restartCount = 0
         let monitor = SignalingHealthMonitor(
-            inboundRtpStallTimeout: 0.02,
             isSignalingAvailable: { true },
             sendSignalingProbe: { "probe-id" },
-            startIceRestart: { _ in restartExpectation.fulfill() },
-            requestReattach: { _ in XCTFail("Should restart ICE before reattaching") }
+            startIceRestart: { _ in restartCount += 1 },
+            requestReattach: { _ in XCTFail("Should not reattach") }
         )
 
         monitor.callStateDidChange(call)
         monitor.inboundRtpSampleReceived(100, for: call)
+        let settledExpectation = expectation(description: "processes unchanged steady-state sample")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.03) {
             monitor.inboundRtpSampleReceived(100, for: call)
+            settledExpectation.fulfill()
         }
 
-        wait(for: [restartExpectation], timeout: 1)
+        wait(for: [settledExpectation], timeout: 1)
+        XCTAssertEqual(restartCount, 0)
     }
 
     func testRestartAnswerWithoutInboundRtpFallsBackToReattach() {

--- a/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
+++ b/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
@@ -33,7 +33,7 @@ final class SignalingHealthMonitorTests: XCTestCase {
             isSignalingAvailable: { true },
             sendSignalingProbe: { "probe-id" },
             startIceRestart: { _ in restartExpectation.fulfill() },
-            requestReattach: { XCTFail("Should not reattach while signaling is healthy") }
+            requestReattach: { _ in XCTFail("Should not reattach while signaling is healthy") }
         )
 
         monitor.peerConnectionStateDidChange(call, state: .disconnected)

--- a/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
+++ b/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
@@ -250,7 +250,8 @@ final class SignalingHealthMonitorTests: XCTestCase {
         let call = makeActiveCall()
         let restartExpectation = expectation(description: "inbound RTP stall starts ICE restart")
         let monitor = SignalingHealthMonitor(
-            inboundRtpCheckInterval: 0.01,
+            inboundRtpSteadyStateCheckInterval: 0.01,
+            inboundRtpVerificationCheckInterval: 0.01,
             inboundRtpStallTimeout: 0.02,
             isSignalingAvailable: { true },
             sendSignalingProbe: { "probe-id" },
@@ -269,7 +270,8 @@ final class SignalingHealthMonitorTests: XCTestCase {
         let restartExpectation = expectation(description: "starts ICE restart")
         let reattachExpectation = expectation(description: "reattaches after media verification timeout")
         let monitor = SignalingHealthMonitor(
-            inboundRtpCheckInterval: 0.01,
+            inboundRtpSteadyStateCheckInterval: 0.01,
+            inboundRtpVerificationCheckInterval: 0.01,
             postIceRestartMediaTimeout: 0.02,
             isSignalingAvailable: { true },
             sendSignalingProbe: { "probe-id" },
@@ -296,7 +298,8 @@ final class SignalingHealthMonitorTests: XCTestCase {
         var didCaptureInitialSample = false
         var reattachCount = 0
         let monitor = SignalingHealthMonitor(
-            inboundRtpCheckInterval: 0.01,
+            inboundRtpSteadyStateCheckInterval: 0.01,
+            inboundRtpVerificationCheckInterval: 0.01,
             postIceRestartMediaTimeout: 0.1,
             isSignalingAvailable: { true },
             sendSignalingProbe: { "probe-id" },

--- a/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
+++ b/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
@@ -50,7 +50,7 @@ final class SignalingHealthMonitorTests: XCTestCase {
             isSignalingAvailable: { true },
             sendSignalingProbe: { "probe-id" },
             startIceRestart: { _ in noRestartExpectation.fulfill() },
-            requestReattach: { XCTFail("Should not reattach after peer reconnects") }
+            requestReattach: { _ in XCTFail("Should not reattach after peer reconnects") }
         )
 
         monitor.peerConnectionStateDidChange(call, state: .disconnected)

--- a/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
+++ b/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
@@ -246,15 +246,15 @@ final class SignalingHealthMonitorTests: XCTestCase {
         wait(for: [reattachExpectation], timeout: 1)
     }
 
-    func testSteadyStateInboundRtpSamplesDoNotTriggerStatsDrivenRecovery() {
+    func testInboundRtpStallStartsIceRestartAfterThreeSecondThreshold() {
         let call = makeActiveCall()
-        let noRestartExpectation = expectation(description: "allows steady-state sampling")
-        noRestartExpectation.isInverted = true
+        let restartExpectation = expectation(description: "inbound RTP stall starts ICE restart")
         let monitor = SignalingHealthMonitor(
+            inboundRtpStallTimeout: 0.02,
             isSignalingAvailable: { true },
             sendSignalingProbe: { "probe-id" },
-            startIceRestart: { _ in noRestartExpectation.fulfill() },
-            requestReattach: { _ in XCTFail("Should not reattach") }
+            startIceRestart: { _ in restartExpectation.fulfill() },
+            requestReattach: { _ in XCTFail("Should restart ICE before reattaching") }
         )
 
         monitor.callStateDidChange(call)
@@ -263,7 +263,7 @@ final class SignalingHealthMonitorTests: XCTestCase {
             monitor.inboundRtpSampleReceived(100, for: call)
         }
 
-        wait(for: [noRestartExpectation], timeout: 0.1)
+        wait(for: [restartExpectation], timeout: 1)
     }
 
     func testRestartAnswerWithoutInboundRtpFallsBackToReattach() {

--- a/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
+++ b/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
@@ -246,6 +246,90 @@ final class SignalingHealthMonitorTests: XCTestCase {
         wait(for: [reattachExpectation], timeout: 1)
     }
 
+    func testInboundRtpStallStartsIceRestartAfterFiveSecondThreshold() {
+        let call = makeActiveCall()
+        let restartExpectation = expectation(description: "inbound RTP stall starts ICE restart")
+        let monitor = SignalingHealthMonitor(
+            inboundRtpCheckInterval: 0.01,
+            inboundRtpStallTimeout: 0.02,
+            isSignalingAvailable: { true },
+            sendSignalingProbe: { "probe-id" },
+            startIceRestart: { _ in restartExpectation.fulfill() },
+            readInboundRtpPackets: { _, completion in completion(100) },
+            requestReattach: { _ in XCTFail("Should restart ICE before reattaching") }
+        )
+
+        monitor.callStateDidChange(call)
+
+        wait(for: [restartExpectation], timeout: 1)
+    }
+
+    func testRestartAnswerWithoutInboundRtpFallsBackToReattach() {
+        let call = makeActiveCall()
+        let restartExpectation = expectation(description: "starts ICE restart")
+        let reattachExpectation = expectation(description: "reattaches after media verification timeout")
+        let monitor = SignalingHealthMonitor(
+            inboundRtpCheckInterval: 0.01,
+            postIceRestartMediaTimeout: 0.02,
+            isSignalingAvailable: { true },
+            sendSignalingProbe: { "probe-id" },
+            startIceRestart: { _ in restartExpectation.fulfill() },
+            readInboundRtpPackets: { _, completion in completion(100) },
+            requestReattach: { _ in reattachExpectation.fulfill() }
+        )
+
+        monitor.callStateDidChange(call)
+        monitor.peerConnectionStateDidChange(call, state: .failed)
+        wait(for: [restartExpectation], timeout: 1)
+        monitor.iceRestartDidComplete(for: call)
+
+        wait(for: [reattachExpectation], timeout: 1)
+    }
+
+    func testInboundRtpGrowthAfterRestartAnswerCompletesRecovery() {
+        let call = makeActiveCall()
+        let initialSampleExpectation = expectation(description: "captures inbound RTP baseline")
+        let restartExpectation = expectation(description: "starts ICE restart")
+        let resumedExpectation = expectation(description: "watchdog observes inbound RTP growth")
+        var packetsReceived = 100
+        var shouldExpectGrowth = false
+        var didCaptureInitialSample = false
+        var reattachCount = 0
+        let monitor = SignalingHealthMonitor(
+            inboundRtpCheckInterval: 0.01,
+            postIceRestartMediaTimeout: 0.1,
+            isSignalingAvailable: { true },
+            sendSignalingProbe: { "probe-id" },
+            startIceRestart: { _ in restartExpectation.fulfill() },
+            readInboundRtpPackets: { _, completion in
+                if !didCaptureInitialSample {
+                    didCaptureInitialSample = true
+                    initialSampleExpectation.fulfill()
+                }
+                if shouldExpectGrowth && packetsReceived == 101 {
+                    resumedExpectation.fulfill()
+                    shouldExpectGrowth = false
+                }
+                completion(packetsReceived)
+            },
+            requestReattach: { _ in reattachCount += 1 }
+        )
+
+        monitor.callStateDidChange(call)
+        wait(for: [initialSampleExpectation], timeout: 1)
+        monitor.peerConnectionStateDidChange(call, state: .failed)
+        wait(for: [restartExpectation], timeout: 1)
+        monitor.iceRestartDidComplete(for: call)
+        packetsReceived = 101
+        shouldExpectGrowth = true
+
+        wait(for: [resumedExpectation], timeout: 1)
+        let settledExpectation = expectation(description: "media verification window expires")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) { settledExpectation.fulfill() }
+        wait(for: [settledExpectation], timeout: 1)
+        XCTAssertEqual(reattachCount, 0)
+    }
+
     private func makeResponse(id: String) -> Message {
         Message().decode(message: "{\"jsonrpc\":\"2.0\",\"id\":\"\(id)\",\"result\":{}}")!
     }

--- a/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
+++ b/TelnyxRTCTests/CallRecovery/SignalingHealthMonitorTests.swift
@@ -306,6 +306,7 @@ final class SignalingHealthMonitorTests: XCTestCase {
         wait(for: [restartExpectation], timeout: 1)
         monitor.iceRestartDidComplete(for: call)
         monitor.inboundRtpSampleReceived(101, for: call)
+        monitor.inboundRtpSampleReceived(102, for: call)
         let settledExpectation = expectation(description: "media verification window expires")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) { settledExpectation.fulfill() }
         wait(for: [settledExpectation], timeout: 1)

--- a/TelnyxRTCTests/WebRTC/CallTests.swift
+++ b/TelnyxRTCTests/WebRTC/CallTests.swift
@@ -92,6 +92,32 @@ class CallTests: XCTestCase {
         XCTAssertEqual(callCustomHeaders?["X-test1"], "ios-test1", "X-test1 header should match")
         XCTAssertEqual(callCustomHeaders?["X-test2"], "ios-test2", "X-test2 header should match")
     }
+
+    func testSelectedDirectVPNCandidateRequiresRelayForRecovery() {
+        let statistics: [String: [String: Any]] = [
+            "transport": ["type": "transport", "selectedCandidatePairId": "pair"],
+            "pair": ["type": "candidate-pair", "localCandidateId": "local"],
+            "local": ["type": "local-candidate", "networkType": "vpn", "candidateType": "host"]
+        ]
+
+        XCTAssertTrue(Call.selectedCandidateUsesDirectVPN(statistics))
+    }
+
+    func testSelectedRelayOrNonVPNCandidateDoesNotRequireRelayForRecovery() {
+        let relayStatistics: [String: [String: Any]] = [
+            "transport": ["type": "transport", "selectedCandidatePairId": "pair"],
+            "pair": ["type": "candidate-pair", "localCandidateId": "local"],
+            "local": ["type": "local-candidate", "networkType": "vpn", "candidateType": "relay"]
+        ]
+        let wifiStatistics: [String: [String: Any]] = [
+            "transport": ["type": "transport", "selectedCandidatePairId": "pair"],
+            "pair": ["type": "candidate-pair", "localCandidateId": "local"],
+            "local": ["type": "local-candidate", "networkType": "wifi", "candidateType": "host"]
+        ]
+
+        XCTAssertFalse(Call.selectedCandidateUsesDirectVPN(relayStatistics))
+        XCTAssertFalse(Call.selectedCandidateUsesDirectVPN(wifiStatistics))
+    }
 }
 
 // MARK: - CallProtocol

--- a/TelnyxRTCTests/WebRTC/CallTests.swift
+++ b/TelnyxRTCTests/WebRTC/CallTests.swift
@@ -38,14 +38,16 @@ class CallTests: XCTestCase {
      - NOTE: Due that we are not sending a valid sessionID we are going to get an "Authentication error" from the server.
      */
     func testNewCall() {
+        let timeout: TimeInterval = ProcessInfo.processInfo.environment["CI"] != nil ? 30.0 : 10.0
+
         //Wait for socket connection
         expectation = expectation(description: "socket")
-        waitForExpectations(timeout: 10)
+        waitForExpectations(timeout: timeout)
 
         //Wait to send invite message.
         expectation = expectation(description: "newCall")
         self.call?.newCall(callerName: "callerName", callerNumber: "callerNumber", destinationNumber: "destinationNumber")
-        waitForExpectations(timeout: 10)
+        waitForExpectations(timeout: timeout)
     }
     
     /**


### PR DESCRIPTION
## Linear Ticket

https://linear.app/telnyx/issue/VSUP-200/force-relay-for-proven-vpn-direct-path-recovery-failures

## Before

Reconnect/reattach replacements always inherited the app-wide `forceRelayCandidate` setting. A failed direct VPN path had no targeted relay fallback.

## After

- Reads the selected ICE candidate pair at peer/ICE recovery failure.
- Enables relay only when the selected local candidate reports `networkType: vpn` and a non-relay `candidateType`.
- Applies the override once, only to the replacement attach call.
- Keeps the app-wide relay setting untouched and does not alter mandatory network-path teardown/reattach.

## Tests

Focused iPhone 16 simulator tests cover VPN-direct selection, VPN-relay and Wi-Fi non-selection, and recovery propagation of the one-shot relay decision.

## Notes

Stacked on VSUP-199, which is stacked on VSUP-198.