### PR TITLE
fix: preserve region endpoint on reconnect

### DIFF
--- a/TelnyxRTC/Telnyx/Models/TxServerConfiguration.swift
+++ b/TelnyxRTC/Telnyx/Models/TxServerConfiguration.swift
@@ -53,8 +53,13 @@ public struct TxServerConfiguration {
         // Determine the base URL or host based on the environment or signalingServer
         if let signalingServer = signalingServer {
             if let rtc_id = rtc_id {
-                // Use only the host of signalingServer if it already has queries
-                let host = "wss://\(regionPrefix)\(signalingServer.host ?? "")"
+                // A reconnect can pass an already region-resolved endpoint back
+                // into this initializer. Do not prefix that host a second time.
+                let existingHost = signalingServer.host ?? ""
+                let resolvedHost = regionPrefix.isEmpty || existingHost.hasPrefix(regionPrefix)
+                    ? existingHost
+                    : "\(regionPrefix)\(existingHost)"
+                let host = "wss://\(resolvedHost)"
                 let query = createQuery(with: rtc_id)
                 let pushRtcServer = "\(host)\(query)"
                 self.signalingServer = URL(string: pushRtcServer) ?? signalingServer

--- a/TelnyxRTCTests/RegionTests.swift
+++ b/TelnyxRTCTests/RegionTests.swift
@@ -278,6 +278,17 @@ class RegionTests: XCTestCase {
             region: apacConfig.region
         )
         XCTAssertEqual(pushConfig.signalingServer.host, "apac.rtc.telnyx.com")
+
+        // Reconnects pass the already-resolved regional endpoint back through
+        // TxServerConfiguration with fresh voice_sdk_id metadata.
+        let reconnectConfig = TxServerConfiguration(
+            signalingServer: euConfig.signalingServer,
+            webRTCIceServers: euConfig.webRTCIceServers,
+            environment: euConfig.environment,
+            pushMetaData: pushMetaData,
+            region: euConfig.region
+        )
+        XCTAssertEqual(reconnectConfig.signalingServer.host, "eu.rtc.telnyx.com")
     }
     
     // MARK: - Socket Region Extraction Tests


### PR DESCRIPTION
<!-- Ticket details and link -->
[WEBRTC-XXX - Preserve pinned region on reconnect](https://telnyx.atlassian.net/browse/WEBRTC-XXX)
---
Reconnect rebuilding a server configuration with fresh `voice_sdk_id` metadata could prefix an already-resolved regional host a second time.

## :older_man: :baby: Behaviors
### Before changes
- A pinned EU reconnect could resolve `eu.eu.rtc.telnyx.com`.

### After changes
- Reconnect preserves an already-prefixed regional host and adds only the fresh query metadata.

## TODO
- None.

## ✋ Manual testing
1. Ran `TelnyxRTCTests/RegionTests`.
2. Added regression coverage for an EU reconnect with `voice_sdk_id`.

## Known Issues
- None.

## Screenshots
- Not applicable.

## 🔄 iOS Regression Process
- [x] Focused automated regression test run.
- [ ] Manual pinned-region reconnect test.