### PR TITLE
feat: improve iOS call report parity

### DIFF
--- a/TelnyxRTC/Telnyx/Models/CallReportModels.swift
+++ b/TelnyxRTC/Telnyx/Models/CallReportModels.swift
@@ -471,12 +471,14 @@ public struct CallReportIceServerSummary: Codable {
 public struct CallReportSettingsSummary: Codable {
     public let enabled: Bool
     public let intervalMs: Int
+    public let flushIntervalMs: Int
     public let debugLogLevel: String
     public let debugLogMaxEntries: Int
 
-    public init(enabled: Bool, intervalMs: Int, debugLogLevel: String, debugLogMaxEntries: Int) {
+    public init(enabled: Bool, intervalMs: Int, flushIntervalMs: Int = 180_000, debugLogLevel: String, debugLogMaxEntries: Int) {
         self.enabled = enabled
         self.intervalMs = intervalMs
+        self.flushIntervalMs = flushIntervalMs
         self.debugLogLevel = debugLogLevel
         self.debugLogMaxEntries = debugLogMaxEntries
     }

--- a/TelnyxRTC/Telnyx/WebRTC/Call.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call.swift
@@ -1049,6 +1049,56 @@ extension Call {
                 context: ["state": state.telnyx_to_string()]
             )
         }
+
+        peer.onIceConnectionStateChangeForLog = { [weak self] state in
+            self?.callReportCollector?.addLogEntry(
+                level: "info",
+                message: "ICE connection state changed",
+                context: ["state": state.telnyx_to_string()]
+            )
+        }
+
+        peer.onNegotiationNeededForLog = { [weak self] in
+            self?.callReportCollector?.addLogEntry(
+                level: "info",
+                message: "Peer negotiation needed"
+            )
+        }
+
+        peer.onIceCandidateForLog = { [weak self] candidate in
+            guard let self = self else { return }
+            self.callReportCollector?.addLogEntry(
+                level: "info",
+                message: "Local ICE candidate gathered",
+                context: self.sanitizedCandidateContext(
+                    candidate.sdp,
+                    sdpMid: candidate.sdpMid,
+                    sdpMLineIndex: Int(candidate.sdpMLineIndex)
+                )
+            )
+        }
+    }
+
+    /// Candidate SDP contains local/public addresses. Reports keep only safe
+    /// transport metadata needed for diagnostics.
+    private func sanitizedCandidateContext(
+        _ candidate: String,
+        sdpMid: String? = nil,
+        sdpMLineIndex: Int? = nil
+    ) -> [String: Any] {
+        let fields = candidate
+            .replacingOccurrences(of: "a=", with: "")
+            .split(separator: " ")
+            .map(String.init)
+        let typeIndex = fields.firstIndex(of: "typ")
+        var context: [String: Any] = [:]
+        if fields.count > 2 { context["protocol"] = fields[2].lowercased() }
+        if let typeIndex, fields.indices.contains(typeIndex + 1) {
+            context["candidateType"] = fields[typeIndex + 1]
+        }
+        if let sdpMid { context["sdpMid"] = sdpMid }
+        if let sdpMLineIndex { context["sdpMLineIndex"] = sdpMLineIndex }
+        return context
     }
 
     private func startCallReportCollector() {
@@ -1187,6 +1237,7 @@ extension Call {
             callReports: CallReportSettingsSummary(
                 enabled: enableCallReports,
                 intervalMs: Int((callReportInterval * 1000).rounded()),
+                flushIntervalMs: 180_000,
                 debugLogLevel: callReportLogLevel,
                 debugLogMaxEntries: callReportMaxLogEntries
             )
@@ -1563,6 +1614,15 @@ extension Call {
                 let sdpMLineIndex = params["sdpMLineIndex"] as? Int32 ?? 0
 
                 Logger.log.i(message: "[TRICKLE-ICE] Call:: Received remote candidate - forwarding to peer")
+                callReportCollector?.addLogEntry(
+                    level: "info",
+                    message: "Remote ICE candidate received",
+                    context: sanitizedCandidateContext(
+                        candidateString,
+                        sdpMid: sdpMid,
+                        sdpMLineIndex: Int(sdpMLineIndex)
+                    )
+                )
                 self.peer?.handleRemoteCandidate(candidateString: candidateString, sdpMid: sdpMid, sdpMLineIndex: sdpMLineIndex)
             }
             break
@@ -1570,6 +1630,7 @@ extension Call {
         case .END_OF_CANDIDATES:
             // Handle end of remote candidates signal for trickle ICE
             Logger.log.i(message: "[TRICKLE-ICE] Call:: Received END_OF_CANDIDATES - forwarding to peer")
+            callReportCollector?.addLogEntry(level: "info", message: "Remote ICE gathering complete")
             self.peer?.handleEndOfRemoteCandidates()
             break
 

--- a/TelnyxRTC/Telnyx/WebRTC/Peer.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Peer.swift
@@ -1018,6 +1018,10 @@ extension Peer : RTCPeerConnectionDelegate {
         // Mark first ICE candidate for benchmarking
         CallTimingBenchmark.markFirstCandidate()
 
+        // Record every gathered candidate for the call report, including
+        // candidates that legacy non-trickle handling later declines to send.
+        onIceCandidateForLog?(candidate)
+
         // For Trickle ICE, we always send candidates - don't skip based on negotiationEnded
         if !useTrickleIce {
             // Traditional mode: check if negotiation has ended or connection is established
@@ -1050,7 +1054,6 @@ extension Peer : RTCPeerConnectionDelegate {
 
         // We call the callback when the iceCandidate is added
         onIceCandidate?(candidate)
-        onIceCandidateForLog?(candidate)
 
         // Handle trickle ICE - send candidates individually as they are discovered
         if useTrickleIce {

--- a/TelnyxRTC/Telnyx/WebRTC/Peer.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Peer.swift
@@ -154,6 +154,9 @@ class Peer : NSObject, WebRTCEventHandler {
     // Call-report logging closures (separate from WebRTCStatsReporter callbacks)
     var onSignalingStateChangeForLog: ((RTCSignalingState) -> Void)?
     var onIceGatheringStateChangeForLog: ((RTCIceGatheringState) -> Void)?
+    var onIceConnectionStateChangeForLog: ((RTCIceConnectionState) -> Void)?
+    var onNegotiationNeededForLog: (() -> Void)?
+    var onIceCandidateForLog: ((RTCIceCandidate) -> Void)?
     var onIceCandidate: ((RTCIceCandidate) -> Void)?
     var onRemoveIceCandidates: (([RTCIceCandidate]) -> Void)?
     var onDataChannel: ((RTCDataChannel) -> Void)?
@@ -613,6 +616,9 @@ class Peer : NSObject, WebRTCEventHandler {
         self.onPeerConnectionStateChange = nil
         self.onSignalingStateChangeForLog = nil
         self.onIceGatheringStateChangeForLog = nil
+        self.onIceConnectionStateChangeForLog = nil
+        self.onNegotiationNeededForLog = nil
+        self.onIceCandidateForLog = nil
         self.onIceCandidate = nil
         self.onRemoveIceCandidates = nil
         self.onDataChannel = nil
@@ -914,12 +920,14 @@ extension Peer : RTCPeerConnectionDelegate {
 
     func peerConnectionShouldNegotiate(_ peerConnection: RTCPeerConnection) {
         onNegotiationNeeded?()
+        onNegotiationNeededForLog?()
         Logger.log.i(message: "Peer:: connection should negotiate")
     }
 
     func peerConnection(_ peerConnection: RTCPeerConnection, didChange newState: RTCIceConnectionState) {
         onIceConnectionChange?(newState)
         onIceConnectionStateChange?(newState)
+        onIceConnectionStateChangeForLog?(newState)
         Logger.log.i(message: "Peer:: connection didChange ICE connection state: [\(newState.telnyx_to_string().uppercased())]")
         
         // Track ICE connection state changes for benchmarking
@@ -1042,6 +1050,7 @@ extension Peer : RTCPeerConnectionDelegate {
 
         // We call the callback when the iceCandidate is added
         onIceCandidate?(candidate)
+        onIceCandidateForLog?(candidate)
 
         // Handle trickle ICE - send candidates individually as they are discovered
         if useTrickleIce {

--- a/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
@@ -85,6 +85,9 @@ public class TelnyxCallReportCollector {
     // Retry configuration for HTTP POST (aligned with Android)
     private let maxRetryAttempts = 3
     private let retryBaseDelay: TimeInterval = 1.0
+
+    internal static let maxPayloadSizeBytes = 2 * 1024 * 1024
+    internal static let safePayloadSizeBytes = Int(1.9 * 1024 * 1024)
     
     // MARK: - Initialization
     
@@ -259,25 +262,66 @@ public class TelnyxCallReportCollector {
             request.setValue(voiceSdkId, forHTTPHeaderField: "x-voice-sdk-id")
         }
 
-        // Encode payload
-        let jsonData: Data
+        let payloads: [Data]
         do {
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = .prettyPrinted
-            jsonData = try encoder.encode(payload)
-            request.httpBody = jsonData
+            payloads = try Self.chunkedPayloadData(for: payload)
         } catch {
             Logger.log.e(message: "TelnyxCallReportCollector: Failed to encode payload: \(error)")
             return
         }
 
-        // Log the payload for debugging
-        if let jsonString = String(data: jsonData, encoding: .utf8) {
-            Logger.log.i(message: "TelnyxCallReportCollector: Payload:\n\(jsonString)")
+        if payloads.count > 1 {
+            Logger.log.i(message: "TelnyxCallReportCollector: Split report into \(payloads.count) chunks")
         }
 
-        // Post with retry logic (aligned with Android: 3 attempts, exponential backoff, 5xx only)
-        executeUpload(request: request, attempt: 1)
+        uploadPayloads(payloads, index: 0, request: request)
+    }
+
+    internal static func chunkedPayloadData(for payload: CallReportPayload) throws -> [Data] {
+        let encoder = JSONEncoder()
+        let encodedPayload = try encoder.encode(payload)
+        guard encodedPayload.count > maxPayloadSizeBytes, !payload.stats.isEmpty else {
+            return [encodedPayload]
+        }
+
+        var chunks: [Data] = []
+        var currentStats: [CallReportInterval] = []
+
+        for stat in payload.stats {
+            let candidateStats = currentStats + [stat]
+            let candidate = CallReportPayload(
+                summary: payload.summary,
+                stats: candidateStats,
+                logs: payload.logs,
+                segment: payload.segment
+            )
+            let candidateData = try encoder.encode(candidate)
+
+            if candidateData.count > safePayloadSizeBytes, !currentStats.isEmpty {
+                let chunk = CallReportPayload(
+                    summary: payload.summary,
+                    stats: currentStats,
+                    logs: payload.logs,
+                    segment: payload.segment
+                )
+                chunks.append(try encoder.encode(chunk))
+                currentStats = [stat]
+            } else {
+                currentStats = candidateStats
+            }
+        }
+
+        if !currentStats.isEmpty {
+            let chunk = CallReportPayload(
+                summary: payload.summary,
+                stats: currentStats,
+                logs: payload.logs,
+                segment: payload.segment
+            )
+            chunks.append(try encoder.encode(chunk))
+        }
+
+        return chunks
     }
 
     #if DEBUG
@@ -323,49 +367,71 @@ public class TelnyxCallReportCollector {
         #endif
     }
 
-    private func executeUpload(request: URLRequest, attempt: Int) {
+    private func uploadPayloads(_ payloads: [Data], index: Int, request: URLRequest) {
+        guard index < payloads.count else {
+            cleanup()
+            return
+        }
+
+        var chunkRequest = request
+        chunkRequest.httpBody = payloads[index]
+        executeUpload(request: chunkRequest, attempt: 1) { [weak self] success in
+            guard let self = self else { return }
+            guard success else {
+                self.cleanup()
+                return
+            }
+            self.uploadPayloads(payloads, index: index + 1, request: request)
+        }
+    }
+
+    private func executeUpload(request: URLRequest, attempt: Int, completion: @escaping (Bool) -> Void) {
         guard let requestUrl = request.url else {
             Logger.log.e(message: "TelnyxCallReportCollector: Request has no URL, skipping upload")
+            completion(false)
             return
         }
         let session = urlSession(for: requestUrl)
         let task = session.dataTask(with: request) { [weak self] data, response, error in
-            guard let self = self else { return }
+            guard let self = self else {
+                completion(false)
+                return
+            }
 
             if let error = error {
                 Logger.log.e(message: "TelnyxCallReportCollector: Error posting report (attempt \(attempt)): \(error)")
-                self.retryIfNeeded(request: request, attempt: attempt, statusCode: nil)
+                self.retryIfNeeded(request: request, attempt: attempt, statusCode: nil, completion: completion)
                 return
             }
 
             guard let httpResponse = response as? HTTPURLResponse else {
-                self.cleanup()
+                completion(false)
                 return
             }
 
             if httpResponse.statusCode >= 200 && httpResponse.statusCode < 300 {
                 Logger.log.i(message: "TelnyxCallReportCollector: Successfully posted report (status: \(httpResponse.statusCode))")
-                self.cleanup()
+                completion(true)
             } else {
                 let errorText = data.flatMap { String(data: $0, encoding: .utf8) } ?? "No response body"
                 Logger.log.e(message: "TelnyxCallReportCollector: Failed to post report (attempt \(attempt), status: \(httpResponse.statusCode), error: \(errorText))")
-                self.retryIfNeeded(request: request, attempt: attempt, statusCode: httpResponse.statusCode)
+                self.retryIfNeeded(request: request, attempt: attempt, statusCode: httpResponse.statusCode, completion: completion)
             }
         }
         task.resume()
     }
 
-    private func retryIfNeeded(request: URLRequest, attempt: Int, statusCode: Int?) {
+    private func retryIfNeeded(request: URLRequest, attempt: Int, statusCode: Int?, completion: @escaping (Bool) -> Void) {
         // Only retry on 5xx or network errors, not on 4xx
         if let code = statusCode, code >= 400 && code < 500 {
             Logger.log.e(message: "TelnyxCallReportCollector: Not retrying (client error \(code))")
-            cleanup()
+            completion(false)
             return
         }
 
         guard attempt < maxRetryAttempts else {
             Logger.log.e(message: "TelnyxCallReportCollector: All \(maxRetryAttempts) upload attempts failed")
-            cleanup()
+            completion(false)
             return
         }
 
@@ -373,7 +439,11 @@ public class TelnyxCallReportCollector {
         Logger.log.w(message: "TelnyxCallReportCollector: Retrying in \(delay)s (attempt \(attempt + 1)/\(maxRetryAttempts))")
 
         DispatchQueue.global().asyncAfter(deadline: .now() + delay) { [weak self] in
-            self?.executeUpload(request: request, attempt: attempt + 1)
+            guard let self = self else {
+                completion(false)
+                return
+            }
+            self.executeUpload(request: request, attempt: attempt + 1, completion: completion)
         }
     }
     

--- a/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
@@ -526,6 +526,11 @@ public class TelnyxCallReportCollector {
             return
         }
         let session = urlSession(for: requestUrl)
+        let callId = request.value(forHTTPHeaderField: "x-call-id") ?? "nil"
+        let callReportId = request.value(forHTTPHeaderField: "x-call-report-id") ?? "nil"
+        let voiceSdkId = request.value(forHTTPHeaderField: "x-voice-sdk-id") ?? "nil"
+        let bodyBytes = request.httpBody?.count ?? 0
+        Logger.log.i(message: "TelnyxCallReportCollector: Uploading pending report chunk (attempt \(attempt)/\(maxRetryAttempts), bytes: \(bodyBytes), callId: \(callId), callReportId: \(callReportId), voiceSdkId: \(voiceSdkId))")
         let task = session.dataTask(with: request) { [weak self] data, response, error in
             guard let self = self else {
                 completion(.retryLater)

--- a/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
@@ -48,6 +48,10 @@ public class TelnyxCallReportCollector {
     private weak var peerConnection: RTCPeerConnection?
     private var timer: Timer?
     private var isMediaVerificationSamplingEnabled = false
+    /// Native WebRTC statistics complete asynchronously. Keep one request in
+    /// flight so timer ticks cannot process the same interval twice.
+    private let statsCollectionLock = NSLock()
+    private var isStatsCollectionInFlight = false
     private var statsBuffer: [CallReportInterval] = []
     private var intervalStartTime: Date?
     private(set) var callStartTime: Date
@@ -639,12 +643,23 @@ public class TelnyxCallReportCollector {
 
     /// Collect stats from the peer connection and aggregate them
     private func collectStats() {
-        guard let peerConnection = peerConnection, let intervalStartTime = intervalStartTime else {
+        statsCollectionLock.lock()
+        guard !isStatsCollectionInFlight,
+              let peerConnection = peerConnection,
+              let intervalStartTime = intervalStartTime else {
+            statsCollectionLock.unlock()
             return
         }
+        isStatsCollectionInFlight = true
+        statsCollectionLock.unlock()
 
         peerConnection.statistics { [weak self] report in
             guard let self = self else { return }
+            defer {
+                self.statsCollectionLock.lock()
+                self.isStatsCollectionInFlight = false
+                self.statsCollectionLock.unlock()
+            }
 
             let now = Date()
             let parsed = self.parseStatsReport(report)
@@ -788,7 +803,11 @@ public class TelnyxCallReportCollector {
         now: Date
     ) {
         if let outbound = parsed.outbound {
-            if let audioLevel = getAudioLevel(from: statistics, trackId: outbound.trackId) {
+            // iOS exposes the local capture level on media-source. Older
+            // WebRTC builds exposed it on the track record, so keep that as a
+            // fallback for compatibility.
+            if let audioLevel = parsed.outboundMediaSource?.audioLevel ??
+                getAudioLevel(from: statistics, trackId: outbound.trackId) {
                 intervalAudioLevels.outbound.append(audioLevel)
             }
             if let prevBytes = previousStats.outboundBytes, let prevTimestamp = previousStats.timestamp {

--- a/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Stats/TelnyxCallReportCollector.swift
@@ -73,6 +73,8 @@ public class TelnyxCallReportCollector {
     // Flush thresholds for intermediate segment reporting (matches JS SDK)
     let statsFlushThreshold = 300  // ~25 min at 5s intervals
     let logsFlushThreshold = 800
+    private let intermediateFlushInterval: TimeInterval = 180
+    private var lastIntermediateFlushTime: Date?
 
     // Segment tracking for intermediate flushes
     private var segmentIndex: Int = 0
@@ -88,6 +90,9 @@ public class TelnyxCallReportCollector {
 
     internal static let maxPayloadSizeBytes = 2 * 1024 * 1024
     internal static let safePayloadSizeBytes = Int(1.9 * 1024 * 1024)
+
+    private let uploadQueue = DispatchQueue(label: "com.telnyx.call-report-upload")
+    private var isUploadingPendingReports = false
     
     // MARK: - Initialization
     
@@ -103,6 +108,8 @@ public class TelnyxCallReportCollector {
         } else {
             self.logCollector = nil
         }
+
+        replayPendingUploads()
     }
     
     // MARK: - Public Methods
@@ -114,6 +121,7 @@ public class TelnyxCallReportCollector {
         
         self.peerConnection = peerConnection
         self.intervalStartTime = Date()
+        self.lastIntermediateFlushTime = self.intervalStartTime
         
         Logger.log.i(message: "TelnyxCallReportCollector: Starting stats collection (interval: \(config.interval)s, logCollectorActive: \(logCollector?.isActive() ?? false))")
 
@@ -207,6 +215,7 @@ public class TelnyxCallReportCollector {
 
         let currentSegment = segmentIndex
         segmentIndex += 1
+        lastIntermediateFlushTime = Date()
 
         // Snapshot and clear stats buffer
         let stats = statsBuffer
@@ -245,22 +254,12 @@ public class TelnyxCallReportCollector {
         let urlHost = rawHost.contains(":") ? "[\(rawHost)]" : rawHost
         let endpoint = "\(scheme)://\(urlHost)\(wsUrl.port.map { ":\($0)" } ?? "")/call_report"
 
-        guard let endpointUrl = URL(string: endpoint) else {
+        guard URL(string: endpoint) != nil else {
             Logger.log.e(message: "TelnyxCallReportCollector: Failed to construct endpoint URL from: \(endpoint)")
             return
         }
 
         Logger.log.i(message: "TelnyxCallReportCollector: Sending payload (host: \(host), endpoint: \(endpoint), callReportId: \(callReportId), voiceSdkId: \(voiceSdkId ?? "nil"), intervals: \(payload.stats.count), logEntries: \(payload.logs?.count ?? 0), segment: \(payload.segment.map { "\($0)" } ?? "nil"), callId: \(payload.summary.callId))")
-
-        // Build request
-        var request = URLRequest(url: endpointUrl)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue(callReportId, forHTTPHeaderField: "x-call-report-id")
-        request.setValue(payload.summary.callId, forHTTPHeaderField: "x-call-id")
-        if let voiceSdkId = voiceSdkId {
-            request.setValue(voiceSdkId, forHTTPHeaderField: "x-voice-sdk-id")
-        }
 
         let payloads: [Data]
         do {
@@ -274,7 +273,24 @@ public class TelnyxCallReportCollector {
             Logger.log.i(message: "TelnyxCallReportCollector: Split report into \(payloads.count) chunks")
         }
 
-        uploadPayloads(payloads, index: 0, request: request)
+        let uploads = payloads.enumerated().map { index, data in
+            PendingCallReportUpload(
+                endpoint: endpoint,
+                callReportId: callReportId,
+                callId: payload.summary.callId,
+                voiceSdkId: voiceSdkId,
+                segment: payload.segment,
+                chunkIndex: index,
+                body: data
+            )
+        }
+
+        uploadQueue.async { [weak self] in
+            guard let self = self else { return }
+            guard self.persist(uploads) else { return }
+            self.cleanup()
+            self.processPendingUploads()
+        }
     }
 
     internal static func chunkedPayloadData(for payload: CallReportPayload) throws -> [Data] {
@@ -324,6 +340,10 @@ public class TelnyxCallReportCollector {
         return chunks
     }
 
+    internal func isIntermediateFlushDue(at date: Date = Date()) -> Bool {
+        date.timeIntervalSince(lastIntermediateFlushTime ?? callStartTime) >= intermediateFlushInterval
+    }
+
     #if DEBUG
     private class AllowSelfSignedDelegate: NSObject, URLSessionDelegate {
         func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge,
@@ -367,34 +387,148 @@ public class TelnyxCallReportCollector {
         #endif
     }
 
-    private func uploadPayloads(_ payloads: [Data], index: Int, request: URLRequest) {
-        guard index < payloads.count else {
-            cleanup()
-            return
-        }
+    private struct PendingCallReportUpload: Codable {
+        let endpoint: String
+        let callReportId: String
+        let callId: String
+        let voiceSdkId: String?
+        let segment: Int?
+        let chunkIndex: Int
+        let body: Data
+    }
 
-        var chunkRequest = request
-        chunkRequest.httpBody = payloads[index]
-        executeUpload(request: chunkRequest, attempt: 1) { [weak self] success in
-            guard let self = self else { return }
-            guard success else {
-                self.cleanup()
-                return
-            }
-            self.uploadPayloads(payloads, index: index + 1, request: request)
+    private enum UploadResult {
+        case delivered
+        case retryLater
+        case discard
+    }
+
+    private func replayPendingUploads() {
+        uploadQueue.async { [weak self] in
+            self?.processPendingUploads()
         }
     }
 
-    private func executeUpload(request: URLRequest, attempt: Int, completion: @escaping (Bool) -> Void) {
+    private func persist(_ uploads: [PendingCallReportUpload]) -> Bool {
+        do {
+            let directory = try pendingUploadsDirectory()
+            let encoder = JSONEncoder()
+            for upload in uploads {
+                let filename = pendingFilename(for: upload)
+                let url = directory.appendingPathComponent(filename)
+                try encoder.encode(upload).write(to: url, options: .atomic)
+                try? (url as NSURL).setResourceValue(true, forKey: .isExcludedFromBackupKey)
+                try? FileManager.default.setAttributes(
+                    [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication],
+                    ofItemAtPath: url.path
+                )
+            }
+            Logger.log.i(message: "TelnyxCallReportCollector: Persisted \(uploads.count) pending report chunk(s)")
+            return true
+        } catch {
+            Logger.log.e(message: "TelnyxCallReportCollector: Failed to persist pending report: \(error)")
+            return false
+        }
+    }
+
+    private func processPendingUploads() {
+        guard !isUploadingPendingReports else { return }
+        guard let url = nextPendingUploadURL() else { return }
+
+        let upload: PendingCallReportUpload
+        do {
+            upload = try JSONDecoder().decode(PendingCallReportUpload.self, from: Data(contentsOf: url))
+        } catch {
+            Logger.log.e(message: "TelnyxCallReportCollector: Discarding unreadable pending report: \(error)")
+            try? FileManager.default.removeItem(at: url)
+            processPendingUploads()
+            return
+        }
+
+        guard var request = request(for: upload) else {
+            Logger.log.e(message: "TelnyxCallReportCollector: Discarding pending report with invalid endpoint")
+            try? FileManager.default.removeItem(at: url)
+            processPendingUploads()
+            return
+        }
+        request.httpBody = upload.body
+        isUploadingPendingReports = true
+
+        executeUpload(request: request, attempt: 1) { [weak self] result in
+            guard let self = self else { return }
+            self.uploadQueue.async {
+                self.isUploadingPendingReports = false
+                switch result {
+                case .delivered:
+                    try? FileManager.default.removeItem(at: url)
+                    Logger.log.i(message: "TelnyxCallReportCollector: Removed delivered pending report chunk")
+                    self.processPendingUploads()
+                case .discard:
+                    try? FileManager.default.removeItem(at: url)
+                    Logger.log.e(message: "TelnyxCallReportCollector: Discarded pending report after a non-retryable response")
+                    self.processPendingUploads()
+                case .retryLater:
+                    Logger.log.w(message: "TelnyxCallReportCollector: Keeping pending report chunk for a future replay")
+                }
+            }
+        }
+    }
+
+    private func request(for upload: PendingCallReportUpload) -> URLRequest? {
+        guard let endpoint = URL(string: upload.endpoint) else { return nil }
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(upload.callReportId, forHTTPHeaderField: "x-call-report-id")
+        request.setValue(upload.callId, forHTTPHeaderField: "x-call-id")
+        if let voiceSdkId = upload.voiceSdkId {
+            request.setValue(voiceSdkId, forHTTPHeaderField: "x-voice-sdk-id")
+        }
+        return request
+    }
+
+    private func pendingUploadsDirectory() throws -> URL {
+        let fileManager = FileManager.default
+        let base = try fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        let directory = base.appendingPathComponent("TelnyxCallReports", isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private func nextPendingUploadURL() -> URL? {
+        guard let directory = try? pendingUploadsDirectory() else { return nil }
+        return (try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ))?
+            .filter { $0.pathExtension == "json" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+            .first
+    }
+
+    private func pendingFilename(for upload: PendingCallReportUpload) -> String {
+        let callId = upload.callId.replacingOccurrences(of: "[^A-Za-z0-9-]", with: "-", options: .regularExpression)
+        let segment = upload.segment.map(String.init) ?? "final"
+        let timestamp = String(format: "%020.0f", Date().timeIntervalSince1970 * 1_000)
+        return "\(timestamp)-\(callId)-\(segment)-\(upload.chunkIndex)-\(UUID().uuidString).json"
+    }
+
+    private func executeUpload(request: URLRequest, attempt: Int, completion: @escaping (UploadResult) -> Void) {
         guard let requestUrl = request.url else {
             Logger.log.e(message: "TelnyxCallReportCollector: Request has no URL, skipping upload")
-            completion(false)
+            completion(.discard)
             return
         }
         let session = urlSession(for: requestUrl)
         let task = session.dataTask(with: request) { [weak self] data, response, error in
             guard let self = self else {
-                completion(false)
+                completion(.retryLater)
                 return
             }
 
@@ -405,13 +539,13 @@ public class TelnyxCallReportCollector {
             }
 
             guard let httpResponse = response as? HTTPURLResponse else {
-                completion(false)
+                completion(.retryLater)
                 return
             }
 
             if httpResponse.statusCode >= 200 && httpResponse.statusCode < 300 {
                 Logger.log.i(message: "TelnyxCallReportCollector: Successfully posted report (status: \(httpResponse.statusCode))")
-                completion(true)
+                completion(.delivered)
             } else {
                 let errorText = data.flatMap { String(data: $0, encoding: .utf8) } ?? "No response body"
                 Logger.log.e(message: "TelnyxCallReportCollector: Failed to post report (attempt \(attempt), status: \(httpResponse.statusCode), error: \(errorText))")
@@ -421,17 +555,17 @@ public class TelnyxCallReportCollector {
         task.resume()
     }
 
-    private func retryIfNeeded(request: URLRequest, attempt: Int, statusCode: Int?, completion: @escaping (Bool) -> Void) {
+    private func retryIfNeeded(request: URLRequest, attempt: Int, statusCode: Int?, completion: @escaping (UploadResult) -> Void) {
         // Only retry on 5xx or network errors, not on 4xx
         if let code = statusCode, code >= 400 && code < 500 {
             Logger.log.e(message: "TelnyxCallReportCollector: Not retrying (client error \(code))")
-            completion(false)
+            completion(.discard)
             return
         }
 
         guard attempt < maxRetryAttempts else {
             Logger.log.e(message: "TelnyxCallReportCollector: All \(maxRetryAttempts) upload attempts failed")
-            completion(false)
+            completion(.retryLater)
             return
         }
 
@@ -440,7 +574,7 @@ public class TelnyxCallReportCollector {
 
         DispatchQueue.global().asyncAfter(deadline: .now() + delay) { [weak self] in
             guard let self = self else {
-                completion(false)
+                completion(.retryLater)
                 return
             }
             self.executeUpload(request: request, attempt: attempt + 1, completion: completion)
@@ -917,8 +1051,11 @@ public class TelnyxCallReportCollector {
     /// and notify the caller via `onFlushNeeded` if so.
     private func checkFlushThresholds() {
         let logCount = logCollector?.getLogCount() ?? 0
-        if statsBuffer.count >= statsFlushThreshold || logCount >= logsFlushThreshold {
-            Logger.log.i(message: "TelnyxCallReportCollector: Flush threshold reached (stats: \(statsBuffer.count)/\(statsFlushThreshold), logs: \(logCount)/\(logsFlushThreshold))")
+        let secondsSinceLastFlush = Date().timeIntervalSince(lastIntermediateFlushTime ?? callStartTime)
+        if statsBuffer.count >= statsFlushThreshold ||
+            logCount >= logsFlushThreshold ||
+            isIntermediateFlushDue() {
+            Logger.log.i(message: "TelnyxCallReportCollector: Flush threshold reached (stats: \(statsBuffer.count)/\(statsFlushThreshold), logs: \(logCount)/\(logsFlushThreshold), elapsed: \(Int(secondsSinceLastFlush))/\(Int(intermediateFlushInterval))s)")
             onFlushNeeded?()
         }
     }

--- a/TelnyxRTCTests/WebRTC/CallReportCollectorTests.swift
+++ b/TelnyxRTCTests/WebRTC/CallReportCollectorTests.swift
@@ -394,6 +394,11 @@ class CallReportCollectorTests: XCTestCase {
         XCTAssertEqual(decodedStats.map(\.intervalStartUtc), stats.map(\.intervalStartUtc))
     }
 
+    func testIntermediateFlushIsDueAfterThreeMinutes() {
+        XCTAssertFalse(collector.isIntermediateFlushDue(at: collector.callStartTime.addingTimeInterval(179)))
+        XCTAssertTrue(collector.isIntermediateFlushDue(at: collector.callStartTime.addingTimeInterval(180)))
+    }
+
     func testIntervalEncodesJSCompatibleIceAndTransportStats() throws {
         let local = ICECandidateStats(
             id: "local-candidate",

--- a/TelnyxRTCTests/WebRTC/CallReportCollectorTests.swift
+++ b/TelnyxRTCTests/WebRTC/CallReportCollectorTests.swift
@@ -367,6 +367,33 @@ class CallReportCollectorTests: XCTestCase {
         }
     }
 
+    func testLargePayloadSplitsStatsIntoSafeChunks() throws {
+        let summary = CallReportSummary(callId: "call-id")
+        let largeCandidateAddress = String(repeating: "a", count: 50_000)
+        let localCandidate = ICECandidateStats(address: largeCandidateAddress)
+        let stats = (0..<50).map { index in
+            CallReportInterval(
+                intervalStartUtc: "2026-08-23T10:00:\(index).000Z",
+                intervalEndUtc: "2026-08-23T10:00:\(index + 1).000Z",
+                ice: ICECandidatePairStats(local: localCandidate)
+            )
+        }
+        let payload = CallReportPayload(summary: summary, stats: stats)
+
+        let chunks = try TelnyxCallReportCollector.chunkedPayloadData(for: payload)
+
+        XCTAssertGreaterThan(chunks.count, 1)
+        XCTAssertTrue(chunks.allSatisfy {
+            $0.count <= TelnyxCallReportCollector.safePayloadSizeBytes
+        })
+
+        let decodedStats = try chunks.flatMap {
+            try JSONDecoder().decode(CallReportPayload.self, from: $0).stats
+        }
+        XCTAssertEqual(decodedStats.count, stats.count)
+        XCTAssertEqual(decodedStats.map(\.intervalStartUtc), stats.map(\.intervalStartUtc))
+    }
+
     func testIntervalEncodesJSCompatibleIceAndTransportStats() throws {
         let local = ICECandidateStats(
             id: "local-candidate",

--- a/TelnyxRTCTests/WebRTC/CallReportCollectorTests.swift
+++ b/TelnyxRTCTests/WebRTC/CallReportCollectorTests.swift
@@ -89,6 +89,7 @@ class CallReportCollectorTests: XCTestCase {
         let data = try JSONEncoder().encode(summary)
         let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
         let clientSummary = try XCTUnwrap(json["clientSummary"] as? [String: Any])
+        let callReports = try XCTUnwrap(clientSummary["callReports"] as? [String: Any])
         let media = try XCTUnwrap(clientSummary["media"] as? [String: Any])
         let iceServer = try XCTUnwrap((media["iceServers"] as? [[String: Any]])?.first)
 
@@ -97,6 +98,7 @@ class CallReportCollectorTests: XCTestCase {
         XCTAssertEqual(iceServer["hasCredential"] as? Bool, true)
         XCTAssertNil(iceServer["username"])
         XCTAssertNil(iceServer["credential"])
+        XCTAssertEqual(callReports["flushIntervalMs"] as? Int, 180_000)
     }
     
     // MARK: - Start/Stop Tests


### PR DESCRIPTION
<!-- Ticket details and link -->
[WEBRTC-XXX - Ticket title](https://telnyx.atlassian.net/browse/WEBRTC-XXX)
---
<!-- Describe your change here -->
Adds reliable iOS HTTP call-report delivery and improves report parity with the JavaScript shape, without enabling WebRTC socket-stat reporting or collecting sensitive candidate data.

## :older_man: :baby: Behaviors
### Before changes
- Native statistics requests could overlap because `statistics` completes asynchronously, producing inconsistent sampling intervals.
- Outbound microphone-level averages were empty even when native `media-source.audioLevel` was available.
- The client summary omitted the 180-second report flush interval and reports had limited ICE lifecycle visibility.
- Large or failed report uploads could be lost and intermediate call data was only retained in memory.

### After changes
- Serializes native statistics requests so only one is in flight per call-report collector.
- Uses native media-source telemetry for outbound audio-level averages, with the existing track lookup as fallback.
- Adds the flush interval to the client summary.
- Adds sanitized ICE lifecycle/candidate events. Candidate type and protocol are retained; IP addresses, ports, SDP, and credentials are excluded.
- Logs every gathered candidate, including host candidates later filtered by legacy non-trickle handling.
- Splits oversized reports, flushes intermediate report segments, persists pending uploads, and retries transient HTTP failures.

## TODO
None.

## ✋ Manual testing
1. Run `CallReportCollectorTests`.
2. Place an iOS call with call reports enabled and verify outbound audio level, flush interval, and sanitized ICE candidate events in the uploaded report.
3. Confirm disabling WebRTC socket stats does not prevent HTTP call-report collection/upload.
4. Simulate a transient upload failure and verify the persisted report is retried and removed after a successful upload.

## Known Issues
Native WebRTC does not expose all browser-only media-device fields and echo metrics. Those fields remain absent rather than being synthesized.

## Screenshots
Not applicable.


## 🔄 iOS Regression Process

### General Guidelines
- **SDK Release**: Follow all the steps listed on `Application Flow Checklist`.
- **Mobile App Release**: Run all the tests listed on `Application Flow Checklist`
- **Bugfixes or Demo App Changes**: Only include the tests relevant to the implemented changes.

### Release Process for the Demo App
1. Create a release branch for the demo app only.
2. Update the version.
3. Run all tests from `Application Flow Checklist`
4. Merge the PR.
5. Create a tag under release/sample-app/VERSION
6. Release app to the store.

### Release Process for the SDK
1. Create a release branch by running the pipeline:
   [Create Pull Request Pipeline](https://github.com/team-telnyx/telnyx-webrtc-ios/actions/workflows/release_01_create_pull_request.yml).
   This will generate a branch named `release/RELEASE-X.X.X`.
2. Check out the release branch and update the changelog and documentation.
3. Run all tests from `Application Flow Checklist`
4. If errors are found:
   - Create a Jira ticket, resolve the issue, and create a PR to the release branch.
   - Execute the tests associated with the fix (run the failing test case).
5. If all tests pass, merge the release branch.
6. Run the pipeline:
   [Create GitHub Release Pipeline](https://github.com/team-telnyx/telnyx-webrtc-ios/actions/workflows/release_02_create_gh_release.yml) to create the release on GitHub.
7. Run the pipeline:
   [Deploy to CocoaPods Pipeline](https://github.com/team-telnyx/telnyx-webrtc-ios/actions/workflows/release_03_deploy_cocoapods.yml) to publish the release to CocoaPods.

---

## Application Flow Checklist

### 🧪 Logged in with Token

- [ ] **Connection:** Establish connection via Token

#### Inbound Calls (Receiving as Token user)
- [ ] Receive inbound call from SIP Connection
  - [ ] On WiFi
  - [ ] On Mobile Network

#### Outbound Calls (Making calls as Token user)
- [ ] Make outbound call to SIP Connection
  - [ ] On WiFi
  - [ ] On Mobile Network
- [ ] Make outbound call to associated number
  - [ ] On WiFi
  - [ ] On Mobile Network
- [ ] Make outbound call to PSTN
  - [ ] On WiFi
  - [ ] On Mobile Network

#### Notifications (While logged in as Token)
- [ ] Receive push notification (App Background) -> Reject Call
  - [ ] Screen On
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)
- [ ] Receive push notification (App Background) -> Accept Call
  - [ ] Screen On
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)
- [ ] Receive push notification (App Terminated) -> Reject Call
  - [ ] Screen On 
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)
- [ ] Receive push notification (App Terminated) -> Accept Call
  - [ ] Screen On
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)

---

### 📞 Logged in with SIP Connection

- [ ] **Connection:** Establish connection via SIP Credential

#### Inbound Calls (Receiving as SIP user)
- [ ] Receive inbound call from another SIP Connection
  - [ ] On WiFi
  - [ ] On Mobile Network
- [ ] Receive inbound call via associated number
  - [ ] On WiFi
  - [ ] On Mobile Network
- [ ] Receive inbound call from PSTN
  - [ ] On WiFi
  - [ ] On Mobile Network

#### Outbound Calls (Making calls as SIP user)
- [ ] Make outbound call to SIP Connection
  - [ ] On WiFi
  - [ ] On Mobile Network
- [ ] Make outbound call to associated number
  - [ ] On WiFi
  - [ ] On Mobile Network
- [ ] Make outbound call to PSTN
  - [ ] On WiFi
  - [ ] On Mobile Network

#### Notifications (While logged in as SIP)
- [ ] Receive push notification (App Background) -> Reject Call
  - [ ] Screen On
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)
- [ ] Receive push notification (App Background) -> Accept Call
  - [ ] Screen On
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)
- [ ] Receive push notification (App Terminated) -> Reject Call
  - [ ] Screen On 
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)
- [ ] Receive push notification (App Terminated) -> Accept Call
  - [ ] Screen On 
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)

---

### 👤 Logged in with genCred

- [ ] **Connection:** Establish connection via genCred 

#### Inbound Calls (Receiving as genCred user)
- [ ] Receive inbound call from SIP Connection
  - [ ] On WiFi
  - [ ] On Mobile Network
- [ ] Receive inbound call via associated number
  - [ ] On WiFi
  - [ ] On Mobile Network
- [ ] Receive inbound call from PSTN
  - [ ] On WiFi
  - [ ] On Mobile Network

#### Outbound Calls (Making calls as genCred user)
- [ ] Make outbound call to SIP Connection
  - [ ] On WiFi
  - [ ] On Mobile Network
- [ ] Make outbound call to associated number
  - [ ] On WiFi
  - [ ] On Mobile Network
- [ ] Make outbound call to PSTN
  - [ ] On WiFi
  - [ ] On Mobile Network

#### Notifications (While logged in as genCred)
- [ ] Receive push notification (App Background) -> Reject Call
  - [ ] Screen On
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)
- [ ] Receive push notification (App Background) -> Accept Call
  - [ ] Screen On
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)
- [ ] Receive push notification (App Terminated) -> Reject Call
  - [ ] Screen On 
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)
- [ ] Receive push notification (App Terminated) -> Accept Call
  - [ ] Screen On 
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)

---

### 🔁 General Reconnection Scenarios
- [ ] Establish call -> Drop network -> Re-establish connection within timeframe
  - [ ] On WiFi
  - [ ] On 4G/Mobile Network
- [ ] Establish call -> Drop network -> Fail to re-establish connection within timeframe (verify dropped state)
  - [ ] On WiFi
  - [ ] On 4G/Mobile Network

---

### 📊 General Stats Scenarios
- [ ] Enable stats (config level) -> Establish call -> Verify portal stats appear
- [ ] Disable stats (config level) -> Establish call -> Verify no portal stats appear
- [ ] Enable stats (call level) -> Establish call -> Verify quality metrics are available
- [ ] Disable stats (call level) -> Establish call -> Verify quality metrics are not available
