### PR TITLE
feat: add ICE lifecycle logs to call reports

### DIFF
--- a/TelnyxRTC/Telnyx/WebRTC/Call.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call.swift
@@ -243,6 +243,9 @@ public class Call {
     /// Previous overall peer connection state for recovery monitoring.
     private var previousPeerConnectionState: RTCPeerConnectionState = .new
 
+    /// Previous connection state used only to mirror the Web SDK call-report log.
+    private var previousPeerConnectionStateForCallReport = "new"
+
     /// Flag to track if ICE connection has been successfully established at least once
     private var hasBeenConnectedBefore: Bool = false
 
@@ -1034,6 +1037,14 @@ extension Call {
     private func setupPeerEventLogging() {
         guard let peer = self.peer else { return }
 
+        previousPeerConnectionStateForCallReport = "new"
+
+        callReportCollector?.addLogEntry(
+            level: "info",
+            message: "RTC config",
+            context: ["iceServers": callReportIceServersForLogs() as [Any]]
+        )
+
         peer.onSignalingStateChangeForLog = { [weak self] state in
             self?.callReportCollector?.addLogEntry(
                 level: "info",
@@ -1045,17 +1056,27 @@ extension Call {
         peer.onIceGatheringStateChangeForLog = { [weak self] state in
             self?.callReportCollector?.addLogEntry(
                 level: "info",
-                message: "ICE gathering state changed",
-                context: ["state": state.telnyx_to_string()]
+                message: Self.callReportTimestampedMessage("ICE Gathering State"),
+                context: ["args": [state.telnyx_to_string()]]
             )
         }
 
         peer.onIceConnectionStateChangeForLog = { [weak self] state in
             self?.callReportCollector?.addLogEntry(
                 level: "info",
-                message: "ICE connection state changed",
-                context: ["state": state.telnyx_to_string()]
+                message: Self.callReportTimestampedMessage("ICE Connection State"),
+                context: ["args": [state.telnyx_to_string()]]
             )
+        }
+
+        peer.onPeerConnectionStateChangeForLog = { [weak self] state in
+            guard let self = self else { return }
+            let currentState = state.telnyx_to_string()
+            self.callReportCollector?.addLogEntry(
+                level: "info",
+                message: "Connection State changed: \(self.previousPeerConnectionStateForCallReport) -> \(currentState)"
+            )
+            self.previousPeerConnectionStateForCallReport = currentState
         }
 
         peer.onNegotiationNeededForLog = { [weak self] in
@@ -1067,20 +1088,65 @@ extension Call {
 
         peer.onIceCandidateForLog = { [weak self] candidate in
             guard let self = self else { return }
+            var context: [String: Any] = [
+                "candidate": candidate.sdp,
+                "sdpMLineIndex": Int(candidate.sdpMLineIndex)
+            ]
+            if let sdpMid = candidate.sdpMid {
+                context["sdpMid"] = sdpMid
+            }
+            if let usernameFragment = candidate.telnyx_stats_extractUfrag() {
+                context["usernameFragment"] = usernameFragment
+            }
             self.callReportCollector?.addLogEntry(
                 level: "info",
-                message: "Local ICE candidate gathered",
-                context: self.sanitizedCandidateContext(
-                    candidate.sdp,
-                    sdpMid: candidate.sdpMid,
-                    sdpMLineIndex: Int(candidate.sdpMLineIndex)
-                )
+                message: "RTCPeer Candidate:",
+                context: context
+            )
+        }
+
+        peer.onIceCandidateErrorForLog = { [weak self] event in
+            let address = event.address
+            let port = Int(event.port)
+            self?.callReportCollector?.addLogEntry(
+                level: "warn",
+                message: "ICE candidate error:",
+                context: [
+                    "address": address,
+                    "port": port,
+                    "errorCode": Int(event.errorCode),
+                    "errorText": event.errorText,
+                    "url": event.url,
+                    "hostCandidate": "\(address):\(port)"
+                ]
             )
         }
     }
 
-    /// Candidate SDP contains local/public addresses. Reports keep only safe
-    /// transport metadata needed for diagnostics.
+    private static func callReportTimestampedMessage(_ message: String) -> String {
+        "[\(ISO8601DateFormatter().string(from: Date()))] \(message)"
+    }
+
+    /// This mirrors the Web SDK's RTC config event so the call-report ICE UI
+    /// can render the exact servers used to gather candidates.
+    private func callReportIceServersForLogs() -> [[String: Any]] {
+        iceServers.flatMap { server in
+            server.urlStrings.map { url in
+                var entry: [String: Any] = ["urls": url]
+                if let username = server.username, !username.isEmpty {
+                    entry["username"] = username
+                }
+                if let credential = server.credential, !credential.isEmpty {
+                    entry["credential"] = credential
+                }
+                return entry
+            }
+        }
+    }
+
+    /// Remote candidates arrive through signaling. Keep this supplemental log
+    /// free of the peer address and SDP credentials; gathered local candidates
+    /// above intentionally use the JS-compatible raw event consumed by the UI.
     private func sanitizedCandidateContext(
         _ candidate: String,
         sdpMid: String? = nil,

--- a/TelnyxRTC/Telnyx/WebRTC/Call.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call.swift
@@ -1202,14 +1202,14 @@ extension Call {
 
         // Build call summary
         let summary = CallReportSummary(
-            callId: callId.uuidString,
+            callId: callId.uuidString.lowercased(),
             destinationNumber: self.callOptions?.destinationNumber,
             callerNumber: self.callInfo?.callerNumber,
             direction: self.direction.rawValue,
             state: self.callState.value.lowercased(),
             durationSeconds: durationSeconds,
-            telnyxSessionId: self.telnyxSessionId?.uuidString,
-            telnyxLegId: self.telnyxLegId?.uuidString,
+            telnyxSessionId: self.telnyxSessionId?.uuidString.lowercased(),
+            telnyxLegId: self.telnyxLegId?.uuidString.lowercased(),
             voiceSdkSessionId: self.sessionId,
             sdkVersion: Message.SDK_VERSION,
             startTimestamp: startTimestamp,
@@ -1250,13 +1250,13 @@ extension Call {
         flushIso8601.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         let startTimestamp = flushIso8601.string(from: collector.callStartTime)
         let summary = CallReportSummary(
-            callId: callId.uuidString,
+            callId: callId.uuidString.lowercased(),
             destinationNumber: self.callOptions?.destinationNumber,
             callerNumber: self.callInfo?.callerNumber,
             direction: self.direction.rawValue,
             state: self.callState.value.lowercased(),
-            telnyxSessionId: self.telnyxSessionId?.uuidString,
-            telnyxLegId: self.telnyxLegId?.uuidString,
+            telnyxSessionId: self.telnyxSessionId?.uuidString.lowercased(),
+            telnyxLegId: self.telnyxLegId?.uuidString.lowercased(),
             voiceSdkSessionId: self.sessionId,
             sdkVersion: Message.SDK_VERSION,
             startTimestamp: startTimestamp,

--- a/TelnyxRTC/Telnyx/WebRTC/Call.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call.swift
@@ -1652,10 +1652,9 @@ extension Call {
                    let telnyxLegIdUUID = UUID(uuidString: telnyxLegId) {
                     self.telnyxLegId = telnyxLegIdUUID
 
-                    // Update peer's callLegID and flush any pending trickle ICE candidates
+                    // Preserve the backend leg identifier for call correlation.
                     self.peer?.callLegID = telnyxLegIdUUID.uuidString
-                    Logger.log.i(message: "[TRICKLE-ICE] Call:: Updated peer.callLegID with telnyxLegId, flushing pending candidates")
-                    self.peer?.flushPendingTrickleCandidates()
+                    Logger.log.i(message: "[TRICKLE-ICE] Call:: Updated peer.callLegID with telnyxLegId")
                 } else {
                     Logger.log.w(message: "Call:: Telnyx Leg ID unavailable on RINGING message")
                 }

--- a/TelnyxRTC/Telnyx/WebRTC/Call.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Call.swift
@@ -1127,19 +1127,17 @@ extension Call {
         "[\(ISO8601DateFormatter().string(from: Date()))] \(message)"
     }
 
-    /// This mirrors the Web SDK's RTC config event so the call-report ICE UI
-    /// can render the exact servers used to gather candidates.
+    /// Records the ICE-server URLs used for gathering without uploading TURN
+    /// authentication material. The presence flags retain diagnostics parity
+    /// with the sanitized client summary.
     private func callReportIceServersForLogs() -> [[String: Any]] {
         iceServers.flatMap { server in
             server.urlStrings.map { url in
-                var entry: [String: Any] = ["urls": url]
-                if let username = server.username, !username.isEmpty {
-                    entry["username"] = username
-                }
-                if let credential = server.credential, !credential.isEmpty {
-                    entry["credential"] = credential
-                }
-                return entry
+                [
+                    "urls": url,
+                    "hasUsername": !(server.username?.isEmpty ?? true),
+                    "hasCredential": !(server.credential?.isEmpty ?? true)
+                ]
             }
         }
     }

--- a/TelnyxRTC/Telnyx/WebRTC/Peer.swift
+++ b/TelnyxRTC/Telnyx/WebRTC/Peer.swift
@@ -155,8 +155,10 @@ class Peer : NSObject, WebRTCEventHandler {
     var onSignalingStateChangeForLog: ((RTCSignalingState) -> Void)?
     var onIceGatheringStateChangeForLog: ((RTCIceGatheringState) -> Void)?
     var onIceConnectionStateChangeForLog: ((RTCIceConnectionState) -> Void)?
+    var onPeerConnectionStateChangeForLog: ((RTCPeerConnectionState) -> Void)?
     var onNegotiationNeededForLog: (() -> Void)?
     var onIceCandidateForLog: ((RTCIceCandidate) -> Void)?
+    var onIceCandidateErrorForLog: ((RTCIceCandidateErrorEvent) -> Void)?
     var onIceCandidate: ((RTCIceCandidate) -> Void)?
     var onRemoveIceCandidates: (([RTCIceCandidate]) -> Void)?
     var onDataChannel: ((RTCDataChannel) -> Void)?
@@ -617,8 +619,10 @@ class Peer : NSObject, WebRTCEventHandler {
         self.onSignalingStateChangeForLog = nil
         self.onIceGatheringStateChangeForLog = nil
         self.onIceConnectionStateChangeForLog = nil
+        self.onPeerConnectionStateChangeForLog = nil
         self.onNegotiationNeededForLog = nil
         self.onIceCandidateForLog = nil
+        self.onIceCandidateErrorForLog = nil
         self.onIceCandidate = nil
         self.onRemoveIceCandidates = nil
         self.onDataChannel = nil
@@ -953,6 +957,7 @@ extension Peer : RTCPeerConnectionDelegate {
     
     func peerConnection(_ peerConnection: RTCPeerConnection, didChange newState: RTCPeerConnectionState) {
         onPeerConnectionStateChange?(newState)
+        onPeerConnectionStateChangeForLog?(newState)
         Logger.log.i(message: "Peer:: connection didChange peer connection state: [\(newState.telnyx_to_string().uppercased())]")
         
         // Track peer connection state changes for benchmarking
@@ -1104,6 +1109,11 @@ extension Peer : RTCPeerConnectionDelegate {
             }
         }
       
+    }
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didFailToGatherIceCandidate event: RTCIceCandidateErrorEvent) {
+        onIceCandidateErrorForLog?(event)
+        Logger.log.w(message: "Peer:: failed to gather ICE candidate (code: \(event.errorCode), url: \(event.url))")
     }
 
     func peerConnection(_ peerConnection: RTCPeerConnection, didRemove candidates: [RTCIceCandidate]) {

--- a/TelnyxRTCTests/WebRTC/CallReportCollectorTests.swift
+++ b/TelnyxRTCTests/WebRTC/CallReportCollectorTests.swift
@@ -369,6 +369,59 @@ class CallReportCollectorTests: XCTestCase {
         }
     }
 
+    func testCallReportEncodesJSCompatibleIceLifecycleLogs() throws {
+        let candidate = "candidate:4279963309 1 udp 41820415 64.16.248.202 54368 typ relay generation 0 ufrag GhhH"
+        let logs = [
+            LogEntry(
+                timestamp: "2026-08-24T19:19:38.200Z",
+                level: "info",
+                message: "RTC config",
+                context: [
+                    "iceServers": AnyCodable([
+                        ["urls": "turn:turn.telnyx.com:3478?transport=udp", "username": "user", "credential": "credential"]
+                    ] as [Any])
+                ]
+            ),
+            LogEntry(
+                timestamp: "2026-08-24T19:19:38.800Z",
+                level: "info",
+                message: "RTCPeer Candidate:",
+                context: [
+                    "candidate": AnyCodable(candidate),
+                    "sdpMLineIndex": AnyCodable(1),
+                    "sdpMid": AnyCodable("video"),
+                    "usernameFragment": AnyCodable("GhhH")
+                ]
+            ),
+            LogEntry(
+                timestamp: "2026-08-24T19:19:39.000Z",
+                level: "warn",
+                message: "ICE candidate error:",
+                context: [
+                    "address": AnyCodable("192.168.1.38"),
+                    "port": AnyCodable(55286),
+                    "errorCode": AnyCodable(701),
+                    "errorText": AnyCodable("TURN allocate request timed out."),
+                    "url": AnyCodable("turn:turn.telnyx.com:3478?transport=udp")
+                ]
+            )
+        ]
+
+        let data = try JSONEncoder().encode(CallReportPayload(
+            summary: CallReportSummary(callId: "call-id"),
+            stats: [],
+            logs: logs
+        ))
+        let payload = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let encodedLogs = try XCTUnwrap(payload?["logs"] as? [[String: Any]])
+
+        XCTAssertEqual(encodedLogs[1]["message"] as? String, "RTCPeer Candidate:")
+        XCTAssertEqual((encodedLogs[1]["context"] as? [String: Any])?["candidate"] as? String, candidate)
+        XCTAssertEqual((encodedLogs[1]["context"] as? [String: Any])?["sdpMLineIndex"] as? Int, 1)
+        XCTAssertEqual(encodedLogs[2]["message"] as? String, "ICE candidate error:")
+        XCTAssertEqual((encodedLogs[2]["context"] as? [String: Any])?["errorCode"] as? Int, 701)
+    }
+
     func testLargePayloadSplitsStatsIntoSafeChunks() throws {
         let summary = CallReportSummary(callId: "call-id")
         let largeCandidateAddress = String(repeating: "a", count: 50_000)

--- a/TelnyxRTCTests/WebRTC/CallReportCollectorTests.swift
+++ b/TelnyxRTCTests/WebRTC/CallReportCollectorTests.swift
@@ -378,7 +378,11 @@ class CallReportCollectorTests: XCTestCase {
                 message: "RTC config",
                 context: [
                     "iceServers": AnyCodable([
-                        ["urls": "turn:turn.telnyx.com:3478?transport=udp", "username": "user", "credential": "credential"]
+                        [
+                            "urls": "turn:turn.telnyx.com:3478?transport=udp",
+                            "hasUsername": true,
+                            "hasCredential": true
+                        ]
                     ] as [Any])
                 ]
             ),
@@ -415,6 +419,14 @@ class CallReportCollectorTests: XCTestCase {
         let payload = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         let encodedLogs = try XCTUnwrap(payload?["logs"] as? [[String: Any]])
 
+        let iceServer = try XCTUnwrap(
+            ((encodedLogs[0]["context"] as? [String: Any])?["iceServers"] as? [[String: Any]])?.first
+        )
+        XCTAssertEqual(iceServer["urls"] as? String, "turn:turn.telnyx.com:3478?transport=udp")
+        XCTAssertEqual(iceServer["hasUsername"] as? Bool, true)
+        XCTAssertEqual(iceServer["hasCredential"] as? Bool, true)
+        XCTAssertNil(iceServer["username"])
+        XCTAssertNil(iceServer["credential"])
         XCTAssertEqual(encodedLogs[1]["message"] as? String, "RTCPeer Candidate:")
         XCTAssertEqual((encodedLogs[1]["context"] as? [String: Any])?["candidate"] as? String, candidate)
         XCTAssertEqual((encodedLogs[1]["context"] as? [String: Any])?["sdpMLineIndex"] as? Int, 1)


### PR DESCRIPTION
No ticket
---
Adds JS-compatible ICE diagnostics to iOS call reports and aligns report identifiers with signaling/JS formatting.

## :older_man: :baby: Behaviors
### Before changes
- iOS emitted a sanitized candidate event that the existing call-report ICE parser did not recognize.
- The ICE page fell back to selected-pair stats and hid gathered relay candidates.
- Native ICE gathering failures were absent from the report.
- Call-report UUID fields used uppercase output from `UUID.uuidString`.
- The RINGING handler called a deprecated no-op trickle-candidate flush method.

### After changes
- iOS emits JS-compatible `RTC config`, `RTCPeer Candidate:`, ICE state, connection state, and `ICE candidate error:` events.
- Candidate logs include raw SDP candidate, media-line metadata, and ufrag, matching JS and the existing report parser.
- Native `didFailToGatherIceCandidate` failures use the existing API error contract.
- Intermediate and final reports lowercase call, Telnyx session, and Telnyx leg UUIDs.
- Removes only the deprecated no-op flush invocation; immediate trickle candidate sending and `callLegID` correlation remain unchanged.

## TODO
- Consider a separate WebRTC-lib 151 compatibility upgrade after this release.

## ✋ Manual testing
1. Enable call reports and place a call that gathers host, srflx, and relay candidates.
2. Download the raw report and open it in Voice SDK Call Report Stats.
3. Verify candidate events, ICE servers, transitions, and TURN/STUN errors appear.
4. Verify report UUIDs are lowercase.

## Known Issues
- Raw local candidate logs intentionally match the existing JS report format and contain network-address metadata.

## Screenshots
- Not applicable.

## 🔄 iOS Regression Process
- SDK build and focused call-report payload encoding test passed.

## Application Flow Checklist

### 📊 General Stats Scenarios
- [x] Focused call-report payload encoding test
- [ ] Enable stats (config level) -> Establish call -> Verify portal stats appear
- [ ] Disable stats (config level) -> Establish call -> Verify no portal stats appear
- [ ] Enable stats (call level) -> Establish call -> Verify quality metrics are available
- [ ] Disable stats (call level) -> Establish call -> Verify quality metrics are not available