### PR TITLE
fix: prefer fresh push voice SDK ID on reconnect

### DIFF
--- a/TelnyxRTC/Telnyx/TxClient.swift
+++ b/TelnyxRTC/Telnyx/TxClient.swift
@@ -578,17 +578,7 @@ public class TxClient {
         self.gatewayState = .NOREG
         self.txConfig = txConfig
 
-        if(self.voiceSdkId != nil){
-            Logger.log.i(message: "with_id")
-            self.serverConfiguration = TxServerConfiguration(signalingServer: serverConfiguration.signalingServer,
-                                                             webRTCIceServers: serverConfiguration.webRTCIceServers,
-                                                             environment: serverConfiguration.environment,
-                                                             pushMetaData: [
-                                                                "voice_sdk_id":self.voiceSdkId!
-                                                             ])
-        } else {
-            self.serverConfiguration = serverConfiguration
-        }
+        self.serverConfiguration = serverConfigurationForConnection(serverConfiguration)
         self.socket = Socket()
         self.socket?.delegate = self
         self.aiAssistantManager.setSocket(self.socket)
@@ -616,6 +606,29 @@ public class TxClient {
         self.socket?.delegate = self
         self.aiAssistantManager.setSocket(self.socket)
         self.socket?.connect(signalingServer: self.serverConfiguration.signalingServer)
+    }
+
+    /// Builds a connection configuration without allowing a voice SDK ID from
+    /// an earlier session to overwrite newer push metadata. Preserve all push
+    /// metadata as it can contain the CallKit correlation fields as well.
+    private func serverConfigurationForConnection(
+        _ configuration: TxServerConfiguration
+    ) -> TxServerConfiguration {
+        var pushMetaData = configuration.pushMetaData ?? [:]
+        if let pushedVoiceSdkId = pushMetaData["voice_sdk_id"] as? String,
+           !pushedVoiceSdkId.isEmpty {
+            voiceSdkId = pushedVoiceSdkId
+        } else if let voiceSdkId {
+            pushMetaData["voice_sdk_id"] = voiceSdkId
+        }
+
+        return TxServerConfiguration(
+            signalingServer: configuration.signalingServer,
+            webRTCIceServers: configuration.webRTCIceServers,
+            environment: configuration.environment,
+            pushMetaData: pushMetaData.isEmpty ? nil : pushMetaData,
+            region: configuration.region
+        )
     }
     
     /// Connects only the socket without performing login - used for improved push flow
@@ -1074,19 +1087,7 @@ public class TxClient {
             Logger.log.i(message: "TxClient:: anonymousLogin() socket not connected, starting connection process")
             self.pendingAnonymousLoginMessage = anonymousLoginMessage
             
-            // Set up server configuration
-            if self.voiceSdkId != nil {
-                Logger.log.i(message: "TxClient:: anonymousLogin() with voice_sdk_id")
-                self.serverConfiguration = TxServerConfiguration(
-                    signalingServer: serverConfiguration.signalingServer,
-                    webRTCIceServers: serverConfiguration.webRTCIceServers,
-                    environment: serverConfiguration.environment,
-                    pushMetaData: ["voice_sdk_id": self.voiceSdkId!]
-                )
-            } else {
-                Logger.log.i(message: "TxClient:: anonymousLogin() without voice_sdk_id")
-                self.serverConfiguration = serverConfiguration
-            }
+            self.serverConfiguration = serverConfigurationForConnection(serverConfiguration)
             
             Logger.log.i(message: "TxClient:: anonymousLogin() serverConfiguration server: [\(self.serverConfiguration.signalingServer)] ICE Servers [\(self.serverConfiguration.webRTCIceServers)]")
             
@@ -1525,6 +1526,9 @@ extension TxClient {
         }
         
         self.pushMetaData = pushMetaData
+        // A VoIP push is authoritative for this incoming call. Update the
+        // cached ID before any reconnect path can call the normal connect API.
+        self.voiceSdkId = rtc_id
         self.pushCallState = .idle
         
         // Store config objects for later use (don't login immediately)

--- a/TelnyxRTCTests/TxClientSocketErrorTests.swift
+++ b/TelnyxRTCTests/TxClientSocketErrorTests.swift
@@ -73,6 +73,28 @@ class TxClientPingAuthTests: XCTestCase {
                        "No error should occur — ping should be silently ignored on unauthenticated socket")
     }
 
+    func testFreshPushVoiceSdkIdTakesPrecedenceOverCachedIdOnConnect() throws {
+        txClient.onMessageReceived(message: """
+        {"jsonrpc":"2.0","voice_sdk_id":"stale-sdk-id","result":{"params":{"state":"REGED"}}}
+        """)
+
+        let txConfig = TxConfig(sipUser: "test_user", password: "test_password")
+        let serverConfiguration = TxServerConfiguration(
+            pushMetaData: [
+                "voice_sdk_id": "fresh-push-sdk-id",
+                "call_id": UUID().uuidString
+            ]
+        )
+
+        try txClient.connect(txConfig: txConfig, serverConfiguration: serverConfiguration)
+
+        XCTAssertEqual(
+            txClient.serverConfiguration.pushMetaData?["voice_sdk_id"] as? String,
+            "fresh-push-sdk-id"
+        )
+        XCTAssertTrue(txClient.serverConfiguration.signalingServer.absoluteString.contains("fresh-push-sdk-id"))
+    }
+
     func testDeclinePushDoneUsesEndActionUUIDWhenCallIdIsNotProvided() throws {
         let callUUID = UUID()
         try startPushFlow(callId: callUUID)

--- a/TelnyxRTCTests/TxClientSocketErrorTests.swift
+++ b/TelnyxRTCTests/TxClientSocketErrorTests.swift
@@ -92,7 +92,14 @@ class TxClientPingAuthTests: XCTestCase {
             txClient.serverConfiguration.pushMetaData?["voice_sdk_id"] as? String,
             "fresh-push-sdk-id"
         )
-        XCTAssertTrue(txClient.serverConfiguration.signalingServer.absoluteString.contains("fresh-push-sdk-id"))
+        let queryItems = URLComponents(
+            url: txClient.serverConfiguration.signalingServer,
+            resolvingAgainstBaseURL: false
+        )?.queryItems
+        XCTAssertEqual(
+            queryItems?.first(where: { $0.name == "voice_sdk_id" })?.value,
+            "fresh-push-sdk-id"
+        )
     }
 
     func testDeclinePushDoneUsesEndActionUUIDWhenCallIdIsNotProvided() throws {


### PR DESCRIPTION
<!-- Ticket details and link -->
[WEBRTC-XXX - Ticket title](https://telnyx.atlassian.net/browse/WEBRTC-XXX)
---
<!-- Describe your change here -->
Prevents normal socket reconnects from replacing a fresh VoIP-push `voice_sdk_id` with one cached from a previous REGED/login session. The fresh push metadata remains authoritative and preserves its other correlation fields.

## :older_man: :baby: Behaviors
### Before changes
- `processVoIPNotification` stored the fresh push metadata but did not refresh the cached `voiceSdkId`.
- A later normal `connect(...)` rebuilt push metadata from that stale cached ID, dropping the fresh push ID and other metadata.

### After changes
- Processing a VoIP push immediately refreshes the cached ID.
- Normal and anonymous connection paths preserve a supplied push `voice_sdk_id` and all supplied push metadata.
- A regression test verifies a fresh push ID wins over a stale REGED ID.

## TODO
None.

## ✋ Manual testing
1. Run `TxClientPingAuthTests`.
2. Receive a VoIP push after a prior SDK session, then reconnect/answer and verify the WebSocket URL contains the pushed `voice_sdk_id`.

## Known Issues
None.

## Screenshots
Not applicable.


## 🔄 iOS Regression Process

### General Guidelines
- **SDK Release**: Follow all the steps listed on `Application Flow Checklist`.
- **Mobile App Release**: Run all the tests listed on `Application Flow Checklist`
- **Bugfixes or Demo App Changes**: Only include the tests relevant to the implemented changes.

### Release Process for the Demo App
1. Create a release branch for the demo app only.
2. Update the version.
3. Run all tests from `Application Flow Checklist`
4. Merge the PR.
5. Create a tag under release/sample-app/VERSION
6. Release app to the store.

### Release Process for the SDK
1. Create a release branch by running the pipeline:
   [Create Pull Request Pipeline](https://github.com/team-telnyx/telnyx-webrtc-ios/actions/workflows/release_01_create_pull_request.yml).
   This will generate a branch named `release/RELEASE-X.X.X`.
2. Check out the release branch and update the changelog and documentation.
3. Run all tests from `Application Flow Checklist`
4. If errors are found:
   - Create a Jira ticket, resolve the issue, and create a PR to the release branch.
   - Execute the tests associated with the fix (run the failing test case).
5. If all tests pass, merge the release branch.
6. Run the pipeline:
   [Create GitHub Release Pipeline](https://github.com/team-telnyx/telnyx-webrtc-ios/actions/workflows/release_02_create_gh_release.yml) to create the release on GitHub.
7. Run the pipeline:
   [Deploy to CocoaPods Pipeline](https://github.com/team-telnyx/telnyx-webrtc-ios/actions/workflows/release_03_deploy_cocoapods.yml) to publish the release to CocoaPods.

---

## Application Flow Checklist

### 🧪 Logged in with Token

- [ ] **Connection:** Establish connection via Token

#### Inbound Calls (Receiving as Token user)
- [ ] Receive inbound call from SIP Connection
  - [ ] On WiFi
  - [ ] On Mobile Network

#### Outbound Calls (Making calls as Token user)
- [ ] Make outbound call to SIP Connection
  - [ ] On WiFi
  - [ ] On Mobile Network
- [ ] Make outbound call to associated number
  - [ ] On WiFi
  - [ ] On Mobile Network
- [ ] Make outbound call to PSTN
  - [ ] On WiFi
  - [ ] On Mobile Network

#### Notifications (While logged in as Token)
- [ ] Receive push notification (App Background) -> Reject Call
  - [ ] Screen On
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)
- [ ] Receive push notification (App Background) -> Accept Call
  - [ ] Screen On
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)
- [ ] Receive push notification (App Terminated) -> Reject Call
  - [ ] Screen On 
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)
- [ ] Receive push notification (App Terminated) -> Accept Call
  - [ ] Screen On
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)

---

### 📞 Logged in with SIP Connection

- [ ] **Connection:** Establish connection via SIP Credential

#### Inbound Calls (Receiving as SIP user)
- [ ] Receive inbound call from another SIP Connection
  - [ ] On WiFi
  - [ ] On Mobile Network
- [ ] Receive inbound call via associated number
  - [ ] On WiFi
  - [ ] On Mobile Network
- [ ] Receive inbound call from PSTN
  - [ ] On WiFi
  - [ ] On Mobile Network

#### Outbound Calls (Making calls as SIP user)
- [ ] Make outbound call to SIP Connection
  - [ ] On WiFi
  - [ ] On Mobile Network
- [ ] Make outbound call to associated number
  - [ ] On WiFi
  - [ ] On Mobile Network
- [ ] Make outbound call to PSTN
  - [ ] On WiFi
  - [ ] On Mobile Network

#### Notifications (While logged in as SIP)
- [ ] Receive push notification (App Background) -> Reject Call
  - [ ] Screen On
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)
- [ ] Receive push notification (App Background) -> Accept Call
  - [ ] Screen On
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)
- [ ] Receive push notification (App Terminated) -> Reject Call
  - [ ] Screen On 
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)
- [ ] Receive push notification (App Terminated) -> Accept Call
  - [ ] Screen On 
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)

---

### 👤 Logged in with genCred

- [ ] **Connection:** Establish connection via genCred 

#### Inbound Calls (Receiving as genCred user)
- [ ] Receive inbound call from SIP Connection
  - [ ] On WiFi
  - [ ] On Mobile Network
- [ ] Receive inbound call via associated number
  - [ ] On WiFi
  - [ ] On Mobile Network
- [ ] Receive inbound call from PSTN
  - [ ] On WiFi
  - [ ] On Mobile Network

#### Outbound Calls (Making calls as genCred user)
- [ ] Make outbound call to SIP Connection
  - [ ] On WiFi
  - [ ] On Mobile Network
- [ ] Make outbound call to associated number
  - [ ] On WiFi
  - [ ] On Mobile Network
- [ ] Make outbound call to PSTN
  - [ ] On WiFi
  - [ ] On Mobile Network

#### Notifications (While logged in as genCred)
- [ ] Receive push notification (App Background) -> Reject Call
  - [ ] Screen On
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)
- [ ] Receive push notification (App Background) -> Accept Call
  - [ ] Screen On
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)
- [ ] Receive push notification (App Terminated) -> Reject Call
  - [ ] Screen On 
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)
- [ ] Receive push notification (App Terminated) -> Accept Call
  - [ ] Screen On 
  - [ ] Screen Locked (Active)
  - [ ] Screen Locked (Sleep)

---

### 🔁 General Reconnection Scenarios
- [ ] Establish call -> Drop network -> Re-establish connection within timeframe
  - [ ] On WiFi
  - [ ] On 4G/Mobile Network
- [ ] Establish call -> Drop network -> Fail to re-establish connection within timeframe (verify dropped state)
  - [ ] On WiFi
  - [ ] On 4G/Mobile Network

---

### 📊 General Stats Scenarios
- [ ] Enable stats (config level) -> Establish call -> Verify portal stats appear
- [ ] Disable stats (config level) -> Establish call -> Verify no portal stats appear
- [ ] Enable stats (call level) -> Establish call -> Verify quality metrics are available
- [ ] Disable stats (call level) -> Establish call -> Verify quality metrics are not available
