### PR TITLE
[VSUP-205] Prevent phantom ringing after missing push INVITE

### DIFF
--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -840,7 +840,7 @@ public class TxClient {
     
     /// Handles the timeout when no INVITE is received after accepting a VoIP push call
     private func handleInviteTimeout() {
-        Logger.log.w(message: "TxClient:: INVITE timeout - No INVITE received within \(inviteTimeoutInterval) seconds after accepting VoIP push call")
+        Logger.log.w(message: "TxClient:: INVITE timeout - No INVITE received within \(inviteTimeoutInterval) seconds after attachCalls")
         let timedOutCallId = currentCallId
         let pendingAnswerAction = answerCallAction
         
@@ -1121,9 +1121,12 @@ public class TxClient {
                 if (self.isCallFromPush == true){
                     self.sendAttachCall()
                     
-                    // Start INVITE timeout for VoIP push calls that are being answered (not declined)
-                    if answerCallAction != nil && !pendingCallDecline && pushCallState != .inviteReceived {
-                        Logger.log.i(message: "TxClient:: updateGatewayState() Starting INVITE timeout for VoIP push call")
+                    // Every push-originated ringing call needs a terminal path. Start the watchdog
+                    // after registration + attachCalls even when the user has not pressed Answer;
+                    // otherwise a secondary device can remain in CallKit until its system timeout
+                    // when the backend never replays INVITE or terminal cleanup.
+                    if !pendingCallDecline && pushCallState != .inviteReceived {
+                        Logger.log.i(message: "TxClient:: updateGatewayState() Starting post-attach INVITE timeout for VoIP push call")
                         startInviteTimeout()
                     }
                 }

--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -165,6 +165,7 @@ public class TxClient {
     private var pendingAnswerHeaders = [String:String]()
     internal var sendFileLogs: Bool = false
     private var attachCallId: String?
+    internal var pendingAttachCallIdForTesting: String? { attachCallId }
     private var pushMetaData: [String:Any]?
     private let AUTH_ERROR_CODE = "-32001"
     private var reconnectTimeoutTimer: DispatchSourceTimer?
@@ -1608,6 +1609,13 @@ extension TxClient: CallProtocol {
                 self.delegate?.onRemoteCallEnded(callId: callId, reason: nil)
             }
             self._isSpeakerEnabled = false
+
+            // A terminal event can arrive for the placeholder call before the
+            // replayed INVITE. Cancel the post-attach watchdog so it cannot emit
+            // a second DONE/onRemoteCallEnded callback for the same push call.
+            if isCallFromPush && callId == currentCallId {
+                resetPushVariables()
+            }
         }
     }
 
@@ -1892,6 +1900,7 @@ extension TxClient : SocketDelegate {
         //Check if server is sending an error code
         if let error = vertoMessage.serverError {
             if attachCallId == vertoMessage.id {
+                stopInviteTimeout()
                 // Call failed from remote end
               if let callId = pushMetaData?["call_id"] as? String,
                 let callUUID = UUID(uuidString: callId) {
@@ -1902,6 +1911,7 @@ extension TxClient : SocketDelegate {
                   self.delegate?.onRemoteCallEnded(callId: callUUID, reason: terminationReason)
                   self.delegate?.onCallStateUpdated(callState: .DONE(reason: terminationReason), callId: callUUID)
                 }
+                resetPushVariables()
                 return
             }
             let message: String = error["message"] as? String ?? "Unknown"
@@ -1990,20 +2000,21 @@ extension TxClient : SocketDelegate {
                     break
 
                 case .INVITE:
-                    //invite received
-                    if isCallFromPush {
-                        pushCallState = .inviteReceived
-                    }
-                    if isWaitingForInviteAfterPush {
-                        Logger.log.i(message: "TxClient:: INVITE received - stopping timeout timer for VoIP push call")
-                        stopInviteTimeout()
-                    }
-                    
                     if let params = vertoMessage.params {
                         guard let sdp = params["sdp"] as? String,
                               let callId = params["callID"] as? String,
                               let uuid = UUID(uuidString: callId) else {
                             return
+                        }
+
+                        // Only a usable INVITE resolves the pending push flow.
+                        // Malformed messages must leave the watchdog armed.
+                        if isCallFromPush {
+                            pushCallState = .inviteReceived
+                        }
+                        if isWaitingForInviteAfterPush {
+                            Logger.log.i(message: "TxClient:: INVITE received - stopping timeout timer for VoIP push call")
+                            stopInviteTimeout()
                         }
                         
                         self.voiceSdkId = vertoMessage.voiceSdkId
@@ -2057,6 +2068,10 @@ extension TxClient : SocketDelegate {
                           let uuid = UUID(uuidString: callId) else {
                         return
                     }
+
+                    // ATTACH is a successful terminal outcome for the pending
+                    // replay wait. Do not let the INVITE watchdog end this call.
+                    stopInviteTimeout()
                     
                     self.voiceSdkId = vertoMessage.voiceSdkId
 
@@ -2094,6 +2109,7 @@ extension TxClient : SocketDelegate {
                                             customHeaders: customHeaders,
                                             isAttach: true
                     )
+                    resetPushVariables()
                     
                 }
                  break;

--- a/TelnyxRTCTests/TxClientSocketErrorTests.swift
+++ b/TelnyxRTCTests/TxClientSocketErrorTests.swift
@@ -165,6 +165,22 @@ class TxClientPingAuthTests: XCTestCase {
         XCTAssertEqual(mockDelegate.doneCallIds, [callUUID])
     }
 
+    func testAttachSuccessCancelsPushWatchdogWithoutTerminalCleanup() throws {
+        let pushCallUUID = UUID()
+        let signalingCallUUID = UUID()
+        txClient.inviteTimeoutInterval = 0.01
+        try startPushFlow(callId: pushCallUUID)
+        txClient.onMessageReceived(message: gatewayStateMessage(state: "REGED"))
+
+        txClient.onMessageReceived(message: """
+        {"jsonrpc":"2.0","method":"telnyx_rtc.attach","params":{"sdp":"v=0\\r\\n","callID":"\(signalingCallUUID.uuidString)"}}
+        """)
+        waitForWatchdog()
+
+        XCTAssertTrue(mockDelegate.remoteEndedCallIds.isEmpty)
+        XCTAssertTrue(mockDelegate.doneCallIds.isEmpty)
+    }
+
     private func waitForWatchdog() {
         let expectation = expectation(description: "Wait beyond INVITE watchdog")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { expectation.fulfill() }

--- a/TelnyxRTCTests/TxClientSocketErrorTests.swift
+++ b/TelnyxRTCTests/TxClientSocketErrorTests.swift
@@ -134,6 +134,43 @@ class TxClientPingAuthTests: XCTestCase {
         XCTAssertEqual(mockDelegate.doneCallIds, [callUUID])
     }
 
+    func testMalformedInviteDoesNotCancelPushWatchdog() throws {
+        let callUUID = UUID()
+        txClient.inviteTimeoutInterval = 0.01
+        try startPushFlow(callId: callUUID)
+        txClient.onMessageReceived(message: gatewayStateMessage(state: "REGED"))
+
+        txClient.onMessageReceived(message: """
+        {"jsonrpc":"2.0","method":"telnyx_rtc.invite","params":{"callID":"\(UUID().uuidString)"}}
+        """)
+        waitForWatchdog()
+
+        XCTAssertEqual(mockDelegate.remoteEndedCallIds, [callUUID])
+        XCTAssertEqual(mockDelegate.doneCallIds, [callUUID])
+    }
+
+    func testAttachErrorCancelsPushWatchdogAfterSingleCleanup() throws {
+        let callUUID = UUID()
+        txClient.inviteTimeoutInterval = 0.01
+        try startPushFlow(callId: callUUID)
+        txClient.onMessageReceived(message: gatewayStateMessage(state: "REGED"))
+
+        let attachId = try XCTUnwrap(txClient.pendingAttachCallIdForTesting)
+        txClient.onMessageReceived(message: """
+        {"jsonrpc":"2.0","id":"\(attachId)","error":{"code":-1,"message":"Call failed"}}
+        """)
+        waitForWatchdog()
+
+        XCTAssertEqual(mockDelegate.remoteEndedCallIds, [callUUID])
+        XCTAssertEqual(mockDelegate.doneCallIds, [callUUID])
+    }
+
+    private func waitForWatchdog() {
+        let expectation = expectation(description: "Wait beyond INVITE watchdog")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { expectation.fulfill() }
+        wait(for: [expectation], timeout: 1.0)
+    }
+
     private func startPushFlow(callId: UUID) throws {
         let txConfig = TxConfig(sipUser: "test_user", password: "test_password")
         let serverConfig = TxServerConfiguration()

--- a/TelnyxRTCTests/TxClientSocketErrorTests.swift
+++ b/TelnyxRTCTests/TxClientSocketErrorTests.swift
@@ -116,6 +116,24 @@ class TxClientPingAuthTests: XCTestCase {
         XCTAssertEqual(answerAction.fulfillCallCount, 1)
     }
 
+    func testPassivePushInviteTimeoutUsesPushUUIDWithoutAnswerAction() throws {
+        let callUUID = UUID()
+        txClient.inviteTimeoutInterval = 0.01
+        try startPushFlow(callId: callUUID)
+
+        txClient.onSocketConnected()
+        txClient.onMessageReceived(message: gatewayStateMessage(state: "REGED"))
+
+        let timeoutExpectation = expectation(description: "Passive VoIP push INVITE timeout handled")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            timeoutExpectation.fulfill()
+        }
+        wait(for: [timeoutExpectation], timeout: 1.0)
+
+        XCTAssertEqual(mockDelegate.remoteEndedCallIds, [callUUID])
+        XCTAssertEqual(mockDelegate.doneCallIds, [callUUID])
+    }
+
     private func startPushFlow(callId: UUID) throws {
         let txConfig = TxConfig(sipUser: "test_user", password: "test_password")
         let serverConfig = TxServerConfiguration()


### PR DESCRIPTION
[VSUP-205 - Prevent phantom ringing after missing push INVITE](https://telnyx.atlassian.net/browse/VSUP-205)

---

Ensures every push-originated ringing call has a terminal path when `attachCalls` does not produce an INVITE or cleanup event.

## :older_man: :baby: Behaviors

### Before changes

- The 10-second INVITE watchdog started only after the user pressed Answer.
- An untouched secondary device could remain ringing in CallKit until the system's 60-second timeout.

### After changes

- The watchdog starts after successful registration and `attachCalls` for every non-declined push call.
- INVITE, BYE, attach error, cleanup, disconnect, or decline still cancels the pending push flow.
- Timeout emits the existing remote-ended and DONE callbacks using the push call UUID.

## TODO

- Backend should make `attachCalls` idempotent and return matched call IDs before an SDK retry is added.

## ✋ Manual testing

1. Receive the same inbound call on two devices.
2. Leave the secondary device untouched while preventing INVITE replay after `attachCalls`.
3. Verify CallKit ends the secondary ringing call after 10 seconds.
4. Verify a normally replayed INVITE cancels the watchdog and remains answerable.

Automated verification: answered and passive push timeout tests pass on iPhone 17 Simulator (iOS 26.5).

## Known Issues

- This mitigates the client-side phantom ring; the underlying backend fanout race still requires server-side correction.

## Screenshots

Not applicable.
