### PR TITLE
[VSDK-629] - Remove turn2.telnyx.com from default ICE servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,8 +242,7 @@ Relay-only mode sets WebRTC's ICE transport policy to `.relay` for outbound,
 inbound, push, and recovered calls. STUN entries may remain in the ICE catalog,
 but they cannot become the selected media path. A reachable TURN server and
 valid credentials are mandatory. Production defaults include TURN over UDP and
-TCP on port 3478, followed by TURNS on port 443 at `turn.telnyx.com` and
-`turn2.telnyx.com`.
+TCP on port 3478, followed by TURNS on port 443 at `turn.telnyx.com`.
 
 Use this setting selectively. Relaying all media can add connection time,
 latency, relay bandwidth/cost, and may reduce quality for devices that could

--- a/TelnyxRTC/Telnyx/InternalConfig.swift
+++ b/TelnyxRTC/Telnyx/InternalConfig.swift
@@ -15,7 +15,6 @@ private let prodHost = "wss://rtc.telnyx.com"
 private let prodTurnServerUdp = "turn:turn.telnyx.com:3478?transport=udp"
 private let prodTurnTcpUrl = "turn:turn.telnyx.com:3478?transport=tcp"
 private let prodTurns443Url = "turns:turn.telnyx.com:443"
-private let prodTurns443SecondaryUrl = "turns:turn2.telnyx.com:443"
 private let prodStunUrl = "stun:stun.telnyx.com:3478"
 // UDP TURN server (primary - lower latency)
 private let prodTurnUdp = RTCIceServer(urlStrings: [prodTurnServerUdp],
@@ -29,13 +28,10 @@ private let prodTurnTcp = RTCIceServer(urlStrings: [prodTurnTcpUrl],
 private let prodTurns443 = RTCIceServer(urlStrings: [prodTurns443Url],
                                           username: "testuser",
                                           credential: "testpassword")
-private let prodTurns443Secondary = RTCIceServer(urlStrings: [prodTurns443SecondaryUrl],
-                                                 username: "testuser",
-                                                 credential: "testpassword")
 private let prodStun = RTCIceServer(urlStrings: [prodStunUrl])
 // Google STUN server for additional STUN redundancy (aligned with JS WebRTC SDK)
 private let googleStun = RTCIceServer(urlStrings: ["stun:stun.l.google.com:19302"])
-private let prodIceServers = [prodStun, googleStun, prodTurnUdp, prodTurnTcp, prodTurns443, prodTurns443Secondary]
+private let prodIceServers = [prodStun, googleStun, prodTurnUdp, prodTurnTcp, prodTurns443]
 
 // MARK: - Development Servers
 private let developmentHost = "wss://rtcdev.telnyx.com"

--- a/TelnyxRTCTests/TurnServerConfigurationTests.swift
+++ b/TelnyxRTCTests/TurnServerConfigurationTests.swift
@@ -136,12 +136,12 @@ class TurnServerConfigurationTests: XCTestCase {
 
     // MARK: - TURNS 443 Server Tests (VSDK-503)
 
-    /// Test that production includes both primary and secondary TURNS endpoints
-    func testProdIceServersCountIsSix() {
+    /// Test that production includes the TURNS 443 endpoint
+    func testProdIceServersCountIsFive() {
         let config = InternalConfig.default
         let iceServers = config.prodWebRTCIceServers
 
-        XCTAssertEqual(iceServers.count, 6, "Production should have 6 ICE servers including both TURNS endpoints")
+        XCTAssertEqual(iceServers.count, 5, "Production should have 5 ICE servers: STUN, Google STUN, TURN UDP, TURN TCP, TURNS 443")
     }
 
     /// Test that development ICE servers contain exactly 5 servers including TURNS 443

--- a/TelnyxRTCTests/TurnServerConfigurationTests.swift
+++ b/TelnyxRTCTests/TurnServerConfigurationTests.swift
@@ -206,20 +206,20 @@ class TurnServerConfigurationTests: XCTestCase {
 
         XCTAssertTrue(lastProd.urlStrings.contains { $0.contains("turns:") && $0.contains("443") },
                       "Last production ICE server should be TURNS 443")
-        XCTAssertTrue(lastProd.urlStrings.contains("turns:turn2.telnyx.com:443"),
-                      "Last production ICE server should be the secondary turn2 endpoint")
+        XCTAssertTrue(lastProd.urlStrings.contains("turns:turn.telnyx.com:443"),
+                      "Last production ICE server should be the TURNS 443 endpoint")
         XCTAssertTrue(lastDev.urlStrings.contains { $0.contains("turns:") && $0.contains("443") },
                       "Last development ICE server should be TURNS 443")
     }
 
     /// Test that the full production ICE server ordering is preserved:
-    /// STUN → Google STUN → TURN UDP → TURN TCP → primary TURNS → secondary TURNS
+    /// STUN → Google STUN → TURN UDP → TURN TCP → TURNS 443
     func testProdIceServerOrdering() {
         let config = InternalConfig.default
         let iceServers = config.prodWebRTCIceServers
 
-        guard iceServers.count == 6 else {
-            XCTFail("Production should have exactly 6 ICE servers")
+        guard iceServers.count == 5 else {
+            XCTFail("Production should have exactly 5 ICE servers")
             return
         }
 
@@ -243,8 +243,9 @@ class TurnServerConfigurationTests: XCTestCase {
         XCTAssertTrue(iceServers[4].urlStrings.contains { $0.contains("turns:") && $0.contains("443") },
                       "Index 4 should be TURNS 443 server")
 
-        XCTAssertTrue(iceServers[5].urlStrings.contains("turns:turn2.telnyx.com:443"),
-                      "Index 5 should be the secondary TURNS endpoint")
+        // Index 4: TURNS 443 (last server)
+        XCTAssertTrue(iceServers[4].urlStrings.contains("turns:turn.telnyx.com:443"),
+                      "Index 4 should be the TURNS 443 endpoint")
     }
 
     /// Test that the full development ICE server ordering is preserved:


### PR DESCRIPTION
## Summary

Remove the secondary TURNS 443 endpoint (`turns:turn2.telnyx.com:443`) from the default production ICE server list in the iOS SDK.

## Context

- **Linear:** [VSDK-629](https://linear.app/telnyx/issue/VSDK-629)
- **Project:** [Add TURNS over TCP 443 support to Mobile SDKs](https://linear.app/telnyx/project/add-turns-over-tcp-443-support-to-mobile-sdks-fc251074990b)
- **Slack:** [thread](https://telnyx.slack.com/archives/CM7AYEY78/p1787831838887139)

## Changes

- Remove `prodTurns443SecondaryUrl` constant from `InternalConfig.swift`
- Remove `prodTurns443Secondary` RTCIceServer from `InternalConfig.swift`
- Remove `prodTurns443Secondary` from `prodIceServers` array
- Update `TurnServerConfigurationTests.swift`: prod server count 6→5, remove turn2 assertions
- Update `README.md` to remove turn2 reference

## Scope

Only `turns:turn2.telnyx.com:443` is removed. The five other default prod ICE servers are unchanged:
1. `stun:stun.telnyx.com:3478`
2. `stun:stun.l.google.com:19302`
3. `turn:turn.telnyx.com:3478?transport=udp`
4. `turn:turn.telnyx.com:3478?transport=tcp`
5. `turns:turn.telnyx.com:443`

## Test plan

- [x] Unit tests updated to reflect 5-server prod list
- [ ] CI passes