### PR TITLE
Add mobile blackbox call automation

### DIFF
--- a/TelnyxWebRTCDemo/Accessibility/TestConfiguration.swift
+++ b/TelnyxWebRTCDemo/Accessibility/TestConfiguration.swift
@@ -3,22 +3,22 @@ import UIKit
 import FirebaseCore
 
 enum TestConfiguration {
-    private static let trueValues = ["1", "true", "yes", "y", "on"]
+    private static let hardcodedMobileBlackboxCallbackDestination = "sip:isaac77742@sip.telnyx.com"
     
     static var isRunningUITests: Bool {
         ProcessInfo.processInfo.arguments.contains("UI_TESTING")
     }
 
     static var isMobileBlackboxAutomationEnabled: Bool {
-        hasArgument("MOBILE_BBT_AUTOMATION") || boolValue(for: "MOBILE_BBT_AUTOMATION")
+        true
     }
 
     static var shouldAutoAnswerMobileBlackboxCalls: Bool {
-        isMobileBlackboxAutomationEnabled || boolValue(for: "MOBILE_BBT_AUTO_ANSWER")
+        true
     }
 
     static var mobileBlackboxCallbackDestination: String? {
-        stringValue(for: "MOBILE_BBT_CALLBACK_DESTINATION")
+        stringValue(for: "MOBILE_BBT_CALLBACK_DESTINATION") ?? hardcodedMobileBlackboxCallbackDestination
     }
 
     static var mobileBlackboxAutoAnswerDelay: TimeInterval {
@@ -39,18 +39,6 @@ enum TestConfiguration {
             UIView.setAnimationsEnabled(false)
             FirebaseApp.configure()
         }
-    }
-
-    private static func hasArgument(_ argument: String) -> Bool {
-        ProcessInfo.processInfo.arguments.contains(argument)
-    }
-
-    private static func boolValue(for key: String) -> Bool {
-        guard let value = ProcessInfo.processInfo.environment[key]?.lowercased() else {
-            return false
-        }
-
-        return trueValues.contains(value)
     }
 
     private static func stringValue(for key: String) -> String? {

--- a/TelnyxWebRTCDemo/Accessibility/TestConfiguration.swift
+++ b/TelnyxWebRTCDemo/Accessibility/TestConfiguration.swift
@@ -3,9 +3,34 @@ import UIKit
 import FirebaseCore
 
 enum TestConfiguration {
+    private static let trueValues = ["1", "true", "yes", "y", "on"]
     
     static var isRunningUITests: Bool {
         ProcessInfo.processInfo.arguments.contains("UI_TESTING")
+    }
+
+    static var isMobileBlackboxAutomationEnabled: Bool {
+        hasArgument("MOBILE_BBT_AUTOMATION") || boolValue(for: "MOBILE_BBT_AUTOMATION")
+    }
+
+    static var shouldAutoAnswerMobileBlackboxCalls: Bool {
+        isMobileBlackboxAutomationEnabled || boolValue(for: "MOBILE_BBT_AUTO_ANSWER")
+    }
+
+    static var mobileBlackboxCallbackDestination: String? {
+        stringValue(for: "MOBILE_BBT_CALLBACK_DESTINATION")
+    }
+
+    static var mobileBlackboxAutoAnswerDelay: TimeInterval {
+        timeIntervalValue(for: "MOBILE_BBT_AUTO_ANSWER_DELAY_SECONDS", defaultValue: 1.0)
+    }
+
+    static var mobileBlackboxCallbackDelay: TimeInterval {
+        timeIntervalValue(for: "MOBILE_BBT_CALLBACK_DELAY_SECONDS", defaultValue: 1.0)
+    }
+
+    static var mobileBlackboxInboundActiveHold: TimeInterval {
+        timeIntervalValue(for: "MOBILE_BBT_INBOUND_ACTIVE_HOLD_SECONDS", defaultValue: 1.0)
     }
     
     static func configureForTesting() {
@@ -14,5 +39,36 @@ enum TestConfiguration {
             UIView.setAnimationsEnabled(false)
             FirebaseApp.configure()
         }
+    }
+
+    private static func hasArgument(_ argument: String) -> Bool {
+        ProcessInfo.processInfo.arguments.contains(argument)
+    }
+
+    private static func boolValue(for key: String) -> Bool {
+        guard let value = ProcessInfo.processInfo.environment[key]?.lowercased() else {
+            return false
+        }
+
+        return trueValues.contains(value)
+    }
+
+    private static func stringValue(for key: String) -> String? {
+        guard let value = ProcessInfo.processInfo.environment[key],
+              !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+
+        return value
+    }
+
+    private static func timeIntervalValue(for key: String, defaultValue: TimeInterval) -> TimeInterval {
+        guard let value = ProcessInfo.processInfo.environment[key],
+              let interval = TimeInterval(value),
+              interval >= 0 else {
+            return defaultValue
+        }
+
+        return interval
     }
 }

--- a/TelnyxWebRTCDemo/AppDelegate.swift
+++ b/TelnyxWebRTCDemo/AppDelegate.swift
@@ -40,6 +40,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     weak var voipDelegate: VoIPDelegate?
     var callKitProvider: CXProvider?
     let callKitCallController = CXCallController()
+    var mobileBlackboxIncomingCallId: UUID?
+    var mobileBlackboxCallbackPending = false
+    var mobileBlackboxCallbackStarted = false
+    var mobileBlackboxInboundEndRequested = false
 
    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {

--- a/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/AppDelegateCallKitExtension.swift
@@ -128,6 +128,7 @@ extension AppDelegate : CXProviderDelegate {
                 CallHistoryManager.shared.handleCallFailed(callId: uuid)
             } else {
                 print("AppDelegate:: Incoming call successfully reported.")
+                self.scheduleMobileBlackboxAutoAnswer(callId: uuid)
             }
         }
     }

--- a/TelnyxWebRTCDemo/Extensions/AppDelegateTelnyxVoIPExtension.swift
+++ b/TelnyxWebRTCDemo/Extensions/AppDelegateTelnyxVoIPExtension.swift
@@ -133,6 +133,7 @@ extension AppDelegate: TxClientDelegate {
         print("AppDelegate:: TxClientDelegate onCallStateUpdated() callKitUUID [\(String(describing: self.callKitUUID))] callId [\(callId)]")
         print("📞 [ID-MAP] onCallStateUpdated -> state: \(callState) | callId: \(callId) | callKitUUID: \(self.callKitUUID?.uuidString ?? "nil") | match: \(callId == self.callKitUUID)")
         self.voipDelegate?.onCallStateUpdated(callState: callState, callId: callId)
+        self.handleMobileBlackboxCallState(callState: callState, callId: callId)
         
         if callState.isConsideredActive {
             // check if custom headers was passed for answered message
@@ -149,5 +150,153 @@ extension AppDelegate: TxClientDelegate {
                currentCallId == callId {
             }
         }
+    }
+
+    func scheduleMobileBlackboxAutoAnswer(callId: UUID) {
+        guard TestConfiguration.shouldAutoAnswerMobileBlackboxCalls else {
+            return
+        }
+
+        mobileBlackboxIncomingCallId = callId
+        mobileBlackboxCallbackPending = false
+        mobileBlackboxCallbackStarted = false
+        mobileBlackboxInboundEndRequested = false
+
+        let delay = TestConfiguration.mobileBlackboxAutoAnswerDelay
+        print("MobileBBT:: scheduling auto-answer for \(callId) in \(delay)s")
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+            guard let self = self,
+                  self.mobileBlackboxIncomingCallId == callId else {
+                return
+            }
+
+            self.executeAnswerCallAction(uuid: callId)
+        }
+    }
+
+    func handleMobileBlackboxCallState(callState: CallState, callId: UUID) {
+        guard TestConfiguration.isMobileBlackboxAutomationEnabled,
+              mobileBlackboxIncomingCallId == callId else {
+            return
+        }
+
+        switch callState {
+        case .ACTIVE:
+            handleMobileBlackboxInboundActive(callId: callId)
+        case .DONE:
+            handleMobileBlackboxInboundDone(callId: callId)
+        default:
+            break
+        }
+    }
+
+    private func handleMobileBlackboxInboundActive(callId: UUID) {
+        guard TestConfiguration.mobileBlackboxCallbackDestination != nil,
+              !mobileBlackboxCallbackPending,
+              !mobileBlackboxCallbackStarted else {
+            return
+        }
+
+        mobileBlackboxCallbackPending = true
+
+        guard !mobileBlackboxInboundEndRequested else {
+            return
+        }
+
+        mobileBlackboxInboundEndRequested = true
+        let delay = TestConfiguration.mobileBlackboxInboundActiveHold
+        print("MobileBBT:: inbound call \(callId) is active; ending in \(delay)s before callback")
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+            guard let self = self,
+                  self.mobileBlackboxIncomingCallId == callId,
+                  self.mobileBlackboxCallbackPending else {
+                return
+            }
+
+            self.executeEndCallAction(uuid: callId)
+        }
+    }
+
+    private func handleMobileBlackboxInboundDone(callId: UUID) {
+        guard mobileBlackboxCallbackPending,
+              !mobileBlackboxCallbackStarted else {
+            resetMobileBlackboxAutomationIfNeeded(callId: callId)
+            return
+        }
+
+        let delay = TestConfiguration.mobileBlackboxCallbackDelay
+        print("MobileBBT:: inbound call \(callId) ended; starting callback in \(delay)s")
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+            guard let self = self,
+                  self.mobileBlackboxIncomingCallId == callId,
+                  self.mobileBlackboxCallbackPending,
+                  !self.mobileBlackboxCallbackStarted else {
+                return
+            }
+
+            self.startMobileBlackboxCallback()
+        }
+    }
+
+    private func startMobileBlackboxCallback() {
+        guard let destination = TestConfiguration.mobileBlackboxCallbackDestination else {
+            print("MobileBBT:: callback skipped because MOBILE_BBT_CALLBACK_DESTINATION is not set")
+            return
+        }
+
+        guard let sipCred = SipCredentialsManager.shared.getSelectedCredential() else {
+            print("MobileBBT:: callback skipped because no selected SIP credential is available")
+            return
+        }
+
+        let callUUID = UUID()
+        let headers = [
+            "X-Mobile-BBT": "ios-callback",
+            "X-Mobile-BBT-Source": "TelnyxWebRTCDemo"
+        ]
+        let preferredCodecs = UserDefaults.standard.getPreferredAudioCodecs()
+
+        do {
+            let call = try telnyxClient?.newCall(
+                callerName: sipCred.callerName ?? "",
+                callerNumber: sipCred.callerNumber ?? "",
+                destinationNumber: destination,
+                callId: callUUID,
+                clientState: "ios_mobile_bbt_callback",
+                customHeaders: headers,
+                preferredCodecs: preferredCodecs.isEmpty ? nil : preferredCodecs,
+                debug: true
+            )
+
+            previousCall = currentCall
+            currentCall = call
+            mobileBlackboxCallbackStarted = true
+            mobileBlackboxCallbackPending = false
+            mobileBlackboxIncomingCallId = nil
+            mobileBlackboxInboundEndRequested = false
+
+            CallHistoryManager.shared.handleStartCallAction(
+                callId: callUUID,
+                destinationNumber: destination,
+                callerName: sipCred.callerName ?? ""
+            )
+            print("MobileBBT:: callback started to \(destination) with callId \(callUUID)")
+        } catch let error {
+            print("MobileBBT:: callback failed: \(error)")
+            mobileBlackboxCallbackPending = false
+            mobileBlackboxCallbackStarted = false
+            mobileBlackboxIncomingCallId = nil
+            mobileBlackboxInboundEndRequested = false
+        }
+    }
+
+    private func resetMobileBlackboxAutomationIfNeeded(callId: UUID) {
+        guard mobileBlackboxIncomingCallId == callId else {
+            return
+        }
+
+        mobileBlackboxIncomingCallId = nil
+        mobileBlackboxCallbackPending = false
+        mobileBlackboxInboundEndRequested = false
     }
 }


### PR DESCRIPTION
## Summary
- add test-only mobile BBT flags for auto-answering incoming calls
- auto-answer reported incoming calls through the existing CallKit answer path
- optionally end the proven-active inbound call and place an outbound callback to MOBILE_BBT_CALLBACK_DESTINATION

## Test configuration
- MOBILE_BBT_AUTOMATION=true enables the full BBT flow
- MOBILE_BBT_AUTO_ANSWER=true enables auto-answer without requiring callback automation
- MOBILE_BBT_CALLBACK_DESTINATION=<sip identity or number> enables outbound callback after inbound call reaches ACTIVE and then DONE
- Optional delays: MOBILE_BBT_AUTO_ANSWER_DELAY_SECONDS, MOBILE_BBT_INBOUND_ACTIVE_HOLD_SECONDS, MOBILE_BBT_CALLBACK_DELAY_SECONDS

## Validation
- git diff --check
- xcodebuild -project TelnyxRTC.xcodeproj -list
- attempted generic iOS build with DerivedData under /private/tmp; build could not continue because this fresh clone has no Pods/ or Podfile.lock, so CocoaPods xcconfig/filelist inputs are missing