### PR TITLE
feat: improve call stats parity

### DIFF
--- a/TelnyxRTC/Telnyx/Models/CallReportModels.swift
+++ b/TelnyxRTC/Telnyx/Models/CallReportModels.swift
@@ -31,12 +31,26 @@ public struct OutboundAudioStats: Codable {
     public let bytesSent: Int?
     public let audioLevelAvg: Double?
     public let bitrateAvg: Double?
+    public let retransmittedPacketsSent: Int?
+    public let retransmittedBytesSent: Int?
+    public let headerBytesSent: Int?
+    public let nackCount: Int?
+    public let targetBitrate: Double?
+    public let totalPacketSendDelay: Double?
+    public let active: Bool?
     
-    public init(packetsSent: Int? = nil, bytesSent: Int? = nil, audioLevelAvg: Double? = nil, bitrateAvg: Double? = nil) {
+    public init(packetsSent: Int? = nil, bytesSent: Int? = nil, audioLevelAvg: Double? = nil, bitrateAvg: Double? = nil, retransmittedPacketsSent: Int? = nil, retransmittedBytesSent: Int? = nil, headerBytesSent: Int? = nil, nackCount: Int? = nil, targetBitrate: Double? = nil, totalPacketSendDelay: Double? = nil, active: Bool? = nil) {
         self.packetsSent = packetsSent
         self.bytesSent = bytesSent
         self.audioLevelAvg = audioLevelAvg
         self.bitrateAvg = bitrateAvg
+        self.retransmittedPacketsSent = retransmittedPacketsSent
+        self.retransmittedBytesSent = retransmittedBytesSent
+        self.headerBytesSent = headerBytesSent
+        self.nackCount = nackCount
+        self.targetBitrate = targetBitrate
+        self.totalPacketSendDelay = totalPacketSendDelay
+        self.active = active
     }
 }
 
@@ -54,6 +68,17 @@ public struct InboundAudioStats: Codable {
     public let audioLevelAvg: Double?
     public let jitterAvg: Double?
     public let bitrateAvg: Double?
+    public let nackCount: Int?
+    public let headerBytesReceived: Int?
+    public let fecPacketsReceived: Int?
+    public let fecPacketsDiscarded: Int?
+    public let jitterBufferTargetDelay: Double?
+    public let jitterBufferMinimumDelay: Double?
+    public let totalSamplesDecoded: Int?
+    public let samplesDecodedWithSilence: Int?
+    public let samplesDecodedWithConcealment: Int?
+    public let totalAudioEnergy: Double?
+    public let totalSamplesDuration: Double?
     
     public init(
         packetsReceived: Int? = nil,
@@ -67,7 +92,18 @@ public struct InboundAudioStats: Codable {
         concealmentEvents: Int? = nil,
         audioLevelAvg: Double? = nil,
         jitterAvg: Double? = nil,
-        bitrateAvg: Double? = nil
+        bitrateAvg: Double? = nil,
+        nackCount: Int? = nil,
+        headerBytesReceived: Int? = nil,
+        fecPacketsReceived: Int? = nil,
+        fecPacketsDiscarded: Int? = nil,
+        jitterBufferTargetDelay: Double? = nil,
+        jitterBufferMinimumDelay: Double? = nil,
+        totalSamplesDecoded: Int? = nil,
+        samplesDecodedWithSilence: Int? = nil,
+        samplesDecodedWithConcealment: Int? = nil,
+        totalAudioEnergy: Double? = nil,
+        totalSamplesDuration: Double? = nil
     ) {
         self.packetsReceived = packetsReceived
         self.bytesReceived = bytesReceived
@@ -81,6 +117,17 @@ public struct InboundAudioStats: Codable {
         self.audioLevelAvg = audioLevelAvg
         self.jitterAvg = jitterAvg
         self.bitrateAvg = bitrateAvg
+        self.nackCount = nackCount
+        self.headerBytesReceived = headerBytesReceived
+        self.fecPacketsReceived = fecPacketsReceived
+        self.fecPacketsDiscarded = fecPacketsDiscarded
+        self.jitterBufferTargetDelay = jitterBufferTargetDelay
+        self.jitterBufferMinimumDelay = jitterBufferMinimumDelay
+        self.totalSamplesDecoded = totalSamplesDecoded
+        self.samplesDecodedWithSilence = samplesDecodedWithSilence
+        self.samplesDecodedWithConcealment = samplesDecodedWithConcealment
+        self.totalAudioEnergy = totalAudioEnergy
+        self.totalSamplesDuration = totalSamplesDuration
     }
 }
 
@@ -102,20 +149,137 @@ public struct ConnectionStats: Codable {
     public let packetsReceived: Int?
     public let bytesSent: Int?
     public let bytesReceived: Int?
+    public let currentRoundTripTime: Double?
+    public let roundTripTimeSource: String?
     
     public init(
         roundTripTimeAvg: Double? = nil,
         packetsSent: Int? = nil,
         packetsReceived: Int? = nil,
         bytesSent: Int? = nil,
-        bytesReceived: Int? = nil
+        bytesReceived: Int? = nil,
+        currentRoundTripTime: Double? = nil,
+        roundTripTimeSource: String? = nil
     ) {
         self.roundTripTimeAvg = roundTripTimeAvg
         self.packetsSent = packetsSent
         self.packetsReceived = packetsReceived
         self.bytesSent = bytesSent
         self.bytesReceived = bytesReceived
+        self.currentRoundTripTime = currentRoundTripTime
+        self.roundTripTimeSource = roundTripTimeSource
     }
+}
+
+/// A local or remote ICE candidate resolved from the selected candidate pair.
+public struct ICECandidateStats: Codable {
+    public let id: String?
+    public let address: String?
+    public let port: Int?
+    public let candidateType: String?
+    public let protocolType: String?
+    public let networkType: String?
+    public let url: String?
+    public let relayProtocol: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, address, port, candidateType, networkType, url, relayProtocol
+        case protocolType = "protocol"
+    }
+
+    public init(id: String? = nil, address: String? = nil, port: Int? = nil, candidateType: String? = nil, protocolType: String? = nil, networkType: String? = nil, url: String? = nil, relayProtocol: String? = nil) {
+        self.id = id
+        self.address = address
+        self.port = port
+        self.candidateType = candidateType
+        self.protocolType = protocolType
+        self.networkType = networkType
+        self.url = url
+        self.relayProtocol = relayProtocol
+    }
+}
+
+/// Selected ICE candidate-pair details. Field names mirror the JS SDK report.
+public struct ICECandidatePairStats: Codable {
+    public let id: String?
+    public let localCandidateId: String?
+    public let remoteCandidateId: String?
+    public let state: String?
+    public let nominated: Bool?
+    public let writable: Bool?
+    public let currentRoundTripTime: Double?
+    public let requestsSent: Int?
+    public let responsesReceived: Int?
+    public let local: ICECandidateStats?
+    public let remote: ICECandidateStats?
+
+    public init(id: String? = nil, localCandidateId: String? = nil, remoteCandidateId: String? = nil, state: String? = nil, nominated: Bool? = nil, writable: Bool? = nil, currentRoundTripTime: Double? = nil, requestsSent: Int? = nil, responsesReceived: Int? = nil, local: ICECandidateStats? = nil, remote: ICECandidateStats? = nil) {
+        self.id = id
+        self.localCandidateId = localCandidateId
+        self.remoteCandidateId = remoteCandidateId
+        self.state = state
+        self.nominated = nominated
+        self.writable = writable
+        self.currentRoundTripTime = currentRoundTripTime
+        self.requestsSent = requestsSent
+        self.responsesReceived = responsesReceived
+        self.local = local
+        self.remote = remote
+    }
+}
+
+/// DTLS/ICE transport snapshot for a reporting interval.
+public struct TransportStats: Codable {
+    public let iceState: String?
+    public let dtlsState: String?
+    public let srtpCipher: String?
+    public let tlsVersion: String?
+    public let selectedCandidatePairChanges: Int?
+    public let selectedCandidatePairId: String?
+
+    public init(iceState: String? = nil, dtlsState: String? = nil, srtpCipher: String? = nil, tlsVersion: String? = nil, selectedCandidatePairChanges: Int? = nil, selectedCandidatePairId: String? = nil) {
+        self.iceState = iceState
+        self.dtlsState = dtlsState
+        self.srtpCipher = srtpCipher
+        self.tlsVersion = tlsVersion
+        self.selectedCandidatePairChanges = selectedCandidatePairChanges
+        self.selectedCandidatePairId = selectedCandidatePairId
+    }
+}
+
+public struct MediaPlayoutStats: Codable {
+    public let synthesizedSamplesEvents: Int?
+    public let synthesizedSamplesDuration: Double?
+    public let totalPlayoutDelay: Double?
+    public let totalSamplesCount: Int?
+    public let totalSamplesDuration: Double?
+}
+
+public struct RemoteInboundRTCPStats: Codable {
+    public let packetsReceived: Int?
+    public let packetsLost: Int?
+    public let fractionLost: Double?
+    public let jitter: Double?
+    public let roundTripTime: Double?
+    public let totalRoundTripTime: Double?
+    public let roundTripTimeMeasurements: Int?
+    public let roundTripTimeAvg: Double?
+    public let nackCount: Int?
+    public let reportsReceived: Int?
+    public let packetsDiscarded: Int?
+}
+
+public struct RemoteOutboundRTCPStats: Codable {
+    public let packetsSent: Int?
+    public let bytesSent: Int?
+    public let reportsCount: Int?
+    public let roundTripTime: Double?
+    public let totalPacketSendDelay: Double?
+}
+
+public struct RemoteRTCPStats: Codable {
+    public let inbound: RemoteInboundRTCPStats?
+    public let outbound: RemoteOutboundRTCPStats?
 }
 
 /// Statistics collected during a single reporting interval
@@ -124,12 +288,20 @@ public struct CallReportInterval: Codable {
     public let intervalEndUtc: String
     public let audio: AudioStats?
     public let connection: ConnectionStats?
+    public let ice: ICECandidatePairStats?
+    public let transport: TransportStats?
+    public let mediaPlayout: MediaPlayoutStats?
+    public let remoteRtcp: RemoteRTCPStats?
     
-    public init(intervalStartUtc: String, intervalEndUtc: String, audio: AudioStats? = nil, connection: ConnectionStats? = nil) {
+    public init(intervalStartUtc: String, intervalEndUtc: String, audio: AudioStats? = nil, connection: ConnectionStats? = nil, ice: ICECandidatePairStats? = nil, transport: TransportStats? = nil, mediaPlayout: MediaPlayoutStats? = nil, remoteRtcp: RemoteRTCPStats? = nil) {
         self.intervalStartUtc = intervalStartUtc
         self.intervalEndUtc = intervalEndUtc
         self.audio = audio
         self.connection = connection
+        self.ice = ice
+        self.transport = transport
+        self.mediaPlayout = mediaPlayout
+        self.remoteRtcp = remoteRtcp
     }
 }
 

--- a/TelnyxRTC/Telnyx/Models/CallReportModels.swift
+++ b/TelnyxRTC/Telnyx/Models/CallReportModels.swift
@@ -25,6 +25,46 @@ public struct LogEntry: Codable {
     }
 }
 
+/// Codec metadata linked from an RTP statistics record.
+public struct AudioCodecStats: Codable {
+    public let codecId: String?
+    public let mimeType: String?
+    public let payloadType: Int?
+    public let clockRate: Int?
+    public let channels: Int?
+    public let sdpFmtpLine: String?
+
+    public init(codecId: String? = nil, mimeType: String? = nil, payloadType: Int? = nil, clockRate: Int? = nil, channels: Int? = nil, sdpFmtpLine: String? = nil) {
+        self.codecId = codecId
+        self.mimeType = mimeType
+        self.payloadType = payloadType
+        self.clockRate = clockRate
+        self.channels = channels
+        self.sdpFmtpLine = sdpFmtpLine
+    }
+}
+
+/// Local audio-source telemetry linked from outbound RTP statistics.
+public struct AudioMediaSourceStats: Codable {
+    public let id: String?
+    public let audioLevel: Double?
+    public let totalAudioEnergy: Double?
+    public let totalSamplesDuration: Double?
+    public let echoReturnLoss: Double?
+    public let echoReturnLossEnhancement: Double?
+    public let trackIdentifier: String?
+
+    public init(id: String? = nil, audioLevel: Double? = nil, totalAudioEnergy: Double? = nil, totalSamplesDuration: Double? = nil, echoReturnLoss: Double? = nil, echoReturnLossEnhancement: Double? = nil, trackIdentifier: String? = nil) {
+        self.id = id
+        self.audioLevel = audioLevel
+        self.totalAudioEnergy = totalAudioEnergy
+        self.totalSamplesDuration = totalSamplesDuration
+        self.echoReturnLoss = echoReturnLoss
+        self.echoReturnLossEnhancement = echoReturnLossEnhancement
+        self.trackIdentifier = trackIdentifier
+    }
+}
+
 /// Statistics for outbound audio stream
 public struct OutboundAudioStats: Codable {
     public let packetsSent: Int?
@@ -38,8 +78,10 @@ public struct OutboundAudioStats: Codable {
     public let targetBitrate: Double?
     public let totalPacketSendDelay: Double?
     public let active: Bool?
+    public let codec: AudioCodecStats?
+    public let mediaSource: AudioMediaSourceStats?
     
-    public init(packetsSent: Int? = nil, bytesSent: Int? = nil, audioLevelAvg: Double? = nil, bitrateAvg: Double? = nil, retransmittedPacketsSent: Int? = nil, retransmittedBytesSent: Int? = nil, headerBytesSent: Int? = nil, nackCount: Int? = nil, targetBitrate: Double? = nil, totalPacketSendDelay: Double? = nil, active: Bool? = nil) {
+    public init(packetsSent: Int? = nil, bytesSent: Int? = nil, audioLevelAvg: Double? = nil, bitrateAvg: Double? = nil, retransmittedPacketsSent: Int? = nil, retransmittedBytesSent: Int? = nil, headerBytesSent: Int? = nil, nackCount: Int? = nil, targetBitrate: Double? = nil, totalPacketSendDelay: Double? = nil, active: Bool? = nil, codec: AudioCodecStats? = nil, mediaSource: AudioMediaSourceStats? = nil) {
         self.packetsSent = packetsSent
         self.bytesSent = bytesSent
         self.audioLevelAvg = audioLevelAvg
@@ -51,6 +93,8 @@ public struct OutboundAudioStats: Codable {
         self.targetBitrate = targetBitrate
         self.totalPacketSendDelay = totalPacketSendDelay
         self.active = active
+        self.codec = codec
+        self.mediaSource = mediaSource
     }
 }
 
@@ -79,6 +123,7 @@ public struct InboundAudioStats: Codable {
     public let samplesDecodedWithConcealment: Int?
     public let totalAudioEnergy: Double?
     public let totalSamplesDuration: Double?
+    public let codec: AudioCodecStats?
     
     public init(
         packetsReceived: Int? = nil,
@@ -103,7 +148,8 @@ public struct InboundAudioStats: Codable {
         samplesDecodedWithSilence: Int? = nil,
         samplesDecodedWithConcealment: Int? = nil,
         totalAudioEnergy: Double? = nil,
-        totalSamplesDuration: Double? = nil
+        totalSamplesDuration: Double? = nil,
+        codec: AudioCodecStats? = nil
     ) {
         self.packetsReceived = packetsReceived
         self.bytesReceived = bytesReceived
@@ -128,6 +174,7 @@ public struct InboundAudioStats: Codable {
         self.samplesDecodedWithConcealment = samplesDecodedWithConcealment
         self.totalAudioEnergy = totalAudioEnergy
         self.totalSamplesDuration = totalSamplesDuration
+        self.codec = codec
     }
 }
 

--- a/TelnyxRTC/Telnyx/Models/CallReportModels.swift
+++ b/TelnyxRTC/Telnyx/Models/CallReportModels.swift
@@ -366,6 +366,9 @@ public struct CallReportSummary: Codable {
     public let sdkVersion: String?
     public let startTimestamp: String?
     public let endTimestamp: String?
+    /// Sanitized client and call options that were in effect for this call.
+    /// Credentials and ICE usernames are represented only as presence flags.
+    public let clientSummary: CallReportClientSummary?
     
     public init(
         callId: String,
@@ -379,7 +382,8 @@ public struct CallReportSummary: Codable {
         voiceSdkSessionId: String? = nil,
         sdkVersion: String? = nil,
         startTimestamp: String? = nil,
-        endTimestamp: String? = nil
+        endTimestamp: String? = nil,
+        clientSummary: CallReportClientSummary? = nil
     ) {
         self.callId = callId
         self.destinationNumber = destinationNumber
@@ -393,6 +397,88 @@ public struct CallReportSummary: Codable {
         self.sdkVersion = sdkVersion
         self.startTimestamp = startTimestamp
         self.endTimestamp = endTimestamp
+        self.clientSummary = clientSummary
+    }
+}
+
+/// JS-compatible, sanitized runtime configuration included with a call report.
+/// Keep this intentionally narrow: a call report must never contain ICE server
+/// credentials, authentication secrets, or user-provided sensitive values.
+public struct CallReportClientSummary: Codable {
+    public let connection: CallReportConnectionSummary?
+    public let media: CallReportMediaSummary?
+    public let callReports: CallReportSettingsSummary?
+
+    public init(
+        connection: CallReportConnectionSummary? = nil,
+        media: CallReportMediaSummary? = nil,
+        callReports: CallReportSettingsSummary? = nil
+    ) {
+        self.connection = connection
+        self.media = media
+        self.callReports = callReports
+    }
+}
+
+public struct CallReportConnectionSummary: Codable {
+    public let host: String?
+
+    public init(host: String? = nil) {
+        self.host = host
+    }
+}
+
+public struct CallReportMediaSummary: Codable {
+    public let audio: Bool?
+    public let video: Bool?
+    public let mutedMicOnStart: Bool?
+    public let prefetchIceCandidates: Bool?
+    public let forceRelayCandidate: Bool?
+    public let trickleIce: Bool?
+    public let iceServers: [CallReportIceServerSummary]?
+
+    public init(
+        audio: Bool? = nil,
+        video: Bool? = nil,
+        mutedMicOnStart: Bool? = nil,
+        prefetchIceCandidates: Bool? = nil,
+        forceRelayCandidate: Bool? = nil,
+        trickleIce: Bool? = nil,
+        iceServers: [CallReportIceServerSummary]? = nil
+    ) {
+        self.audio = audio
+        self.video = video
+        self.mutedMicOnStart = mutedMicOnStart
+        self.prefetchIceCandidates = prefetchIceCandidates
+        self.forceRelayCandidate = forceRelayCandidate
+        self.trickleIce = trickleIce
+        self.iceServers = iceServers
+    }
+}
+
+public struct CallReportIceServerSummary: Codable {
+    public let urls: [String]
+    public let hasUsername: Bool
+    public let hasCredential: Bool
+
+    public init(urls: [String], hasUsername: Bool, hasCredential: Bool) {
+        self.urls = urls
+        self.hasUsername = hasUsername
+        self.hasCredential = hasCredential
+    }
+}
+
+public struct CallReportSettingsSummary: Codable {
+    public let enabled: Bool
+    public let intervalMs: Int
+    public let debugLogLevel: String
+    public let debugLogMaxEntries: Int
+
+    public init(enabled: Bool, intervalMs: Int, debugLogLevel: String, debugLogMaxEntries: Int) {
+        self.enabled = enabled
+        self.intervalMs = intervalMs
+        self.debugLogLevel = debugLogLevel
+        self.debugLogMaxEntries = debugLogMaxEntries
     }
 }
 

--- a/TelnyxRTC/Telnyx/WebRTC/Call+IceRestart.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call+IceRestart.swift
@@ -3,6 +3,22 @@ import WebRTC
 
 // MARK: - ICE Restart handling
 extension Call {
+
+    /// Mirrors the JavaScript SDK's ICE-restart lifecycle entries in the
+    /// call-report `logs` array. These are signaling lifecycle events, not
+    /// WebRTC statistics snapshots.
+    private func recordIceRestartEvent(level: String = "info", message: String, context: [String: Any] = [:]) {
+        var eventContext = context
+        eventContext["callId"] = signalingCallId.uuidString
+        if let sessionId = sessionId {
+            eventContext["sessionId"] = sessionId
+        }
+        callReportCollector?.addLogEntry(
+            level: level,
+            message: message,
+            context: eventContext
+        )
+    }
     
     /// Performs ICE restart to renegotiate ICE candidates when network conditions change
     /// This helps resolve audio delay issues by establishing new network paths
@@ -11,6 +27,10 @@ extension Call {
         guard let peer = self.peer,
               let sessionId = self.sessionId else {
             Logger.log.e(message: "[ICE-RESTART] Call:: ICE restart failed - missing peer, callId, or sessionId")
+            recordIceRestartEvent(
+                level: "error",
+                message: "ICE restart failed - missing required parameters"
+            )
             completion(false, NSError(domain: "Call", code: -1, userInfo: [NSLocalizedDescriptionKey: "Missing required parameters for ICE restart"]))
             return
         }
@@ -18,6 +38,10 @@ extension Call {
         guard let socket = self.socket, socket.isConnected else {
             let error = NSError(domain: "Call", code: -5, userInfo: [NSLocalizedDescriptionKey: "Signaling socket is not connected"])
             Logger.log.w(message: "[ICE-RESTART] Call:: ICE restart skipped - signaling socket is not connected")
+            recordIceRestartEvent(
+                level: "warn",
+                message: "ICE restart skipped - signaling socket is not connected"
+            )
             completion(false, error)
             return
         }
@@ -25,12 +49,18 @@ extension Call {
         // Check if call is in a valid state for ICE restart
         guard self.callState == .ACTIVE || self.callState == .CONNECTING else {
             Logger.log.w(message: "[ICE-RESTART] Call:: ICE restart skipped - call not in active state: \(self.callState)")
+            recordIceRestartEvent(
+                level: "warn",
+                message: "ICE restart skipped - call not in active state",
+                context: ["callState": callState.value]
+            )
             completion(false, NSError(domain: "Call", code: -2, userInfo: [NSLocalizedDescriptionKey: "Call not in active state"]))
             return
         }
         
         // Set ICE restart flag to prevent automatic answer
         self.isIceRestarting = true
+        recordIceRestartEvent(message: "ICE restart: initiated")
         
         // Mark that we need to reset audio after ICE restart to clear jitter buffers
         self.shouldResetAudioAfterIceRestart = true
@@ -44,6 +74,11 @@ extension Call {
             
             if let error = error {
                 Logger.log.e(message: "[ICE-RESTART] Call:: ICE restart failed: \(error)")
+                self.recordIceRestartEvent(
+                    level: "error",
+                    message: "ICE restart offer creation failed",
+                    context: ["error": error.localizedDescription]
+                )
                 
                 // Reset ICE restart flags
                 self.isIceRestarting = false
@@ -55,6 +90,10 @@ extension Call {
             
             guard let sdp = sdp else {
                 Logger.log.e(message: "[ICE-RESTART] Call:: ICE restart failed - no SDP generated")
+                self.recordIceRestartEvent(
+                    level: "error",
+                    message: "ICE restart failed - no SDP generated"
+                )
                 
                 // Reset ICE restart flags
                 self.isIceRestarting = false
@@ -68,6 +107,10 @@ extension Call {
             let iceRestartMessage = ICERestartMessage(sessionId: sessionId, callId: self.signalingCallId.uuidString, sdp: sdp.sdp)
             let message = iceRestartMessage.encode() ?? ""
             socket.sendMessage(message: message)
+            self.recordIceRestartEvent(
+                message: "ICE restart: sending \(self.useTrickleIce ? "trickle " : "")Modify with new offer SDP",
+                context: ["trickle": self.useTrickleIce]
+            )
 
             // Keep the restart in flight until the updateMedia answer is applied.
             // Sending an SDP offer is only a request, not successful recovery.
@@ -113,12 +156,23 @@ extension Call {
     internal func handleIceRestartResponse(message: Message, dataMessage: String, txClient: TxClient) {
         guard let result = message.result,
               let action = result["action"] as? String,
-              action == "updateMedia",
-              let sdp = result["sdp"] as? String else {
+              action == "updateMedia" else {
+            return
+        }
+
+        guard let sdp = result["sdp"] as? String else {
+            Logger.log.e(message: "[ICE-RESTART] Call:: ICE restart Modify response missing SDP")
+            recordIceRestartEvent(
+                level: "error",
+                message: "ICE restart Modify response missing SDP"
+            )
+            isIceRestarting = false
+            shouldResetAudioAfterIceRestart = false
             return
         }
         
         Logger.log.i(message: "[ICE-RESTART] Call:: Processing ICE restart response")
+        recordIceRestartEvent(message: "ICE restart Modify response received")
         
         // Set the new remote SDP from the ICE restart response as answer
         let remoteDescription = RTCSessionDescription(type: .answer, sdp: sdp)
@@ -127,6 +181,11 @@ extension Call {
             
             if let error = error {
                 Logger.log.e(message: "[ICE-RESTART] Call:: Error setting ICE restart remote description: \(error)")
+                self.recordIceRestartEvent(
+                    level: "error",
+                    message: "ICE restart remote SDP apply failed",
+                    context: ["error": error.localizedDescription]
+                )
                 
                 // Reset ICE restart flags
                 self.isIceRestarting = false
@@ -145,6 +204,7 @@ extension Call {
                 self.shouldResetAudioAfterIceRestart = false
                 
                 Logger.log.i(message: "[ICE-RESTART] Call:: ICE restart completed successfully - connection should be stable")
+                self.recordIceRestartEvent(message: "ICE restart remote SDP applied")
                 self.delegate?.callIceRestartCompleted(call: self)
             }
         })

--- a/TelnyxRTC/Telnyx/WebRTC/Call+IceRestart.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call+IceRestart.swift
@@ -161,6 +161,11 @@ extension Call {
         }
 
         guard let sdp = result["sdp"] as? String else {
+            let error = NSError(
+                domain: "Call",
+                code: -3,
+                userInfo: [NSLocalizedDescriptionKey: "ICE restart Modify response missing SDP"]
+            )
             Logger.log.e(message: "[ICE-RESTART] Call:: ICE restart Modify response missing SDP")
             recordIceRestartEvent(
                 level: "error",
@@ -168,6 +173,7 @@ extension Call {
             )
             isIceRestarting = false
             shouldResetAudioAfterIceRestart = false
+            delegate?.callIceRestartFailed(call: self, error: error)
             return
         }
         

--- a/TelnyxRTC/Telnyx/WebRTC/Call.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call.swift
@@ -1123,7 +1123,8 @@ extension Call {
             voiceSdkSessionId: self.sessionId,
             sdkVersion: Message.SDK_VERSION,
             startTimestamp: startTimestamp,
-            endTimestamp: endTimestamp
+            endTimestamp: endTimestamp,
+            clientSummary: callReportClientSummary()
         )
         
         // Get call_report_id and host
@@ -1168,7 +1169,8 @@ extension Call {
             telnyxLegId: self.telnyxLegId?.uuidString,
             voiceSdkSessionId: self.sessionId,
             sdkVersion: Message.SDK_VERSION,
-            startTimestamp: startTimestamp
+            startTimestamp: startTimestamp,
+            clientSummary: callReportClientSummary()
         )
 
         guard let payload = collector.flush(summary: summary) else { return }
@@ -1182,6 +1184,39 @@ extension Call {
         )
 
         Logger.log.i(message: "Call:: Flushed intermediate call report segment \(payload.segment ?? -1)")
+    }
+
+    /// Mirrors the JS SDK's call-report `clientSummary` while deliberately
+    /// excluding ICE usernames and credentials.
+    private func callReportClientSummary() -> CallReportClientSummary {
+        let iceServerSummaries = iceServers.map {
+            CallReportIceServerSummary(
+                urls: $0.urlStrings,
+                hasUsername: !($0.username?.isEmpty ?? true),
+                hasCredential: !($0.credential?.isEmpty ?? true)
+            )
+        }
+
+        return CallReportClientSummary(
+            connection: CallReportConnectionSummary(
+                host: socket?.signalingServer?.absoluteString
+            ),
+            media: CallReportMediaSummary(
+                audio: callOptions?.audio ?? true,
+                video: callOptions?.video ?? false,
+                mutedMicOnStart: false,
+                prefetchIceCandidates: false,
+                forceRelayCandidate: forceRelayCandidate,
+                trickleIce: useTrickleIce,
+                iceServers: iceServerSummaries
+            ),
+            callReports: CallReportSettingsSummary(
+                enabled: enableCallReports,
+                intervalMs: Int((callReportInterval * 1000).rounded()),
+                debugLogLevel: callReportLogLevel,
+                debugLogMaxEntries: callReportMaxLogEntries
+            )
+        )
     }
 }
 

--- a/TelnyxRTC/Telnyx/WebRTC/Peer.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Peer.swift
@@ -119,6 +119,11 @@ class Peer : NSObject, WebRTCEventHandler {
     /// Prevents sending duplicate endOfCandidates messages during trickle ICE
     private var endOfCandidatesSent: Bool = false
 
+    /// A delayed candidate-gathering callback can outlive call teardown because it
+    /// is scheduled on the main run loop. Keep an explicit lifecycle guard so it
+    /// cannot signal an already-ended server session.
+    private var isDisposed: Bool = false
+
     /// Queued candidates for answering side (until ANSWER is sent)
     /// When answering a call, we queue local ICE candidates until the ANSWER is sent
     /// to avoid race conditions where candidates arrive before the ANSWER
@@ -513,6 +518,11 @@ class Peer : NSObject, WebRTCEventHandler {
      - Sends SDP with all candidates included after timeout
      */
     fileprivate func startNegotiation(peerConnection: RTCPeerConnection, didGenerate candidate: RTCIceCandidate) {
+        guard !isDisposed else {
+            Logger.log.i(message: "[TRICKLE-ICE] Peer:: Skipping negotiation timer - peer is disposed")
+            return
+        }
+
         Logger.log.i(message: "[TRICKLE-ICE] Peer:: startNegotiation called (useTrickleIce: \(useTrickleIce))")
 
         // For Trickle ICE: restart timer to send endOfCandidates when no more candidates arrive
@@ -524,8 +534,17 @@ class Peer : NSObject, WebRTCEventHandler {
             self.negotiationTimer?.invalidate()
             self.negotiationTimer = nil
             DispatchQueue.main.async {
+                guard !self.isDisposed else {
+                    Logger.log.i(message: "[TRICKLE-ICE] Peer:: Skipping negotiation timer scheduling - peer is disposed")
+                    return
+                }
                 self.negotiationTimer = Timer.scheduledTimer(withTimeInterval: self.TRICKLE_ICE_TIMEOUT, repeats: false) { timer in
                     self.negotiationTimer?.invalidate()
+
+                    guard !self.isDisposed else {
+                        Logger.log.i(message: "[TRICKLE-ICE] Peer:: Skipping end of candidates - peer is disposed")
+                        return
+                    }
 
                     Logger.log.i(message: "[TRICKLE-ICE] Peer:: No more candidates for \(self.TRICKLE_ICE_TIMEOUT)s - sending endOfCandidates")
                     self.sendEndOfCandidates()
@@ -568,6 +587,12 @@ class Peer : NSObject, WebRTCEventHandler {
     func dispose() {
         Logger.log.i(message: "Peer:: dispose()")
 
+        // Invalidate before closing the connection. A timer block that was already
+        // queued on the main run loop also checks this flag before it can signal.
+        self.isDisposed = true
+        self.negotiationTimer?.invalidate()
+        self.negotiationTimer = nil
+
         self.connection?.close()
         self.delegate = nil
 
@@ -594,8 +619,6 @@ class Peer : NSObject, WebRTCEventHandler {
 
         // Reset trickle ICE state
         self.endOfCandidatesSent = false
-        self.negotiationTimer?.invalidate()
-        self.negotiationTimer = nil
 
         // Clear queued candidates and reset answering flags
         self.queuedCandidates.removeAll()
@@ -1160,6 +1183,11 @@ extension Peer : RTCPeerConnectionDelegate {
     
     /// Sends end of candidates signal for trickle ICE
     private func sendEndOfCandidates() {
+        guard !isDisposed else {
+            Logger.log.i(message: "[TRICKLE-ICE] Peer:: Skipping end of candidates - peer is disposed")
+            return
+        }
+
         guard let socket = socket, useTrickleIce else {
             Logger.log.i(message: "[TRICKLE-ICE] Peer:: Skipping end of candidates - socket: \(socket != nil), useTrickleIce: \(useTrickleIce)")
             return

--- a/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
@@ -460,6 +460,16 @@ public class TelnyxCallReportCollector {
     }
 
     private func parseStatsReport(_ report: RTCStatisticsReport) -> ParsedStats {
+        parseStatistics(
+            Dictionary(uniqueKeysWithValues: report.statistics.map { ($0.key, $0.value as CallReportStatisticsRecord) })
+        )
+    }
+
+    /// Parses the native WebRTC report after it has been normalized into the
+    /// small record type below. Keeping the selection/linking here makes the
+    /// production parser testable without fabricating unavailable RTCStatistics
+    /// Objective-C instances in unit tests.
+    private func parseStatistics(_ statistics: [String: CallReportStatisticsRecord]) -> ParsedStats {
         var outboundAudio: RTCOutboundRTPStreamStats?
         var inboundAudio: RTCInboundRTPStreamStats?
         var candidatePairs: [RTCIceCandidatePairStats] = []
@@ -468,34 +478,34 @@ public class TelnyxCallReportCollector {
         var remoteInbound: RTCRemoteInboundRTPStreamStats?
         var remoteOutbound: RTCRemoteOutboundRTPStreamStats?
 
-        for stats in report.statistics.values {
-            switch stats.type {
+        for stats in statistics.values {
+            switch stats.statsType {
             case "outbound-rtp":
-                if let kind = stats.values["kind"] as? String, kind == "audio" {
+                if let kind = stats.statsValues["kind"] as? String, kind == "audio" {
                     outboundAudio = RTCOutboundRTPStreamStats(stats)
                 }
             case "inbound-rtp":
-                if let kind = stats.values["kind"] as? String, kind == "audio" {
+                if let kind = stats.statsValues["kind"] as? String, kind == "audio" {
                     inboundAudio = RTCInboundRTPStreamStats(stats)
                 }
             case "candidate-pair":
-                let nominated = stats.values["nominated"] as? Bool ?? false
-                let state = stats.values["state"] as? String ?? ""
+                let nominated = stats.statsValues["nominated"] as? Bool ?? false
+                let state = stats.statsValues["state"] as? String ?? ""
                 if nominated || state == "succeeded" {
                     candidatePairs.append(RTCIceCandidatePairStats(stats))
                 }
             case "transport":
                 transport = RTCTransportStats(stats)
             case "media-playout":
-                if let kind = stats.values["kind"] as? String, kind == "audio" {
+                if let kind = stats.statsValues["kind"] as? String, kind == "audio" {
                     mediaPlayout = RTCMediaPlayoutStats(stats)
                 }
             case "remote-inbound-rtp":
-                if let kind = stats.values["kind"] as? String, kind == "audio" {
+                if let kind = stats.statsValues["kind"] as? String, kind == "audio" {
                     remoteInbound = RTCRemoteInboundRTPStreamStats(stats)
                 }
             case "remote-outbound-rtp":
-                if let kind = stats.values["kind"] as? String, kind == "audio" {
+                if let kind = stats.statsValues["kind"] as? String, kind == "audio" {
                     remoteOutbound = RTCRemoteOutboundRTPStreamStats(stats)
                 }
             default:
@@ -507,10 +517,10 @@ public class TelnyxCallReportCollector {
             candidatePairs.first { $0.id == selectedId }
         } ?? candidatePairs.last
         let localCandidate = candidatePair?.localCandidateId.flatMap { id in
-            report.statistics[id].map(RTCIceCandidateStats.init)
+            statistics[id].map(RTCIceCandidateStats.init)
         }
         let remoteCandidate = candidatePair?.remoteCandidateId.flatMap { id in
-            report.statistics[id].map(RTCIceCandidateStats.init)
+            statistics[id].map(RTCIceCandidateStats.init)
         }
 
         return ParsedStats(
@@ -523,6 +533,24 @@ public class TelnyxCallReportCollector {
             mediaPlayout: mediaPlayout,
             remoteInbound: remoteInbound,
             remoteOutbound: remoteOutbound
+        )
+    }
+
+    /// Exposes the production report-selection path to the module test target.
+    /// It deliberately returns only stable, externally meaningful fields.
+    internal func parsedStatisticsSnapshot(
+        _ records: [CallReportStatisticsRecord]
+    ) -> CallReportStatisticsSnapshot {
+        let parsed = parseStatistics(Dictionary(uniqueKeysWithValues: records.map { ($0.statsId, $0) }))
+        return CallReportStatisticsSnapshot(
+            inboundPacketsReceived: parsed.inbound?.packetsReceived,
+            inboundBytesReceived: parsed.inbound?.bytesReceived,
+            selectedCandidatePairId: parsed.candidate?.id,
+            localCandidateType: parsed.localCandidate?.candidateType,
+            localCandidateProtocol: parsed.localCandidate?.protocolType,
+            remoteCandidateType: parsed.remoteCandidate?.candidateType,
+            iceState: parsed.transport?.iceState,
+            dtlsState: parsed.transport?.dtlsState
         )
     }
 
@@ -808,6 +836,55 @@ public class TelnyxCallReportCollector {
 
 // MARK: - Helper Structs for RTCStatistics Parsing
 
+/// A normalized WebRTC statistics record used by the collector parser.
+///
+/// `RTCStatistics` cannot be constructed by Swift tests, so this type lets
+/// representative native report data exercise the same parser used in calls.
+internal protocol CallReportStatisticsRecord {
+    var statsId: String { get }
+    var statsType: String { get }
+    var statsTimestampMs: Double { get }
+    var statsValues: [String: Any] { get }
+}
+
+extension RTCStatistics: CallReportStatisticsRecord {
+    internal var statsId: String { id }
+    internal var statsType: String { type }
+    internal var statsTimestampMs: Double { timestamp_us / 1000.0 }
+    internal var statsValues: [String: Any] { values }
+}
+
+/// Fixture representation of one native `RTCStatistics` record.
+internal struct CallReportStatisticsFixture: CallReportStatisticsRecord {
+    internal let statsId: String
+    internal let statsType: String
+    internal let statsTimestampMs: Double
+    internal let statsValues: [String: Any]
+
+    internal init(
+        id: String,
+        type: String,
+        timestampMs: Double = 0,
+        values: [String: Any]
+    ) {
+        self.statsId = id
+        self.statsType = type
+        self.statsTimestampMs = timestampMs
+        self.statsValues = values
+    }
+}
+
+internal struct CallReportStatisticsSnapshot {
+    internal let inboundPacketsReceived: Int?
+    internal let inboundBytesReceived: Int?
+    internal let selectedCandidatePairId: String?
+    internal let localCandidateType: String?
+    internal let localCandidateProtocol: String?
+    internal let remoteCandidateType: String?
+    internal let iceState: String?
+    internal let dtlsState: String?
+}
+
 private struct RTCOutboundRTPStreamStats {
     let packetsSent: Int
     let bytesSent: Int
@@ -821,18 +898,18 @@ private struct RTCOutboundRTPStreamStats {
     let totalPacketSendDelay: Double?
     let active: Bool?
     
-    init(_ stats: RTCStatistics) {
-        self.packetsSent = stats.values["packetsSent"] as? Int ?? 0
-        self.bytesSent = stats.values["bytesSent"] as? Int ?? 0
-        self.trackId = stats.values["trackId"] as? String
-        self.timestamp = stats.timestamp_us / 1000.0
-        self.retransmittedPacketsSent = stats.values["retransmittedPacketsSent"] as? Int
-        self.retransmittedBytesSent = stats.values["retransmittedBytesSent"] as? Int
-        self.headerBytesSent = stats.values["headerBytesSent"] as? Int
-        self.nackCount = stats.values["nackCount"] as? Int
-        self.targetBitrate = stats.values["targetBitrate"] as? Double
-        self.totalPacketSendDelay = stats.values["totalPacketSendDelay"] as? Double
-        self.active = stats.values["active"] as? Bool
+    init(_ stats: CallReportStatisticsRecord) {
+        self.packetsSent = stats.statsValues["packetsSent"] as? Int ?? 0
+        self.bytesSent = stats.statsValues["bytesSent"] as? Int ?? 0
+        self.trackId = stats.statsValues["trackId"] as? String
+        self.timestamp = stats.statsTimestampMs
+        self.retransmittedPacketsSent = stats.statsValues["retransmittedPacketsSent"] as? Int
+        self.retransmittedBytesSent = stats.statsValues["retransmittedBytesSent"] as? Int
+        self.headerBytesSent = stats.statsValues["headerBytesSent"] as? Int
+        self.nackCount = stats.statsValues["nackCount"] as? Int
+        self.targetBitrate = stats.statsValues["targetBitrate"] as? Double
+        self.totalPacketSendDelay = stats.statsValues["totalPacketSendDelay"] as? Double
+        self.active = stats.statsValues["active"] as? Bool
     }
 }
 
@@ -861,30 +938,30 @@ private struct RTCInboundRTPStreamStats {
     let totalAudioEnergy: Double?
     let totalSamplesDuration: Double?
     
-    init(_ stats: RTCStatistics) {
-        self.packetsReceived = stats.values["packetsReceived"] as? Int ?? 0
-        self.bytesReceived = stats.values["bytesReceived"] as? Int ?? 0
-        self.packetsLost = stats.values["packetsLost"] as? Int ?? 0
-        self.packetsDiscarded = stats.values["packetsDiscarded"] as? Int
-        self.jitter = stats.values["jitter"] as? Double ?? 0
-        self.jitterBufferDelay = stats.values["jitterBufferDelay"] as? Double
-        self.jitterBufferEmittedCount = stats.values["jitterBufferEmittedCount"] as? Int
-        self.totalSamplesReceived = stats.values["totalSamplesReceived"] as? Int
-        self.concealedSamples = stats.values["concealedSamples"] as? Int
-        self.concealmentEvents = stats.values["concealmentEvents"] as? Int
-        self.trackId = stats.values["trackId"] as? String
-        self.timestamp = stats.timestamp_us / 1000.0
-        self.nackCount = stats.values["nackCount"] as? Int
-        self.headerBytesReceived = stats.values["headerBytesReceived"] as? Int
-        self.fecPacketsReceived = stats.values["fecPacketsReceived"] as? Int
-        self.fecPacketsDiscarded = stats.values["fecPacketsDiscarded"] as? Int
-        self.jitterBufferTargetDelay = stats.values["jitterBufferTargetDelay"] as? Double
-        self.jitterBufferMinimumDelay = stats.values["jitterBufferMinimumDelay"] as? Double
-        self.totalSamplesDecoded = stats.values["totalSamplesDecoded"] as? Int
-        self.samplesDecodedWithSilence = stats.values["samplesDecodedWithSilence"] as? Int
-        self.samplesDecodedWithConcealment = stats.values["samplesDecodedWithConcealment"] as? Int
-        self.totalAudioEnergy = stats.values["totalAudioEnergy"] as? Double
-        self.totalSamplesDuration = stats.values["totalSamplesDuration"] as? Double
+    init(_ stats: CallReportStatisticsRecord) {
+        self.packetsReceived = stats.statsValues["packetsReceived"] as? Int ?? 0
+        self.bytesReceived = stats.statsValues["bytesReceived"] as? Int ?? 0
+        self.packetsLost = stats.statsValues["packetsLost"] as? Int ?? 0
+        self.packetsDiscarded = stats.statsValues["packetsDiscarded"] as? Int
+        self.jitter = stats.statsValues["jitter"] as? Double ?? 0
+        self.jitterBufferDelay = stats.statsValues["jitterBufferDelay"] as? Double
+        self.jitterBufferEmittedCount = stats.statsValues["jitterBufferEmittedCount"] as? Int
+        self.totalSamplesReceived = stats.statsValues["totalSamplesReceived"] as? Int
+        self.concealedSamples = stats.statsValues["concealedSamples"] as? Int
+        self.concealmentEvents = stats.statsValues["concealmentEvents"] as? Int
+        self.trackId = stats.statsValues["trackId"] as? String
+        self.timestamp = stats.statsTimestampMs
+        self.nackCount = stats.statsValues["nackCount"] as? Int
+        self.headerBytesReceived = stats.statsValues["headerBytesReceived"] as? Int
+        self.fecPacketsReceived = stats.statsValues["fecPacketsReceived"] as? Int
+        self.fecPacketsDiscarded = stats.statsValues["fecPacketsDiscarded"] as? Int
+        self.jitterBufferTargetDelay = stats.statsValues["jitterBufferTargetDelay"] as? Double
+        self.jitterBufferMinimumDelay = stats.statsValues["jitterBufferMinimumDelay"] as? Double
+        self.totalSamplesDecoded = stats.statsValues["totalSamplesDecoded"] as? Int
+        self.samplesDecodedWithSilence = stats.statsValues["samplesDecodedWithSilence"] as? Int
+        self.samplesDecodedWithConcealment = stats.statsValues["samplesDecodedWithConcealment"] as? Int
+        self.totalAudioEnergy = stats.statsValues["totalAudioEnergy"] as? Double
+        self.totalSamplesDuration = stats.statsValues["totalSamplesDuration"] as? Double
     }
 }
 
@@ -903,20 +980,20 @@ private struct RTCIceCandidatePairStats {
     let requestsSent: Int?
     let responsesReceived: Int?
     
-    init(_ stats: RTCStatistics) {
-        self.id = stats.id
-        self.localCandidateId = stats.values["localCandidateId"] as? String
-        self.remoteCandidateId = stats.values["remoteCandidateId"] as? String
-        self.state = stats.values["state"] as? String
-        self.nominated = stats.values["nominated"] as? Bool
-        self.writable = stats.values["writable"] as? Bool
-        self.packetsSent = stats.values["packetsSent"] as? Int
-        self.packetsReceived = stats.values["packetsReceived"] as? Int
-        self.bytesSent = stats.values["bytesSent"] as? Int
-        self.bytesReceived = stats.values["bytesReceived"] as? Int
-        self.currentRoundTripTime = stats.values["currentRoundTripTime"] as? Double
-        self.requestsSent = stats.values["requestsSent"] as? Int
-        self.responsesReceived = stats.values["responsesReceived"] as? Int
+    init(_ stats: CallReportStatisticsRecord) {
+        self.id = stats.statsId
+        self.localCandidateId = stats.statsValues["localCandidateId"] as? String
+        self.remoteCandidateId = stats.statsValues["remoteCandidateId"] as? String
+        self.state = stats.statsValues["state"] as? String
+        self.nominated = stats.statsValues["nominated"] as? Bool
+        self.writable = stats.statsValues["writable"] as? Bool
+        self.packetsSent = stats.statsValues["packetsSent"] as? Int
+        self.packetsReceived = stats.statsValues["packetsReceived"] as? Int
+        self.bytesSent = stats.statsValues["bytesSent"] as? Int
+        self.bytesReceived = stats.statsValues["bytesReceived"] as? Int
+        self.currentRoundTripTime = stats.statsValues["currentRoundTripTime"] as? Double
+        self.requestsSent = stats.statsValues["requestsSent"] as? Int
+        self.responsesReceived = stats.statsValues["responsesReceived"] as? Int
     }
 }
 
@@ -930,15 +1007,15 @@ private struct RTCIceCandidateStats {
     let url: String?
     let relayProtocol: String?
 
-    init(_ stats: RTCStatistics) {
-        self.id = stats.id
-        self.address = (stats.values["address"] as? String) ?? (stats.values["ip"] as? String)
-        self.port = stats.values["port"] as? Int
-        self.candidateType = stats.values["candidateType"] as? String
-        self.protocolType = stats.values["protocol"] as? String
-        self.networkType = stats.values["networkType"] as? String
-        self.url = stats.values["url"] as? String
-        self.relayProtocol = stats.values["relayProtocol"] as? String
+    init(_ stats: CallReportStatisticsRecord) {
+        self.id = stats.statsId
+        self.address = (stats.statsValues["address"] as? String) ?? (stats.statsValues["ip"] as? String)
+        self.port = stats.statsValues["port"] as? Int
+        self.candidateType = stats.statsValues["candidateType"] as? String
+        self.protocolType = stats.statsValues["protocol"] as? String
+        self.networkType = stats.statsValues["networkType"] as? String
+        self.url = stats.statsValues["url"] as? String
+        self.relayProtocol = stats.statsValues["relayProtocol"] as? String
     }
 }
 
@@ -956,13 +1033,13 @@ private struct RTCTransportStats {
     let selectedCandidatePairChanges: Int?
     let selectedCandidatePairId: String?
 
-    init(_ stats: RTCStatistics) {
-        self.iceState = stats.values["iceState"] as? String
-        self.dtlsState = stats.values["dtlsState"] as? String
-        self.srtpCipher = stats.values["srtpCipher"] as? String
-        self.tlsVersion = stats.values["tlsVersion"] as? String
-        self.selectedCandidatePairChanges = stats.values["selectedCandidatePairChanges"] as? Int
-        self.selectedCandidatePairId = stats.values["selectedCandidatePairId"] as? String
+    init(_ stats: CallReportStatisticsRecord) {
+        self.iceState = stats.statsValues["iceState"] as? String
+        self.dtlsState = stats.statsValues["dtlsState"] as? String
+        self.srtpCipher = stats.statsValues["srtpCipher"] as? String
+        self.tlsVersion = stats.statsValues["tlsVersion"] as? String
+        self.selectedCandidatePairChanges = stats.statsValues["selectedCandidatePairChanges"] as? Int
+        self.selectedCandidatePairId = stats.statsValues["selectedCandidatePairId"] as? String
     }
 }
 
@@ -973,12 +1050,12 @@ private struct RTCMediaPlayoutStats {
     let totalSamplesCount: Int?
     let totalSamplesDuration: Double?
 
-    init(_ stats: RTCStatistics) {
-        self.synthesizedSamplesEvents = stats.values["synthesizedSamplesEvents"] as? Int
-        self.synthesizedSamplesDuration = stats.values["synthesizedSamplesDuration"] as? Double
-        self.totalPlayoutDelay = stats.values["totalPlayoutDelay"] as? Double
-        self.totalSamplesCount = stats.values["totalSamplesCount"] as? Int
-        self.totalSamplesDuration = stats.values["totalSamplesDuration"] as? Double
+    init(_ stats: CallReportStatisticsRecord) {
+        self.synthesizedSamplesEvents = stats.statsValues["synthesizedSamplesEvents"] as? Int
+        self.synthesizedSamplesDuration = stats.statsValues["synthesizedSamplesDuration"] as? Double
+        self.totalPlayoutDelay = stats.statsValues["totalPlayoutDelay"] as? Double
+        self.totalSamplesCount = stats.statsValues["totalSamplesCount"] as? Int
+        self.totalSamplesDuration = stats.statsValues["totalSamplesDuration"] as? Double
     }
 }
 
@@ -994,17 +1071,17 @@ private struct RTCRemoteInboundRTPStreamStats {
     let reportsReceived: Int?
     let packetsDiscarded: Int?
 
-    init(_ stats: RTCStatistics) {
-        self.packetsReceived = stats.values["packetsReceived"] as? Int
-        self.packetsLost = stats.values["packetsLost"] as? Int
-        self.fractionLost = stats.values["fractionLost"] as? Double
-        self.jitter = stats.values["jitter"] as? Double
-        self.roundTripTime = stats.values["roundTripTime"] as? Double
-        self.totalRoundTripTime = stats.values["totalRoundTripTime"] as? Double
-        self.roundTripTimeMeasurements = stats.values["roundTripTimeMeasurements"] as? Int
-        self.nackCount = stats.values["nackCount"] as? Int
-        self.reportsReceived = stats.values["reportsReceived"] as? Int
-        self.packetsDiscarded = stats.values["packetsDiscarded"] as? Int
+    init(_ stats: CallReportStatisticsRecord) {
+        self.packetsReceived = stats.statsValues["packetsReceived"] as? Int
+        self.packetsLost = stats.statsValues["packetsLost"] as? Int
+        self.fractionLost = stats.statsValues["fractionLost"] as? Double
+        self.jitter = stats.statsValues["jitter"] as? Double
+        self.roundTripTime = stats.statsValues["roundTripTime"] as? Double
+        self.totalRoundTripTime = stats.statsValues["totalRoundTripTime"] as? Double
+        self.roundTripTimeMeasurements = stats.statsValues["roundTripTimeMeasurements"] as? Int
+        self.nackCount = stats.statsValues["nackCount"] as? Int
+        self.reportsReceived = stats.statsValues["reportsReceived"] as? Int
+        self.packetsDiscarded = stats.statsValues["packetsDiscarded"] as? Int
     }
 }
 
@@ -1015,11 +1092,11 @@ private struct RTCRemoteOutboundRTPStreamStats {
     let roundTripTime: Double?
     let totalPacketSendDelay: Double?
 
-    init(_ stats: RTCStatistics) {
-        self.packetsSent = stats.values["packetsSent"] as? Int
-        self.bytesSent = stats.values["bytesSent"] as? Int
-        self.reportsCount = stats.values["reportsCount"] as? Int
-        self.roundTripTime = stats.values["roundTripTime"] as? Double
-        self.totalPacketSendDelay = stats.values["totalPacketSendDelay"] as? Double
+    init(_ stats: CallReportStatisticsRecord) {
+        self.packetsSent = stats.statsValues["packetsSent"] as? Int
+        self.bytesSent = stats.statsValues["bytesSent"] as? Int
+        self.reportsCount = stats.statsValues["reportsCount"] as? Int
+        self.roundTripTime = stats.statsValues["roundTripTime"] as? Double
+        self.totalPacketSendDelay = stats.statsValues["totalPacketSendDelay"] as? Double
     }
 }

--- a/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
@@ -409,6 +409,12 @@ public class TelnyxCallReportCollector {
         let outbound: RTCOutboundRTPStreamStats?
         let inbound: RTCInboundRTPStreamStats?
         let candidate: RTCIceCandidatePairStats?
+        let localCandidate: RTCIceCandidateStats?
+        let remoteCandidate: RTCIceCandidateStats?
+        let transport: RTCTransportStats?
+        let mediaPlayout: RTCMediaPlayoutStats?
+        let remoteInbound: RTCRemoteInboundRTPStreamStats?
+        let remoteOutbound: RTCRemoteOutboundRTPStreamStats?
     }
 
     private struct PreviousStats {
@@ -456,7 +462,11 @@ public class TelnyxCallReportCollector {
     private func parseStatsReport(_ report: RTCStatisticsReport) -> ParsedStats {
         var outboundAudio: RTCOutboundRTPStreamStats?
         var inboundAudio: RTCInboundRTPStreamStats?
-        var candidatePair: RTCIceCandidatePairStats?
+        var candidatePairs: [RTCIceCandidatePairStats] = []
+        var transport: RTCTransportStats?
+        var mediaPlayout: RTCMediaPlayoutStats?
+        var remoteInbound: RTCRemoteInboundRTPStreamStats?
+        var remoteOutbound: RTCRemoteOutboundRTPStreamStats?
 
         for stats in report.statistics.values {
             switch stats.type {
@@ -472,13 +482,48 @@ public class TelnyxCallReportCollector {
                 let nominated = stats.values["nominated"] as? Bool ?? false
                 let state = stats.values["state"] as? String ?? ""
                 if nominated || state == "succeeded" {
-                    candidatePair = RTCIceCandidatePairStats(stats)
+                    candidatePairs.append(RTCIceCandidatePairStats(stats))
+                }
+            case "transport":
+                transport = RTCTransportStats(stats)
+            case "media-playout":
+                if let kind = stats.values["kind"] as? String, kind == "audio" {
+                    mediaPlayout = RTCMediaPlayoutStats(stats)
+                }
+            case "remote-inbound-rtp":
+                if let kind = stats.values["kind"] as? String, kind == "audio" {
+                    remoteInbound = RTCRemoteInboundRTPStreamStats(stats)
+                }
+            case "remote-outbound-rtp":
+                if let kind = stats.values["kind"] as? String, kind == "audio" {
+                    remoteOutbound = RTCRemoteOutboundRTPStreamStats(stats)
                 }
             default:
                 break
             }
         }
-        return ParsedStats(outbound: outboundAudio, inbound: inboundAudio, candidate: candidatePair)
+
+        let candidatePair = transport?.selectedCandidatePairId.flatMap { selectedId in
+            candidatePairs.first { $0.id == selectedId }
+        } ?? candidatePairs.last
+        let localCandidate = candidatePair?.localCandidateId.flatMap { id in
+            report.statistics[id].map(RTCIceCandidateStats.init)
+        }
+        let remoteCandidate = candidatePair?.remoteCandidateId.flatMap { id in
+            report.statistics[id].map(RTCIceCandidateStats.init)
+        }
+
+        return ParsedStats(
+            outbound: outboundAudio,
+            inbound: inboundAudio,
+            candidate: candidatePair,
+            localCandidate: localCandidate,
+            remoteCandidate: remoteCandidate,
+            transport: transport,
+            mediaPlayout: mediaPlayout,
+            remoteInbound: remoteInbound,
+            remoteOutbound: remoteOutbound
+        )
     }
 
     private func accumulateSamples(
@@ -517,8 +562,10 @@ public class TelnyxCallReportCollector {
             previousStats.inboundBytes = inbound.bytesReceived
         }
 
-        if let candidate = parsed.candidate, candidate.currentRoundTripTime > 0 {
-            intervalRTTs.append(candidate.currentRoundTripTime)
+        if let candidate = parsed.candidate,
+           let currentRoundTripTime = candidate.currentRoundTripTime,
+           currentRoundTripTime > 0 {
+            intervalRTTs.append(currentRoundTripTime)
         }
 
         previousStats.timestamp = parsed.outbound?.timestamp ?? parsed.inbound?.timestamp ?? now.timeIntervalSince1970 * 1000
@@ -530,7 +577,13 @@ public class TelnyxCallReportCollector {
             end: end,
             outboundAudio: parsed.outbound,
             inboundAudio: parsed.inbound,
-            candidatePair: parsed.candidate
+            candidatePair: parsed.candidate,
+            localCandidate: parsed.localCandidate,
+            remoteCandidate: parsed.remoteCandidate,
+            transport: parsed.transport,
+            mediaPlayout: parsed.mediaPlayout,
+            remoteInbound: parsed.remoteInbound,
+            remoteOutbound: parsed.remoteOutbound
         )
 
         statsBuffer.append(statsEntry)
@@ -559,7 +612,13 @@ public class TelnyxCallReportCollector {
         end: Date,
         outboundAudio: RTCOutboundRTPStreamStats?,
         inboundAudio: RTCInboundRTPStreamStats?,
-        candidatePair: RTCIceCandidatePairStats?
+        candidatePair: RTCIceCandidatePairStats?,
+        localCandidate: RTCIceCandidateStats?,
+        remoteCandidate: RTCIceCandidateStats?,
+        transport: RTCTransportStats?,
+        mediaPlayout: RTCMediaPlayoutStats?,
+        remoteInbound: RTCRemoteInboundRTPStreamStats?,
+        remoteOutbound: RTCRemoteOutboundRTPStreamStats?
     ) -> CallReportInterval {
         
         var audioStats: AudioStats?
@@ -571,7 +630,14 @@ public class TelnyxCallReportCollector {
                 packetsSent: outbound.packetsSent,
                 bytesSent: outbound.bytesSent,
                 audioLevelAvg: average(intervalAudioLevels.outbound),
-                bitrateAvg: average(intervalBitrates.outbound)
+                bitrateAvg: average(intervalBitrates.outbound),
+                retransmittedPacketsSent: outbound.retransmittedPacketsSent,
+                retransmittedBytesSent: outbound.retransmittedBytesSent,
+                headerBytesSent: outbound.headerBytesSent,
+                nackCount: outbound.nackCount,
+                targetBitrate: outbound.targetBitrate,
+                totalPacketSendDelay: outbound.totalPacketSendDelay,
+                active: outbound.active
             )
         }
         
@@ -588,7 +654,18 @@ public class TelnyxCallReportCollector {
                 concealmentEvents: inbound.concealmentEvents,
                 audioLevelAvg: average(intervalAudioLevels.inbound),
                 jitterAvg: average(intervalJitters),
-                bitrateAvg: average(intervalBitrates.inbound)
+                bitrateAvg: average(intervalBitrates.inbound),
+                nackCount: inbound.nackCount,
+                headerBytesReceived: inbound.headerBytesReceived,
+                fecPacketsReceived: inbound.fecPacketsReceived,
+                fecPacketsDiscarded: inbound.fecPacketsDiscarded,
+                jitterBufferTargetDelay: inbound.jitterBufferTargetDelay,
+                jitterBufferMinimumDelay: inbound.jitterBufferMinimumDelay,
+                totalSamplesDecoded: inbound.totalSamplesDecoded,
+                samplesDecodedWithSilence: inbound.samplesDecodedWithSilence,
+                samplesDecodedWithConcealment: inbound.samplesDecodedWithConcealment,
+                totalAudioEnergy: inbound.totalAudioEnergy,
+                totalSamplesDuration: inbound.totalSamplesDuration
             )
         }
         
@@ -603,15 +680,94 @@ public class TelnyxCallReportCollector {
                 packetsSent: candidate.packetsSent,
                 packetsReceived: candidate.packetsReceived,
                 bytesSent: candidate.bytesSent,
-                bytesReceived: candidate.bytesReceived
+                bytesReceived: candidate.bytesReceived,
+                currentRoundTripTime: candidate.currentRoundTripTime,
+                roundTripTimeSource: candidate.currentRoundTripTime == nil ? nil : "candidate-pair.currentRoundTripTime"
             )
         }
+
+        let iceStats = candidatePair.map { candidate in
+            ICECandidatePairStats(
+                id: candidate.id,
+                localCandidateId: candidate.localCandidateId,
+                remoteCandidateId: candidate.remoteCandidateId,
+                state: candidate.state,
+                nominated: candidate.nominated,
+                writable: candidate.writable,
+                currentRoundTripTime: candidate.currentRoundTripTime,
+                requestsSent: candidate.requestsSent,
+                responsesReceived: candidate.responsesReceived,
+                local: localCandidate.map(ICECandidateStats.init),
+                remote: remoteCandidate.map(ICECandidateStats.init)
+            )
+        }
+
+        let transportStats = transport.map { stats in
+            TransportStats(
+                iceState: stats.iceState,
+                dtlsState: stats.dtlsState,
+                srtpCipher: stats.srtpCipher,
+                tlsVersion: stats.tlsVersion,
+                selectedCandidatePairChanges: stats.selectedCandidatePairChanges,
+                selectedCandidatePairId: stats.selectedCandidatePairId
+            )
+        }
+
+        let mediaPlayoutStats = mediaPlayout.map { stats in
+            MediaPlayoutStats(
+                synthesizedSamplesEvents: stats.synthesizedSamplesEvents,
+                synthesizedSamplesDuration: stats.synthesizedSamplesDuration,
+                totalPlayoutDelay: stats.totalPlayoutDelay,
+                totalSamplesCount: stats.totalSamplesCount,
+                totalSamplesDuration: stats.totalSamplesDuration
+            )
+        }
+
+        let remoteInboundStats = remoteInbound.map { stats -> RemoteInboundRTCPStats in
+            let rttAverage: Double?
+            if let total = stats.totalRoundTripTime,
+               let measurements = stats.roundTripTimeMeasurements,
+               measurements > 0 {
+                rttAverage = total / Double(measurements)
+            } else {
+                rttAverage = nil
+            }
+            return RemoteInboundRTCPStats(
+                packetsReceived: stats.packetsReceived,
+                packetsLost: stats.packetsLost,
+                fractionLost: stats.fractionLost,
+                jitter: stats.jitter.map { $0 * 1000 },
+                roundTripTime: stats.roundTripTime,
+                totalRoundTripTime: stats.totalRoundTripTime,
+                roundTripTimeMeasurements: stats.roundTripTimeMeasurements,
+                roundTripTimeAvg: rttAverage,
+                nackCount: stats.nackCount,
+                reportsReceived: stats.reportsReceived,
+                packetsDiscarded: stats.packetsDiscarded
+            )
+        }
+        let remoteOutboundStats = remoteOutbound.map { stats in
+            RemoteOutboundRTCPStats(
+                packetsSent: stats.packetsSent,
+                bytesSent: stats.bytesSent,
+                reportsCount: stats.reportsCount,
+                roundTripTime: stats.roundTripTime,
+                totalPacketSendDelay: stats.totalPacketSendDelay
+            )
+        }
+        let remoteRtcpStats = (remoteInboundStats != nil || remoteOutboundStats != nil)
+            ? RemoteRTCPStats(inbound: remoteInboundStats, outbound: remoteOutboundStats)
+            : nil
         
         return CallReportInterval(
             intervalStartUtc: Self.iso8601Formatter.string(from: start),
             intervalEndUtc: Self.iso8601Formatter.string(from: end),
             audio: audioStats,
-            connection: connectionStats
+            connection: connectionStats,
+            ice: iceStats,
+            transport: transportStats,
+            mediaPlayout: mediaPlayoutStats,
+            remoteRtcp: remoteRtcpStats
         )
     }
     
@@ -657,12 +813,26 @@ private struct RTCOutboundRTPStreamStats {
     let bytesSent: Int
     let trackId: String?
     let timestamp: Double
+    let retransmittedPacketsSent: Int?
+    let retransmittedBytesSent: Int?
+    let headerBytesSent: Int?
+    let nackCount: Int?
+    let targetBitrate: Double?
+    let totalPacketSendDelay: Double?
+    let active: Bool?
     
     init(_ stats: RTCStatistics) {
         self.packetsSent = stats.values["packetsSent"] as? Int ?? 0
         self.bytesSent = stats.values["bytesSent"] as? Int ?? 0
         self.trackId = stats.values["trackId"] as? String
         self.timestamp = stats.timestamp_us / 1000.0
+        self.retransmittedPacketsSent = stats.values["retransmittedPacketsSent"] as? Int
+        self.retransmittedBytesSent = stats.values["retransmittedBytesSent"] as? Int
+        self.headerBytesSent = stats.values["headerBytesSent"] as? Int
+        self.nackCount = stats.values["nackCount"] as? Int
+        self.targetBitrate = stats.values["targetBitrate"] as? Double
+        self.totalPacketSendDelay = stats.values["totalPacketSendDelay"] as? Double
+        self.active = stats.values["active"] as? Bool
     }
 }
 
@@ -679,6 +849,17 @@ private struct RTCInboundRTPStreamStats {
     let concealmentEvents: Int?
     let trackId: String?
     let timestamp: Double
+    let nackCount: Int?
+    let headerBytesReceived: Int?
+    let fecPacketsReceived: Int?
+    let fecPacketsDiscarded: Int?
+    let jitterBufferTargetDelay: Double?
+    let jitterBufferMinimumDelay: Double?
+    let totalSamplesDecoded: Int?
+    let samplesDecodedWithSilence: Int?
+    let samplesDecodedWithConcealment: Int?
+    let totalAudioEnergy: Double?
+    let totalSamplesDuration: Double?
     
     init(_ stats: RTCStatistics) {
         self.packetsReceived = stats.values["packetsReceived"] as? Int ?? 0
@@ -693,21 +874,152 @@ private struct RTCInboundRTPStreamStats {
         self.concealmentEvents = stats.values["concealmentEvents"] as? Int
         self.trackId = stats.values["trackId"] as? String
         self.timestamp = stats.timestamp_us / 1000.0
+        self.nackCount = stats.values["nackCount"] as? Int
+        self.headerBytesReceived = stats.values["headerBytesReceived"] as? Int
+        self.fecPacketsReceived = stats.values["fecPacketsReceived"] as? Int
+        self.fecPacketsDiscarded = stats.values["fecPacketsDiscarded"] as? Int
+        self.jitterBufferTargetDelay = stats.values["jitterBufferTargetDelay"] as? Double
+        self.jitterBufferMinimumDelay = stats.values["jitterBufferMinimumDelay"] as? Double
+        self.totalSamplesDecoded = stats.values["totalSamplesDecoded"] as? Int
+        self.samplesDecodedWithSilence = stats.values["samplesDecodedWithSilence"] as? Int
+        self.samplesDecodedWithConcealment = stats.values["samplesDecodedWithConcealment"] as? Int
+        self.totalAudioEnergy = stats.values["totalAudioEnergy"] as? Double
+        self.totalSamplesDuration = stats.values["totalSamplesDuration"] as? Double
     }
 }
 
 private struct RTCIceCandidatePairStats {
+    let id: String
+    let localCandidateId: String?
+    let remoteCandidateId: String?
+    let state: String?
+    let nominated: Bool?
+    let writable: Bool?
     let packetsSent: Int?
     let packetsReceived: Int?
     let bytesSent: Int?
     let bytesReceived: Int?
-    let currentRoundTripTime: Double
+    let currentRoundTripTime: Double?
+    let requestsSent: Int?
+    let responsesReceived: Int?
     
     init(_ stats: RTCStatistics) {
+        self.id = stats.id
+        self.localCandidateId = stats.values["localCandidateId"] as? String
+        self.remoteCandidateId = stats.values["remoteCandidateId"] as? String
+        self.state = stats.values["state"] as? String
+        self.nominated = stats.values["nominated"] as? Bool
+        self.writable = stats.values["writable"] as? Bool
         self.packetsSent = stats.values["packetsSent"] as? Int
         self.packetsReceived = stats.values["packetsReceived"] as? Int
         self.bytesSent = stats.values["bytesSent"] as? Int
         self.bytesReceived = stats.values["bytesReceived"] as? Int
-        self.currentRoundTripTime = stats.values["currentRoundTripTime"] as? Double ?? 0
+        self.currentRoundTripTime = stats.values["currentRoundTripTime"] as? Double
+        self.requestsSent = stats.values["requestsSent"] as? Int
+        self.responsesReceived = stats.values["responsesReceived"] as? Int
+    }
+}
+
+private struct RTCIceCandidateStats {
+    let id: String
+    let address: String?
+    let port: Int?
+    let candidateType: String?
+    let protocolType: String?
+    let networkType: String?
+    let url: String?
+    let relayProtocol: String?
+
+    init(_ stats: RTCStatistics) {
+        self.id = stats.id
+        self.address = (stats.values["address"] as? String) ?? (stats.values["ip"] as? String)
+        self.port = stats.values["port"] as? Int
+        self.candidateType = stats.values["candidateType"] as? String
+        self.protocolType = stats.values["protocol"] as? String
+        self.networkType = stats.values["networkType"] as? String
+        self.url = stats.values["url"] as? String
+        self.relayProtocol = stats.values["relayProtocol"] as? String
+    }
+}
+
+private extension ICECandidateStats {
+    init(_ stats: RTCIceCandidateStats) {
+        self.init(id: stats.id, address: stats.address, port: stats.port, candidateType: stats.candidateType, protocolType: stats.protocolType, networkType: stats.networkType, url: stats.url, relayProtocol: stats.relayProtocol)
+    }
+}
+
+private struct RTCTransportStats {
+    let iceState: String?
+    let dtlsState: String?
+    let srtpCipher: String?
+    let tlsVersion: String?
+    let selectedCandidatePairChanges: Int?
+    let selectedCandidatePairId: String?
+
+    init(_ stats: RTCStatistics) {
+        self.iceState = stats.values["iceState"] as? String
+        self.dtlsState = stats.values["dtlsState"] as? String
+        self.srtpCipher = stats.values["srtpCipher"] as? String
+        self.tlsVersion = stats.values["tlsVersion"] as? String
+        self.selectedCandidatePairChanges = stats.values["selectedCandidatePairChanges"] as? Int
+        self.selectedCandidatePairId = stats.values["selectedCandidatePairId"] as? String
+    }
+}
+
+private struct RTCMediaPlayoutStats {
+    let synthesizedSamplesEvents: Int?
+    let synthesizedSamplesDuration: Double?
+    let totalPlayoutDelay: Double?
+    let totalSamplesCount: Int?
+    let totalSamplesDuration: Double?
+
+    init(_ stats: RTCStatistics) {
+        self.synthesizedSamplesEvents = stats.values["synthesizedSamplesEvents"] as? Int
+        self.synthesizedSamplesDuration = stats.values["synthesizedSamplesDuration"] as? Double
+        self.totalPlayoutDelay = stats.values["totalPlayoutDelay"] as? Double
+        self.totalSamplesCount = stats.values["totalSamplesCount"] as? Int
+        self.totalSamplesDuration = stats.values["totalSamplesDuration"] as? Double
+    }
+}
+
+private struct RTCRemoteInboundRTPStreamStats {
+    let packetsReceived: Int?
+    let packetsLost: Int?
+    let fractionLost: Double?
+    let jitter: Double?
+    let roundTripTime: Double?
+    let totalRoundTripTime: Double?
+    let roundTripTimeMeasurements: Int?
+    let nackCount: Int?
+    let reportsReceived: Int?
+    let packetsDiscarded: Int?
+
+    init(_ stats: RTCStatistics) {
+        self.packetsReceived = stats.values["packetsReceived"] as? Int
+        self.packetsLost = stats.values["packetsLost"] as? Int
+        self.fractionLost = stats.values["fractionLost"] as? Double
+        self.jitter = stats.values["jitter"] as? Double
+        self.roundTripTime = stats.values["roundTripTime"] as? Double
+        self.totalRoundTripTime = stats.values["totalRoundTripTime"] as? Double
+        self.roundTripTimeMeasurements = stats.values["roundTripTimeMeasurements"] as? Int
+        self.nackCount = stats.values["nackCount"] as? Int
+        self.reportsReceived = stats.values["reportsReceived"] as? Int
+        self.packetsDiscarded = stats.values["packetsDiscarded"] as? Int
+    }
+}
+
+private struct RTCRemoteOutboundRTPStreamStats {
+    let packetsSent: Int?
+    let bytesSent: Int?
+    let reportsCount: Int?
+    let roundTripTime: Double?
+    let totalPacketSendDelay: Double?
+
+    init(_ stats: RTCStatistics) {
+        self.packetsSent = stats.values["packetsSent"] as? Int
+        self.bytesSent = stats.values["bytesSent"] as? Int
+        self.reportsCount = stats.values["reportsCount"] as? Int
+        self.roundTripTime = stats.values["roundTripTime"] as? Double
+        self.totalPacketSendDelay = stats.values["totalPacketSendDelay"] as? Double
     }
 }

--- a/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
@@ -415,6 +415,9 @@ public class TelnyxCallReportCollector {
         let mediaPlayout: RTCMediaPlayoutStats?
         let remoteInbound: RTCRemoteInboundRTPStreamStats?
         let remoteOutbound: RTCRemoteOutboundRTPStreamStats?
+        let outboundCodec: RTCCodecStats?
+        let inboundCodec: RTCCodecStats?
+        let outboundMediaSource: RTCMediaSourceStats?
     }
 
     private struct PreviousStats {
@@ -477,6 +480,8 @@ public class TelnyxCallReportCollector {
         var mediaPlayout: RTCMediaPlayoutStats?
         var remoteInbound: RTCRemoteInboundRTPStreamStats?
         var remoteOutbound: RTCRemoteOutboundRTPStreamStats?
+        var codecs: [String: RTCCodecStats] = [:]
+        var mediaSources: [String: RTCMediaSourceStats] = [:]
 
         for stats in statistics.values {
             switch stats.statsType {
@@ -508,6 +513,12 @@ public class TelnyxCallReportCollector {
                 if let kind = stats.statsValues["kind"] as? String, kind == "audio" {
                     remoteOutbound = RTCRemoteOutboundRTPStreamStats(stats)
                 }
+            case "codec":
+                codecs[stats.statsId] = RTCCodecStats(stats)
+            case "media-source":
+                if let kind = stats.statsValues["kind"] as? String, kind == "audio" {
+                    mediaSources[stats.statsId] = RTCMediaSourceStats(stats)
+                }
             default:
                 break
             }
@@ -522,6 +533,9 @@ public class TelnyxCallReportCollector {
         let remoteCandidate = candidatePair?.remoteCandidateId.flatMap { id in
             statistics[id].map(RTCIceCandidateStats.init)
         }
+        let outboundCodec = outboundAudio?.codecId.flatMap { codecs[$0] }
+        let inboundCodec = inboundAudio?.codecId.flatMap { codecs[$0] }
+        let outboundMediaSource = outboundAudio?.mediaSourceId.flatMap { mediaSources[$0] }
 
         return ParsedStats(
             outbound: outboundAudio,
@@ -532,7 +546,10 @@ public class TelnyxCallReportCollector {
             transport: transport,
             mediaPlayout: mediaPlayout,
             remoteInbound: remoteInbound,
-            remoteOutbound: remoteOutbound
+            remoteOutbound: remoteOutbound,
+            outboundCodec: outboundCodec,
+            inboundCodec: inboundCodec,
+            outboundMediaSource: outboundMediaSource
         )
     }
 
@@ -550,7 +567,9 @@ public class TelnyxCallReportCollector {
             localCandidateProtocol: parsed.localCandidate?.protocolType,
             remoteCandidateType: parsed.remoteCandidate?.candidateType,
             iceState: parsed.transport?.iceState,
-            dtlsState: parsed.transport?.dtlsState
+            dtlsState: parsed.transport?.dtlsState,
+            outboundCodecMimeType: parsed.outboundCodec?.mimeType,
+            outboundMediaSourceAudioLevel: parsed.outboundMediaSource?.audioLevel
         )
     }
 
@@ -611,7 +630,10 @@ public class TelnyxCallReportCollector {
             transport: parsed.transport,
             mediaPlayout: parsed.mediaPlayout,
             remoteInbound: parsed.remoteInbound,
-            remoteOutbound: parsed.remoteOutbound
+            remoteOutbound: parsed.remoteOutbound,
+            outboundCodec: parsed.outboundCodec,
+            inboundCodec: parsed.inboundCodec,
+            outboundMediaSource: parsed.outboundMediaSource
         )
 
         statsBuffer.append(statsEntry)
@@ -646,7 +668,10 @@ public class TelnyxCallReportCollector {
         transport: RTCTransportStats?,
         mediaPlayout: RTCMediaPlayoutStats?,
         remoteInbound: RTCRemoteInboundRTPStreamStats?,
-        remoteOutbound: RTCRemoteOutboundRTPStreamStats?
+        remoteOutbound: RTCRemoteOutboundRTPStreamStats?,
+        outboundCodec: RTCCodecStats?,
+        inboundCodec: RTCCodecStats?,
+        outboundMediaSource: RTCMediaSourceStats?
     ) -> CallReportInterval {
         
         var audioStats: AudioStats?
@@ -665,7 +690,9 @@ public class TelnyxCallReportCollector {
                 nackCount: outbound.nackCount,
                 targetBitrate: outbound.targetBitrate,
                 totalPacketSendDelay: outbound.totalPacketSendDelay,
-                active: outbound.active
+                active: outbound.active,
+                codec: outboundCodec.map(AudioCodecStats.init),
+                mediaSource: outboundMediaSource.map(AudioMediaSourceStats.init)
             )
         }
         
@@ -693,7 +720,8 @@ public class TelnyxCallReportCollector {
                 samplesDecodedWithSilence: inbound.samplesDecodedWithSilence,
                 samplesDecodedWithConcealment: inbound.samplesDecodedWithConcealment,
                 totalAudioEnergy: inbound.totalAudioEnergy,
-                totalSamplesDuration: inbound.totalSamplesDuration
+                totalSamplesDuration: inbound.totalSamplesDuration,
+                codec: inboundCodec.map(AudioCodecStats.init)
             )
         }
         
@@ -883,6 +911,8 @@ internal struct CallReportStatisticsSnapshot {
     internal let remoteCandidateType: String?
     internal let iceState: String?
     internal let dtlsState: String?
+    internal let outboundCodecMimeType: String?
+    internal let outboundMediaSourceAudioLevel: Double?
 }
 
 private struct RTCOutboundRTPStreamStats {
@@ -897,6 +927,8 @@ private struct RTCOutboundRTPStreamStats {
     let targetBitrate: Double?
     let totalPacketSendDelay: Double?
     let active: Bool?
+    let codecId: String?
+    let mediaSourceId: String?
     
     init(_ stats: CallReportStatisticsRecord) {
         self.packetsSent = stats.statsValues["packetsSent"] as? Int ?? 0
@@ -910,6 +942,8 @@ private struct RTCOutboundRTPStreamStats {
         self.targetBitrate = stats.statsValues["targetBitrate"] as? Double
         self.totalPacketSendDelay = stats.statsValues["totalPacketSendDelay"] as? Double
         self.active = stats.statsValues["active"] as? Bool
+        self.codecId = stats.statsValues["codecId"] as? String
+        self.mediaSourceId = stats.statsValues["mediaSourceId"] as? String
     }
 }
 
@@ -937,6 +971,7 @@ private struct RTCInboundRTPStreamStats {
     let samplesDecodedWithConcealment: Int?
     let totalAudioEnergy: Double?
     let totalSamplesDuration: Double?
+    let codecId: String?
     
     init(_ stats: CallReportStatisticsRecord) {
         self.packetsReceived = stats.statsValues["packetsReceived"] as? Int ?? 0
@@ -962,6 +997,72 @@ private struct RTCInboundRTPStreamStats {
         self.samplesDecodedWithConcealment = stats.statsValues["samplesDecodedWithConcealment"] as? Int
         self.totalAudioEnergy = stats.statsValues["totalAudioEnergy"] as? Double
         self.totalSamplesDuration = stats.statsValues["totalSamplesDuration"] as? Double
+        self.codecId = stats.statsValues["codecId"] as? String
+    }
+}
+
+private struct RTCCodecStats {
+    let id: String
+    let mimeType: String?
+    let payloadType: Int?
+    let clockRate: Int?
+    let channels: Int?
+    let sdpFmtpLine: String?
+
+    init(_ stats: CallReportStatisticsRecord) {
+        self.id = stats.statsId
+        self.mimeType = stats.statsValues["mimeType"] as? String
+        self.payloadType = stats.statsValues["payloadType"] as? Int
+        self.clockRate = stats.statsValues["clockRate"] as? Int
+        self.channels = stats.statsValues["channels"] as? Int
+        self.sdpFmtpLine = stats.statsValues["sdpFmtpLine"] as? String
+    }
+}
+
+private extension AudioCodecStats {
+    init(_ stats: RTCCodecStats) {
+        self.init(
+            codecId: stats.id,
+            mimeType: stats.mimeType,
+            payloadType: stats.payloadType,
+            clockRate: stats.clockRate,
+            channels: stats.channels,
+            sdpFmtpLine: stats.sdpFmtpLine
+        )
+    }
+}
+
+private struct RTCMediaSourceStats {
+    let id: String
+    let audioLevel: Double?
+    let totalAudioEnergy: Double?
+    let totalSamplesDuration: Double?
+    let echoReturnLoss: Double?
+    let echoReturnLossEnhancement: Double?
+    let trackIdentifier: String?
+
+    init(_ stats: CallReportStatisticsRecord) {
+        self.id = stats.statsId
+        self.audioLevel = stats.statsValues["audioLevel"] as? Double
+        self.totalAudioEnergy = stats.statsValues["totalAudioEnergy"] as? Double
+        self.totalSamplesDuration = stats.statsValues["totalSamplesDuration"] as? Double
+        self.echoReturnLoss = stats.statsValues["echoReturnLoss"] as? Double
+        self.echoReturnLossEnhancement = stats.statsValues["echoReturnLossEnhancement"] as? Double
+        self.trackIdentifier = stats.statsValues["trackIdentifier"] as? String
+    }
+}
+
+private extension AudioMediaSourceStats {
+    init(_ stats: RTCMediaSourceStats) {
+        self.init(
+            id: stats.id,
+            audioLevel: stats.audioLevel,
+            totalAudioEnergy: stats.totalAudioEnergy,
+            totalSamplesDuration: stats.totalSamplesDuration,
+            echoReturnLoss: stats.echoReturnLoss,
+            echoReturnLossEnhancement: stats.echoReturnLossEnhancement,
+            trackIdentifier: stats.trackIdentifier
+        )
     }
 }
 

--- a/TelnyxRTCTests/WebRTC/CallReportCollectorTests.swift
+++ b/TelnyxRTCTests/WebRTC/CallReportCollectorTests.swift
@@ -331,14 +331,6 @@ class CallReportCollectorTests: XCTestCase {
     
     func testCallReportPayloadStructure() {
         collector.start(peerConnection: mockPeerConnection)
-        
-        // Wait for stats
-        let statsExpectation = expectation(description: "Stats")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-            statsExpectation.fulfill()
-        }
-        wait(for: [statsExpectation], timeout: 1.0)
-        
         collector.stop()
         
         let summary = CallReportSummary(

--- a/TelnyxRTCTests/WebRTC/CallReportCollectorTests.swift
+++ b/TelnyxRTCTests/WebRTC/CallReportCollectorTests.swift
@@ -58,6 +58,46 @@ class CallReportCollectorTests: XCTestCase {
         disabledCollector.start(peerConnection: mockPeerConnection)
         disabledCollector.stop()
     }
+
+    func testClientSummaryEncodesSanitizedIceServerConfiguration() throws {
+        let summary = CallReportSummary(
+            callId: "call-id",
+            clientSummary: CallReportClientSummary(
+                connection: CallReportConnectionSummary(host: "wss://rtc.telnyx.com"),
+                media: CallReportMediaSummary(
+                    audio: true,
+                    video: false,
+                    forceRelayCandidate: false,
+                    trickleIce: true,
+                    iceServers: [
+                        CallReportIceServerSummary(
+                            urls: ["turns:turn.telnyx.com:443"],
+                            hasUsername: true,
+                            hasCredential: true
+                        )
+                    ]
+                ),
+                callReports: CallReportSettingsSummary(
+                    enabled: true,
+                    intervalMs: 5000,
+                    debugLogLevel: "debug",
+                    debugLogMaxEntries: 1000
+                )
+            )
+        )
+
+        let data = try JSONEncoder().encode(summary)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let clientSummary = try XCTUnwrap(json["clientSummary"] as? [String: Any])
+        let media = try XCTUnwrap(clientSummary["media"] as? [String: Any])
+        let iceServer = try XCTUnwrap((media["iceServers"] as? [[String: Any]])?.first)
+
+        XCTAssertEqual(iceServer["urls"] as? [String], ["turns:turn.telnyx.com:443"])
+        XCTAssertEqual(iceServer["hasUsername"] as? Bool, true)
+        XCTAssertEqual(iceServer["hasCredential"] as? Bool, true)
+        XCTAssertNil(iceServer["username"])
+        XCTAssertNil(iceServer["credential"])
+    }
     
     // MARK: - Start/Stop Tests
     

--- a/TelnyxRTCTests/WebRTC/CallReportCollectorTests.swift
+++ b/TelnyxRTCTests/WebRTC/CallReportCollectorTests.swift
@@ -398,6 +398,36 @@ class CallReportCollectorTests: XCTestCase {
                 ]
             ),
             CallReportStatisticsFixture(
+                id: "outbound-audio",
+                type: "outbound-rtp",
+                values: [
+                    "kind": "audio",
+                    "packetsSent": 24,
+                    "bytesSent": 4_096,
+                    "codecId": "opus-codec",
+                    "mediaSourceId": "mic-source"
+                ]
+            ),
+            CallReportStatisticsFixture(
+                id: "opus-codec",
+                type: "codec",
+                values: [
+                    "mimeType": "audio/opus",
+                    "payloadType": 111,
+                    "clockRate": 48_000,
+                    "channels": 2
+                ]
+            ),
+            CallReportStatisticsFixture(
+                id: "mic-source",
+                type: "media-source",
+                values: [
+                    "kind": "audio",
+                    "audioLevel": 0.125,
+                    "totalAudioEnergy": 42.5
+                ]
+            ),
+            CallReportStatisticsFixture(
                 id: "selected-pair",
                 type: "candidate-pair",
                 values: [
@@ -436,6 +466,8 @@ class CallReportCollectorTests: XCTestCase {
         XCTAssertEqual(snapshot.remoteCandidateType, "host")
         XCTAssertEqual(snapshot.iceState, "connected")
         XCTAssertEqual(snapshot.dtlsState, "connected")
+        XCTAssertEqual(snapshot.outboundCodecMimeType, "audio/opus")
+        XCTAssertEqual(snapshot.outboundMediaSourceAudioLevel, 0.125)
     }
     
     func testCollectorHandlesLongCalls() {

--- a/TelnyxRTCTests/WebRTC/CallReportCollectorTests.swift
+++ b/TelnyxRTCTests/WebRTC/CallReportCollectorTests.swift
@@ -334,6 +334,55 @@ class CallReportCollectorTests: XCTestCase {
             XCTFail("Failed to encode payload: \(error)")
         }
     }
+
+    func testIntervalEncodesJSCompatibleIceAndTransportStats() throws {
+        let local = ICECandidateStats(
+            id: "local-candidate",
+            address: "10.0.0.2",
+            port: 54543,
+            candidateType: "relay",
+            protocolType: "udp",
+            networkType: "wifi",
+            url: "turn:turn.telnyx.com:3478",
+            relayProtocol: "udp"
+        )
+        let ice = ICECandidatePairStats(
+            id: "candidate-pair",
+            localCandidateId: "local-candidate",
+            remoteCandidateId: "remote-candidate",
+            state: "succeeded",
+            nominated: true,
+            writable: true,
+            currentRoundTripTime: 0.125,
+            requestsSent: 7,
+            responsesReceived: 7,
+            local: local
+        )
+        let transport = TransportStats(
+            iceState: "connected",
+            dtlsState: "connected",
+            srtpCipher: "AES_CM_128_HMAC_SHA1_80",
+            tlsVersion: "FEFD",
+            selectedCandidatePairChanges: 1,
+            selectedCandidatePairId: "candidate-pair"
+        )
+        let interval = CallReportInterval(
+            intervalStartUtc: "2026-08-19T10:00:00.000Z",
+            intervalEndUtc: "2026-08-19T10:00:05.000Z",
+            ice: ice,
+            transport: transport
+        )
+
+        let json = try JSONSerialization.jsonObject(with: JSONEncoder().encode(interval)) as? [String: Any]
+        let encodedIce = try XCTUnwrap(json?["ice"] as? [String: Any])
+        let encodedLocal = try XCTUnwrap(encodedIce["local"] as? [String: Any])
+        let encodedTransport = try XCTUnwrap(json?["transport"] as? [String: Any])
+
+        XCTAssertEqual(encodedIce["localCandidateId"] as? String, "local-candidate")
+        XCTAssertEqual(encodedLocal["protocol"] as? String, "udp")
+        XCTAssertEqual(encodedTransport["selectedCandidatePairId"] as? String, "candidate-pair")
+        XCTAssertEqual(encodedTransport["iceState"] as? String, "connected")
+    }
     
     func testCollectorHandlesLongCalls() {
         // Simulate a scenario where stats buffer could grow large

--- a/TelnyxRTCTests/WebRTC/CallReportCollectorTests.swift
+++ b/TelnyxRTCTests/WebRTC/CallReportCollectorTests.swift
@@ -383,6 +383,60 @@ class CallReportCollectorTests: XCTestCase {
         XCTAssertEqual(encodedTransport["selectedCandidatePairId"] as? String, "candidate-pair")
         XCTAssertEqual(encodedTransport["iceState"] as? String, "connected")
     }
+
+    func testParserMapsRepresentativeRTCStatisticsFixture() {
+        let snapshot = collector.parsedStatisticsSnapshot([
+            CallReportStatisticsFixture(
+                id: "inbound-audio",
+                type: "inbound-rtp",
+                timestampMs: 5_000,
+                values: [
+                    "kind": "audio",
+                    "packetsReceived": 42,
+                    "bytesReceived": 8_192,
+                    "jitter": 0.012
+                ]
+            ),
+            CallReportStatisticsFixture(
+                id: "selected-pair",
+                type: "candidate-pair",
+                values: [
+                    "state": "succeeded",
+                    "nominated": true,
+                    "localCandidateId": "local-relay",
+                    "remoteCandidateId": "remote-host"
+                ]
+            ),
+            CallReportStatisticsFixture(
+                id: "local-relay",
+                type: "local-candidate",
+                values: ["candidateType": "relay", "protocol": "tcp"]
+            ),
+            CallReportStatisticsFixture(
+                id: "remote-host",
+                type: "remote-candidate",
+                values: ["candidateType": "host"]
+            ),
+            CallReportStatisticsFixture(
+                id: "transport",
+                type: "transport",
+                values: [
+                    "selectedCandidatePairId": "selected-pair",
+                    "iceState": "connected",
+                    "dtlsState": "connected"
+                ]
+            )
+        ])
+
+        XCTAssertEqual(snapshot.inboundPacketsReceived, 42)
+        XCTAssertEqual(snapshot.inboundBytesReceived, 8_192)
+        XCTAssertEqual(snapshot.selectedCandidatePairId, "selected-pair")
+        XCTAssertEqual(snapshot.localCandidateType, "relay")
+        XCTAssertEqual(snapshot.localCandidateProtocol, "tcp")
+        XCTAssertEqual(snapshot.remoteCandidateType, "host")
+        XCTAssertEqual(snapshot.iceState, "connected")
+        XCTAssertEqual(snapshot.dtlsState, "connected")
+    }
     
     func testCollectorHandlesLongCalls() {
         // Simulate a scenario where stats buffer could grow large

--- a/TelnyxRTCTests/WebRTC/CallTests.swift
+++ b/TelnyxRTCTests/WebRTC/CallTests.swift
@@ -38,14 +38,16 @@ class CallTests: XCTestCase {
      - NOTE: Due that we are not sending a valid sessionID we are going to get an "Authentication error" from the server.
      */
     func testNewCall() {
+        let timeout: TimeInterval = ProcessInfo.processInfo.environment["CI"] != nil ? 30.0 : 10.0
+
         //Wait for socket connection
         expectation = expectation(description: "socket")
-        waitForExpectations(timeout: 10)
+        waitForExpectations(timeout: timeout)
 
         //Wait to send invite message.
         expectation = expectation(description: "newCall")
         self.call?.newCall(callerName: "callerName", callerNumber: "callerNumber", destinationNumber: "destinationNumber")
-        waitForExpectations(timeout: 10)
+        waitForExpectations(timeout: timeout)
     }
     
     /**


### PR DESCRIPTION
Adds the current iOS call-report ICE-stat parity work. Follow-up commits will complete the remaining JS-equivalent call-report fields.